### PR TITLE
Add /start discovery page and redirect 404s to it

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -29,7 +29,7 @@
   },
   "errors": {
     "404": {
-      "redirect": "/start"
+      "redirect": true
     }
   },
   "api": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -27,6 +27,11 @@
     "light": "/logo/light.svg",
     "dark": "/logo/dark.svg"
   },
+  "errors": {
+    "404": {
+      "redirect": "/start"
+    }
+  },
   "api": {
     "playground": {
       "display": "interactive"
@@ -46,7 +51,7 @@
             "groups": [
               {
                 "group": "Get Started",
-                "pages": ["introduction", "llm-quickstart", "new-features/api-v3", "pricing"]
+                "pages": ["introduction", "llm-quickstart", "new-features/api-v3", "pricing", "start"]
               },
               {
                 "group": "Guides",

--- a/docs/start.mdx
+++ b/docs/start.mdx
@@ -1,0 +1,42 @@
+---
+title: Start Here
+description: Browser Use Cloud documentation entry point. Find guides, API references, tips, and machine-readable resources.
+icon: compass
+---
+
+Looking for something? You may have followed a broken link. Here's the fastest path to what you need.
+
+## For developers
+
+<CardGroup cols={2}>
+  <Card title="Get Started" icon="rocket" href="/introduction">
+    Quickstart guide and first API call
+  </Card>
+  <Card title="API Overview" icon="code" href="/guides/overview">
+    Core concepts — tasks, sessions, browser API
+  </Card>
+  <Card title="Troubleshooting" icon="wrench" href="/faq">
+    Common issues and FAQ
+  </Card>
+  <Card title="Pricing" icon="credit-card" href="/pricing">
+    Models, usage limits, and billing
+  </Card>
+</CardGroup>
+
+## Quick links
+
+- [LLM Quickstart](/llm-quickstart) — paste into your AI editor to start building
+- [Agent Tasks guide](/guides/tasks) — run browser tasks with any LLM
+- [Tips & Recipes](/tips/data/structured-output) — tested code patterns for common use cases
+
+## Machine-readable resources
+
+If you are an LLM agent, these resources will help you understand the full documentation:
+
+- [`llms.txt`](/llms.txt) — lightweight doc index for LLMs
+- [`llms-full.txt`](/llms-full.txt) — complete documentation in plain text
+- [`sitemap.xml`](/sitemap.xml) — all page URLs
+- [OpenAPI v2 spec](/openapi/v2.json) — stable API schema
+- [OpenAPI v3 spec](/openapi/v3.json) — experimental BU Agent API schema
+
+**Browser Use Cloud** is a hosted browser automation API. You send a natural-language task (or structured instructions) and get back extracted data, screenshots, and session recordings. The API supports persistent sessions, proxy configuration, authentication profiles, file downloads, structured output, and real-time streaming.

--- a/docs/start.mdx
+++ b/docs/start.mdx
@@ -33,9 +33,9 @@ Looking for something? You may have followed a broken link. Here's the fastest p
 
 If you are an LLM agent, these resources will help you understand the full documentation:
 
-- [`llms.txt`](/llms.txt) — lightweight doc index for LLMs
-- [`llms-full.txt`](/llms-full.txt) — complete documentation in plain text
-- [`sitemap.xml`](/sitemap.xml) — all page URLs
+- [`llms.txt`](https://docs.cloud.browser-use.com/llms.txt) — lightweight doc index for LLMs
+- [`llms-full.txt`](https://docs.cloud.browser-use.com/llms-full.txt) — complete documentation in plain text
+- [`sitemap.xml`](https://docs.cloud.browser-use.com/sitemap.xml) — all page URLs
 - [OpenAPI v2 spec](/openapi/v2.json) — stable API schema
 - [OpenAPI v3 spec](/openapi/v3.json) — experimental BU Agent API schema
 


### PR DESCRIPTION
LLM agents that fetch non-existent docs URLs get a 404 and never see the page body. This adds a /start page with developer cards, quick links, and machine-readable resource URLs (llms.txt, sitemap, OpenAPI specs) so both humans and agents land somewhere useful.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a /start discovery page and redirects docs 404s to it so humans and agents land on a helpful entry point. Fixes CI by using a boolean redirect and absolute URLs for non-page resources.

- **New Features**
  - Redirects docs 404s to /start via docs.json.
  - Adds /start page with developer cards, quick links, and a sidebar entry under Get Started.
  - Surfaces machine-readable resources: llms.txt, llms-full.txt, sitemap.xml, OpenAPI v2/v3.

- **Bug Fixes**
  - Use boolean for errors.404.redirect in Mintlify config.
  - Switch llms.txt, llms-full.txt, and sitemap.xml to full URLs to pass link validation.

<sup>Written for commit 639f4476a48a91f9dd05c8b9d29bcb9d23203e5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

