### PR TITLE
Add hidden sitemap reference to Get Started pages for LLM discovery

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -4,6 +4,10 @@ description: You know the open-source library. Here's what cloud adds.
 icon: house
 ---
 
+<div style={{display: "none"}}>
+  Full docs sitemap: https://docs.cloud.browser-use.com/sitemap.xml
+</div>
+
 <CardGroup cols={2}>
   <Card title="Stealth Browsers" icon="shield-halved" href="/guides/proxies-and-stealth">
     Anti-detect, CAPTCHA solving, proxies in 195+ countries.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -4,9 +4,9 @@ description: You know the open-source library. Here's what cloud adds.
 icon: house
 ---
 
-<div style={{display: "none"}}>
-  Full docs sitemap: https://docs.cloud.browser-use.com/sitemap.xml
-</div>
+<Note>
+  Full docs sitemap: [docs.cloud.browser-use.com/sitemap.xml](https://docs.cloud.browser-use.com/sitemap.xml)
+</Note>
 
 <CardGroup cols={2}>
   <Card title="Stealth Browsers" icon="shield-halved" href="/guides/proxies-and-stealth">

--- a/docs/llm-quickstart.mdx
+++ b/docs/llm-quickstart.mdx
@@ -4,6 +4,10 @@ description: Copy one blob into your AI editor. Your agent knows the entire API.
 icon: brain
 ---
 
+<div style={{display: "none"}}>
+  Full docs sitemap: https://docs.cloud.browser-use.com/sitemap.xml
+</div>
+
 Paste the following into **Claude Code**, **Codex**, **Cursor**, or any coding agent. It contains the full SDK reference for both BU Agent API (v3 Experimental) and v2 API — every method, every parameter, working examples.
 
 Your agent will be able to write Browser Use Cloud code immediately.

--- a/docs/llm-quickstart.mdx
+++ b/docs/llm-quickstart.mdx
@@ -4,9 +4,9 @@ description: Copy one blob into your AI editor. Your agent knows the entire API.
 icon: brain
 ---
 
-<div style={{display: "none"}}>
-  Full docs sitemap: https://docs.cloud.browser-use.com/sitemap.xml
-</div>
+<Note>
+  Full docs sitemap: [docs.cloud.browser-use.com/sitemap.xml](https://docs.cloud.browser-use.com/sitemap.xml)
+</Note>
 
 Paste the following into **Claude Code**, **Codex**, **Cursor**, or any coding agent. It contains the full SDK reference for both BU Agent API (v3 Experimental) and v2 API — every method, every parameter, working examples.
 

--- a/docs/new-features/api-v3.mdx
+++ b/docs/new-features/api-v3.mdx
@@ -4,6 +4,10 @@ description: A new, more powerful browser agent built from scratch.
 icon: rocket
 ---
 
+<div style={{display: "none"}}>
+  Full docs sitemap: https://docs.cloud.browser-use.com/sitemap.xml
+</div>
+
 ## What is it?
 
 A completely new agent built from scratch. Think **Claude Code for the browser**: web scraping, data extraction, file manipulation, and complex multi-step workflows.

--- a/docs/new-features/api-v3.mdx
+++ b/docs/new-features/api-v3.mdx
@@ -4,9 +4,9 @@ description: A new, more powerful browser agent built from scratch.
 icon: rocket
 ---
 
-<div style={{display: "none"}}>
-  Full docs sitemap: https://docs.cloud.browser-use.com/sitemap.xml
-</div>
+<Note>
+  Full docs sitemap: [docs.cloud.browser-use.com/sitemap.xml](https://docs.cloud.browser-use.com/sitemap.xml)
+</Note>
 
 ## What is it?
 

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -4,9 +4,9 @@ description: "Browser Use Cloud API pricing structure and cost breakdown."
 icon: "dollar-sign"
 ---
 
-<div style={{display: "none"}}>
-  Full docs sitemap: https://docs.cloud.browser-use.com/sitemap.xml
-</div>
+<Note>
+  Full docs sitemap: [docs.cloud.browser-use.com/sitemap.xml](https://docs.cloud.browser-use.com/sitemap.xml)
+</Note>
 
 ## Pricing Overview
 

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -4,6 +4,10 @@ description: "Browser Use Cloud API pricing structure and cost breakdown."
 icon: "dollar-sign"
 ---
 
+<div style={{display: "none"}}>
+  Full docs sitemap: https://docs.cloud.browser-use.com/sitemap.xml
+</div>
+
 ## Pricing Overview
 
 | Product | Pay As You Go | Business/Scaleup | Notes |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a visible Note at the top of the Introduction, LLM Quickstart, API v3, and Pricing pages linking to the full docs sitemap to help language models discover and index the docs.

<sup>Written for commit 8b1e6cb52d2265614480de9ad0f66c1a29596067. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

