### PR TITLE
Add workspaces guide, v3 message streaming, and api-v3 updates

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -54,6 +54,7 @@
                   "guides/overview",
                   "guides/tasks",
                   "guides/sessions",
+                  "guides/workspaces",
                   "guides/browser-api",
                   "guides/proxies-and-stealth",
                   "guides/skills",

--- a/docs/guides/tasks.mdx
+++ b/docs/guides/tasks.mdx
@@ -103,6 +103,68 @@ console.log(run.result?.output);  // final result after iteration
 ```
 </CodeGroup>
 
+## Message streaming (v3)
+
+In the BU Agent API, use `sessions.messages()` to poll the agent's message history while a task runs. This gives you the full conversation — user messages, assistant reasoning, and tool calls.
+
+<CodeGroup>
+```python Python
+import asyncio
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+
+session = await client.sessions.create("Find the top story on Hacker News")
+session_id = str(session.id)
+
+seen = set()
+while True:
+    s = await client.sessions.get(session_id)
+    msgs = await client.sessions.messages(session_id, limit=100)
+
+    for m in msgs.messages:
+        if str(m.id) not in seen:
+            seen.add(str(m.id))
+            print(f"[{m.role}] {m.data[:200]}")
+
+    if s.status.value in ("idle", "stopped", "error", "timed_out"):
+        print(f"\nDone — {s.output}")
+        break
+    await asyncio.sleep(2)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+
+const client = new BrowserUse();
+
+const session = await client.sessions.create({
+  task: "Find the top story on Hacker News",
+});
+const sessionId = session.id;
+
+const seen = new Set<string>();
+while (true) {
+  const s = await client.sessions.get(sessionId);
+  const msgs = await client.sessions.messages(sessionId, { limit: 100 });
+
+  for (const m of msgs.messages) {
+    if (!seen.has(m.id)) {
+      seen.add(m.id);
+      console.log(`[${m.role}] ${m.data.slice(0, 200)}`);
+    }
+  }
+
+  if (["idle", "stopped", "error", "timed_out"].includes(s.status)) {
+    console.log(`\nDone — ${s.output}`);
+    break;
+  }
+  await new Promise((r) => setTimeout(r, 2000));
+}
+```
+</CodeGroup>
+
+Use `after` and `before` cursors for pagination through large message histories.
+
 ## Files
 
 Upload images, PDFs, documents, and text files (10 MB max) to sessions, and download output files from completed tasks.

--- a/docs/guides/workspaces.mdx
+++ b/docs/guides/workspaces.mdx
@@ -1,0 +1,140 @@
+---
+title: Workspaces
+description: Persistent shared file storage across sessions.
+icon: folder
+---
+
+## What are workspaces?
+
+A workspace is a persistent storage container that lives across sessions. Use workspaces to share files between tasks — upload input data before a task starts, or retrieve output files after it completes.
+
+<Tip>
+  Every project gets a default "My Files" workspace automatically.
+</Tip>
+
+## Create a workspace
+
+<CodeGroup>
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+workspace = await client.workspaces.create(name="my-workspace")
+print(workspace.id, workspace.name)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+
+const client = new BrowserUse();
+const workspace = await client.workspaces.create({ name: "my-workspace" });
+console.log(workspace.id, workspace.name);
+```
+</CodeGroup>
+
+## Manage workspaces
+
+<CodeGroup>
+```python Python
+# Get
+workspace = await client.workspaces.get(workspace_id)
+
+# Update
+updated = await client.workspaces.update(workspace_id, name="renamed")
+
+# List
+workspaces = await client.workspaces.list()
+for w in workspaces.items:
+    print(w.id, w.name)
+
+# Delete
+await client.workspaces.delete(workspace_id)
+```
+```typescript TypeScript
+// Get
+const workspace = await client.workspaces.get(workspaceId);
+
+// Update
+const updated = await client.workspaces.update(workspaceId, { name: "renamed" });
+
+// List
+const workspaces = await client.workspaces.list();
+for (const w of workspaces.items) {
+  console.log(w.id, w.name);
+}
+
+// Delete
+await client.workspaces.delete(workspaceId);
+```
+</CodeGroup>
+
+## Use a workspace with a task
+
+Pass `workspace_id` when running a task. The agent can read and write files in the workspace during execution.
+
+<CodeGroup>
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+
+workspace = await client.workspaces.create(name="my-workspace")
+
+result = await client.run(
+    'Create a file called HEARTBEAT.md with the text "say hello"',
+    workspace_id=str(workspace.id),
+)
+print(result.output)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+
+const client = new BrowserUse();
+
+const workspace = await client.workspaces.create({ name: "my-workspace" });
+
+const result = await client.run(
+  'Create a file called HEARTBEAT.md with the text "say hello"',
+  { workspaceId: workspace.id },
+);
+console.log(result.output);
+```
+</CodeGroup>
+
+## List and delete files
+
+After a task completes, list files in the workspace or clean up individual files.
+
+<CodeGroup>
+```python Python
+# List files
+files = await client.workspaces.files(workspace_id, include_urls=True)
+for f in files.files:
+    print(f.path, f.size)
+
+# Delete a file
+await client.workspaces.delete_file(workspace_id, path="HEARTBEAT.md")
+```
+```typescript TypeScript
+// List files
+const files = await client.workspaces.files(workspaceId, { includeUrls: true });
+for (const f of files.files) {
+  console.log(f.path, f.size);
+}
+
+// Delete a file
+await client.workspaces.deleteFile(workspaceId, "HEARTBEAT.md");
+```
+</CodeGroup>
+
+<Warning>
+  Deleting a workspace permanently removes all its files. This cannot be undone.
+</Warning>
+
+<CardGroup cols={2}>
+  <Card title="Workspaces API Reference" icon="code" href="/api-v3/workspaces/list-workspaces">
+    Full endpoint reference.
+  </Card>
+  <Card title="Sessions Guide" icon="browser" href="/guides/sessions">
+    Learn about sessions and profiles.
+  </Card>
+</CardGroup>

--- a/docs/new-features/api-v3.mdx
+++ b/docs/new-features/api-v3.mdx
@@ -75,9 +75,58 @@ console.log(result.output);
 ```
 </CodeGroup>
 
+### Workspaces
+
+Workspaces are persistent file storage that lives across sessions. Attach a workspace to a task and the agent can read and write files in it.
+
+<CodeGroup>
+```python Python
+workspace = await client.workspaces.create(name="my-workspace")
+result = await client.run("Save results to output.csv", workspace_id=str(workspace.id))
+
+files = await client.workspaces.files(str(workspace.id))
+for f in files.files:
+    print(f.path, f.size)
+```
+```typescript TypeScript
+const workspace = await client.workspaces.create({ name: "my-workspace" });
+const result = await client.run("Save results to output.csv", { workspaceId: workspace.id });
+
+const files = await client.workspaces.files(workspace.id);
+for (const f of files.files) {
+  console.log(f.path, f.size);
+}
+```
+</CodeGroup>
+
+See the full [Workspaces guide](/guides/workspaces) for CRUD, file management, and more.
+
+### Session messages
+
+Retrieve the full message history for a session — useful for debugging or building custom UIs.
+
+<CodeGroup>
+```python Python
+msgs = await client.sessions.messages(session_id, limit=50)
+for m in msgs.messages:
+    print(f"[{m.role}] {m.data[:200]}")
+```
+```typescript TypeScript
+const msgs = await client.sessions.messages(sessionId, { limit: 50 });
+for (const m of msgs.messages) {
+  console.log(`[${m.role}] ${m.data.slice(0, 200)}`);
+}
+```
+</CodeGroup>
+
+Use `after` and `before` cursors for pagination through large message histories.
+
 <CardGroup cols={2}>
   <Card title="BU Agent API Reference" icon="code" href="/api-v3/sessions/create-session">
     Full endpoint reference.
+  </Card>
+  <Card title="Workspaces Guide" icon="folder" href="/guides/workspaces">
+    Persistent file storage across sessions.
   </Card>
   <Card title="Agent Tasks" icon="play" href="/guides/tasks">
     Task guide.


### PR DESCRIPTION
- New docs/guides/workspaces.mdx: CRUD, task integration, file ops
- Add "Message streaming (v3)" section to tasks guide
- Add workspaces + session messages sections to api-v3 page
- Add workspaces to nav sidebar

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Workspaces guide and v3 message streaming docs, plus API v3 updates for workspaces and session messages. Enables persistent files across sessions and streaming conversation data during tasks.

- **New Features**
  - New Workspaces guide: CRUD, attach to tasks via workspace_id, list/delete files.
  - Tasks guide: “Message streaming (v3)” with Python/TS polling examples and pagination.
  - API v3: new Workspaces and Session messages sections with samples and cross-links.
  - Sidebar: added Workspaces under Guides.

<sup>Written for commit 9a4a4660eb57d2b51d67e134b957e87b3a531efe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

