### PR TITLE
Add sitemap footer to Get Started pages for LLM discovery

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -27,6 +27,13 @@
     "light": "/logo/light.svg",
     "dark": "/logo/dark.svg"
   },
+  "errors": {
+    "404": {
+      "redirect": false,
+      "title": "Page Not Found",
+      "description": "The page you're looking for doesn't exist. Browse the [full sitemap](https://docs.cloud.browser-use.com/sitemap.xml) or go back to the [introduction](/)."
+    }
+  },
   "api": {
     "playground": {
       "display": "interactive"

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -180,3 +180,7 @@ See [Tasks](/guides/tasks) for all parameters, or browse [Tips](/tips/data/struc
     Four ways to automate the web — pick the one that fits.
   </Card>
 </CardGroup>
+
+---
+
+*For LLM agents: full docs sitemap available at https://docs.cloud.browser-use.com/sitemap.xml*

--- a/docs/llm-quickstart.mdx
+++ b/docs/llm-quickstart.mdx
@@ -376,3 +376,7 @@ for await (const step of client.run("Go to google.com")) {
 - **Vision**: agent can take screenshots. Enable with `vision=True`
 - **1Password**: auto-fill passwords and 2FA/TOTP codes with `op_vault_id`
 ````
+
+---
+
+*For LLM agents: full docs sitemap available at https://docs.cloud.browser-use.com/sitemap.xml*

--- a/docs/new-features/api-v3.mdx
+++ b/docs/new-features/api-v3.mdx
@@ -87,3 +87,7 @@ console.log(result.output);
 <Note>
   The BU Agent API is experimental. The interface may change.
 </Note>
+
+---
+
+*For LLM agents: full docs sitemap available at https://docs.cloud.browser-use.com/sitemap.xml*

--- a/docs/pricing.mdx
+++ b/docs/pricing.mdx
@@ -134,3 +134,7 @@ Proxy is automatically enabled when you set `proxyCountryCode` on a session. Dat
 **Scaleup & Enterprise** — [contact us](https://browser-use.com/pricing) to get started. We sign ZDR (zero data retention), no-training, HIPAA, BAA, and custom compliance contracts. Includes dedicated browser pool, on-prem deployment options, and custom SLAs.
 
 [See plans & pricing →](https://browser-use.com/pricing)
+
+---
+
+*For LLM agents: full docs sitemap available at https://docs.cloud.browser-use.com/sitemap.xml*


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a small sitemap footer to key Get Started docs and a custom 404 message linking the sitemap to help LLM agents discover the full docs without changing reader content.

- **New Features**
  - Footer added on: Introduction, LLM Quickstart, API v3 (new features), and Pricing pages.
  - Custom 404 page: shows “Page Not Found” with links to the full sitemap and the introduction (no redirect).

<sup>Written for commit 7df922c93ec2a6424db23f74694f3e256460d92f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

