### PR TITLE
Fern docs api key link

### DIFF
--- a/fern/docs/pages/introduction.mdx
+++ b/fern/docs/pages/introduction.mdx
@@ -35,7 +35,7 @@ subtitle: You know the open-source library. Here's what cloud adds.
   </CodeBlock>
 </CodeBlocks>
 
-Get a key at [cloud.browser-use.com](https://cloud.browser-use.com), then:
+Get a key at [cloud.browser-use.com](https://cloud.browser-use.com/new-api-key), then:
 
 ```bash
 export BROWSER_USE_API_KEY=your_key

--- a/fern/docs/pages/llm-quickstart.mdx
+++ b/fern/docs/pages/llm-quickstart.mdx
@@ -20,7 +20,7 @@ Your agent will be able to write Browser Use Cloud code immediately.
 
 ## Setup
 Set `BROWSER_USE_API_KEY` env var, or pass `api_key`/`apiKey` to the constructor.
-Get a key at https://cloud.browser-use.com
+Get a key at https://cloud.browser-use.com/new-api-key
 
 ## Python SDK
 

--- a/fern/docs/pages/pricing.mdx
+++ b/fern/docs/pages/pricing.mdx
@@ -187,4 +187,4 @@ Based on included credits:
 
 **Enterprise** — custom pricing, dedicated browser pool, on-prem deployment, BAA, zero data retention. [Contact us](https://cloud.browser-use.com).
 
-[Get started →](https://cloud.browser-use.com)
+[Get started →](https://cloud.browser-use.com/new-api-key)


### PR DESCRIPTION
Update API key links in `fern` docs to point directly to `/new-api-key` for consistency with the main `browser-use` repo.

---
[Slack Thread](https://browser-use.slack.com/archives/C08P3EMVDJ5/p1771288063208629?thread_ts=1771288063.208629&cid=C08P3EMVDJ5)

<p><a href="https://cursor.com/background-agent?bcId=bc-042c9133-f2f0-56ab-86c6-1ad599fcf550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-042c9133-f2f0-56ab-86c6-1ad599fcf550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated "Get a key" and "Get started" links in Fern docs to point directly to https://cloud.browser-use.com/new-api-key. This aligns with the main browser-use repo and reduces clicks when creating an API key.

<sup>Written for commit ceb69f1069b92fdee886562d4c9107e5da66f0d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

