### PR TITLE
add pictures to chat-ui tutorial

### DIFF
--- a/docs/tutorials/chat-ui.mdx
+++ b/docs/tutorials/chat-ui.mdx
@@ -6,6 +6,10 @@ icon: messages
 
 This tutorial walks through the [chat-ui-example](https://github.com/browser-use/chat-ui-example) — a Next.js app that lets users chat with a Browser Use agent in real time. We'll focus on the SDK integration, not the UI components.
 
+![Home page](https://raw.githubusercontent.com/browser-use/chat-ui-example/main/public/chat-ui-preview.png)
+
+![Session view](https://raw.githubusercontent.com/browser-use/chat-ui-example/main/public/chat-ui-session.png)
+
 The app has two pages:
 
 1. **Home** — the user types a task, the app creates a session and sends the task.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added two screenshots to the chat-ui tutorial to show the Home page and Session view, giving readers clearer visual context. This improves readability and helps users understand what to expect from the UI.

<sup>Written for commit 3e318a464f03d0fd23c638842fa5a19a4964529f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

