### PR TITLE
Add Cloud/Open Source version dropdown to docs navbar

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -37,54 +37,64 @@
     }
   },
   "navigation": {
-    "tabs": [
+    "versions": [
       {
-        "tab": "Docs",
-        "groups": [
+        "version": "Cloud",
+        "tabs": [
           {
-            "group": "Get Started",
-            "pages": ["introduction", "llm-quickstart", "pricing"]
-          },
-          {
-            "group": "Guides",
-            "pages": [
-              "guides/overview",
-              "guides/tasks",
-              "guides/sessions",
-              "guides/browser-api",
-              "guides/proxies-and-stealth",
-              "guides/skills",
-              "guides/authentication",
-              "guides/mcp-server",
-              "guides/webhooks"
+            "tab": "Docs",
+            "groups": [
+              {
+                "group": "Get Started",
+                "pages": ["introduction", "llm-quickstart", "new-features/api-v3", "pricing"]
+              },
+              {
+                "group": "Guides",
+                "pages": [
+                  "guides/overview",
+                  "guides/tasks",
+                  "guides/sessions",
+                  "guides/browser-api",
+                  "guides/proxies-and-stealth",
+                  "guides/skills",
+                  "guides/authentication",
+                  "guides/mcp-server",
+                  "guides/webhooks"
+                ]
+              },
+              {
+                "group": "Resources",
+                "pages": ["examples", "faq"]
+              }
             ]
           },
           {
-            "group": "New Features",
-            "pages": ["new-features/api-v3"]
-          },
-          {
-            "group": "Resources",
-            "pages": ["examples", "faq"]
+            "tab": "API Reference",
+            "groups": [
+              {
+                "group": "API v2 (Stable)",
+                "openapi": {
+                  "source": "openapi/v2.json",
+                  "directory": "api-v2"
+                }
+              },
+              {
+                "group": "BU Agent API (Experimental)",
+                "openapi": {
+                  "source": "openapi/v3.json",
+                  "directory": "api-v3"
+                }
+              }
+            ]
           }
         ]
       },
       {
-        "tab": "API Reference",
+        "version": "Open Source",
         "groups": [
           {
-            "group": "API v2 (Stable)",
-            "openapi": {
-              "source": "openapi/v2.json",
-              "directory": "api-v2"
-            }
-          },
-          {
-            "group": "BU Agent API (Experimental)",
-            "openapi": {
-              "source": "openapi/v3.json",
-              "directory": "api-v3"
-            }
+            "group": "Open Source",
+            "pages": ["open-source"]
           }
         ]
       }
@@ -192,6 +202,10 @@
     {
       "source": "/usage/authentication",
       "destination": "/guides/authentication"
+    },
+    {
+      "source": "/open-source",
+      "destination": "https://docs.browser-use.com/introduction"
     }
   ]
 }

--- a/docs/open-source.mdx
+++ b/docs/open-source.mdx
@@ -1,0 +1,9 @@
+---
+title: "Open Source Documentation"
+description: "Browser Use open source documentation"
+icon: "code"
+---
+
+Redirecting to Open Source documentation...
+
+<meta http-equiv="refresh" content="0; url=https://docs.browser-use.com/introduction" />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a version dropdown in the docs navbar so users can switch between Cloud and Open Source. Open Source redirects to the external browser-use docs; Cloud keeps the current docs.

- **New Features**
  - Added "versions" to navigation with Cloud and Open Source.
  - Cloud: moved "API v3 new features" into Get Started; API Reference includes v2 (Stable) and BU Agent API (Experimental).
  - Open Source: new page that instantly redirects to https://docs.browser-use.com/introduction and a /open-source redirect route.

<sup>Written for commit fea6eec5bab1473dacfd16f5a8fbfb0fd9425ebe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

