### PR TITLE
Add custom 404 page with sitemap link for LLM discovery

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -262,10 +262,6 @@
     {
       "source": "/examples",
       "destination": "/tips/data/structured-output"
-    },
-    {
-      "source": "/:slug*",
-      "destination": "/sitemap.xml"
     }
   ]
 }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -27,6 +27,13 @@
     "light": "/logo/light.svg",
     "dark": "/logo/dark.svg"
   },
+  "errors": {
+    "404": {
+      "redirect": false,
+      "title": "Page Not Found",
+      "description": "The page you're looking for doesn't exist. Browse the [full sitemap](https://docs.cloud.browser-use.com/sitemap.xml) or go back to the [introduction](/)."
+    }
+  },
   "api": {
     "playground": {
       "display": "interactive"
@@ -255,6 +262,10 @@
     {
       "source": "/examples",
       "destination": "/tips/data/structured-output"
+    },
+    {
+      "source": "/:slug*",
+      "destination": "/sitemap.xml"
     }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a custom 404 page in docs.json with a clear title and description, linking to the sitemap and the introduction. Removes the wildcard catch‑all redirect to avoid breaking pages, keeping users and crawlers on the 404 with helpful links for discovery.

<sup>Written for commit 264a972984a09f3f9f716d93a01d7a7cabd7e5d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

