### PR TITLE
add tags for filters

### DIFF
--- a/docs/cloud/api-reference.mdx
+++ b/docs/cloud/api-reference.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: API Reference
 description: "Complete REST API reference for v2 and v3. Endpoints, authentication, SDKs, and request/response examples."
 mode: wide

--- a/docs/cloud/coding-agent-quickstart.mdx
+++ b/docs/cloud/coding-agent-quickstart.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Coding Agent Quickstart
 description: "Complete Cloud SDK reference for AI coding agents. Copy one blob into Claude Code, Cursor, or Copilot for instant API integration."
 icon: brain

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Troubleshooting & FAQ
 description: "Fix common issues — slow tasks, failed agents, login problems, blocked sites, and unexpected costs."
 icon: circle-question

--- a/docs/cloud/guides/authentication.mdx
+++ b/docs/cloud/guides/authentication.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Authentication & 2FA
 description: "Authenticate browser automation tasks using profile sync, domain-scoped secrets, and the 1Password integration with TOTP/2FA."
 icon: key

--- a/docs/cloud/guides/browser-api.mdx
+++ b/docs/cloud/guides/browser-api.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Browser Infrastructure
 description: "Direct Chrome DevTools Protocol (CDP) access to stealth browsers. Connect with Playwright, Puppeteer, or Selenium."
 icon: globe

--- a/docs/cloud/guides/mcp-server.mdx
+++ b/docs/cloud/guides/mcp-server.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: MCP Server
 description: "Run browser automation tasks from your AI coding assistant. Connect to Claude, Cursor, Windsurf, or any MCP client."
 icon: plug

--- a/docs/cloud/guides/proxies-and-stealth.mdx
+++ b/docs/cloud/guides/proxies-and-stealth.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Proxies & Stealth
 description: "Configure anti-detect browsers with CAPTCHA solving and residential proxies in 195+ countries."
 icon: mask

--- a/docs/cloud/guides/sessions.mdx
+++ b/docs/cloud/guides/sessions.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Sessions & Profiles
 description: "Manage stateful browser sessions. Persistent login with profile sync, multi-step workflows, and cookie management."
 icon: browser

--- a/docs/cloud/guides/skills.mdx
+++ b/docs/cloud/guides/skills.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Skills
 description: "Turn any website into a deterministic API endpoint. Create once, call repeatedly."
 icon: wand-magic-sparkles

--- a/docs/cloud/guides/tasks.mdx
+++ b/docs/cloud/guides/tasks.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Tasks
 description: "Run AI browser automation tasks with structured output, configurable models, real-time streaming, cost controls, and natural language instructions."
 icon: play

--- a/docs/cloud/guides/webhooks.mdx
+++ b/docs/cloud/guides/webhooks.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Webhooks
 description: "Receive real-time notifications when tasks complete. Configure webhook endpoints for async task monitoring."
 icon: webhook

--- a/docs/cloud/guides/workspaces.mdx
+++ b/docs/cloud/guides/workspaces.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Workspaces
 description: "Persistent file storage across sessions. Upload input files, download results, and share data across tasks."
 icon: folder

--- a/docs/cloud/introduction.mdx
+++ b/docs/cloud/introduction.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: "Browser Use Cloud"
 sidebarTitle: "Introduction"
 description: "State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure."

--- a/docs/cloud/new-features/api-v3.mdx
+++ b/docs/cloud/new-features/api-v3.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: BU Agent API (Experimental)
 description: BU Agent API (v3) — a next-generation AI browser agent for web scraping, data extraction, file manipulation, and multi-step workflows in a single API call.
 icon: rocket

--- a/docs/cloud/pricing.mdx
+++ b/docs/cloud/pricing.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: "Models and Pricing"
 description: "Cloud API pricing, models, and cost breakdown."
 icon: "dollar-sign"

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Quickstart
 description: "Install the SDK, set your API key, and run your first AI browser automation task with Python or TypeScript."
 icon: rocket

--- a/docs/cloud/tips/authentication/1password-2fa.mdx
+++ b/docs/cloud/tips/authentication/1password-2fa.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: 1Password Login with 2FA
 description: Auto-fill passwords and TOTP codes from your 1Password vault during agent tasks.
 ---

--- a/docs/cloud/tips/authentication/profiles-and-secrets.mdx
+++ b/docs/cloud/tips/authentication/profiles-and-secrets.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Profiles & Secrets
 description: Run tasks on authenticated sites using saved browser profiles and domain-scoped credentials.
 ---

--- a/docs/cloud/tips/authentication/social-media.mdx
+++ b/docs/cloud/tips/authentication/social-media.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Social Media Platforms
 description: Use browser profiles and residential proxies to automate social media and job platforms reliably.
 ---

--- a/docs/cloud/tips/data/file-downloads.mdx
+++ b/docs/cloud/tips/data/file-downloads.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: File Downloads
 description: Download files the agent saves during a task — PDFs, CSVs, images, and more.
 ---

--- a/docs/cloud/tips/data/geo-scraping.mdx
+++ b/docs/cloud/tips/data/geo-scraping.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Geo-Specific Scraping
 description: Scrape location-dependent content using residential proxies in 195+ countries.
 ---

--- a/docs/cloud/tips/data/streaming.mdx
+++ b/docs/cloud/tips/data/streaming.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Stream Task Progress
 description: Stream agent steps in real time as the task executes.
 ---

--- a/docs/cloud/tips/data/structured-output.mdx
+++ b/docs/cloud/tips/data/structured-output.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Structured Output
 description: Extract typed data from any website using Pydantic models or Zod schemas.
 ---

--- a/docs/cloud/tips/integrations/n8n.mdx
+++ b/docs/cloud/tips/integrations/n8n.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: n8n Integration
 description: Use Browser Use as an HTTP node in n8n workflows.
 ---

--- a/docs/cloud/tips/integrations/playwright.mdx
+++ b/docs/cloud/tips/integrations/playwright.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Direct Browser (Playwright)
 description: Connect Playwright to a cloud browser via CDP for full programmatic control.
 ---

--- a/docs/cloud/tips/live-view/human-takeover.mdx
+++ b/docs/cloud/tips/live-view/human-takeover.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Human Takeover
 description: Combine human judgment with agent automation — hand control back and forth in the same session.
 ---

--- a/docs/cloud/tips/live-view/iframe-embed.mdx
+++ b/docs/cloud/tips/live-view/iframe-embed.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Embed Live View
 description: Embed the agent's live browser view in your app using an iframe.
 ---

--- a/docs/cloud/tips/parallel/concurrent-extraction.mdx
+++ b/docs/cloud/tips/parallel/concurrent-extraction.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Parallel Extraction
 description: Run multiple extraction tasks concurrently with asyncio.gather or Promise.all.
 ---

--- a/docs/cloud/tips/parallel/shared-config.mdx
+++ b/docs/cloud/tips/parallel/shared-config.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Parallel Browsers with Shared Auth
 description: Run concurrent sessions that share the same profile and proxy for authenticated parallel tasks.
 ---

--- a/docs/cloud/tutorials/chat-ui.mdx
+++ b/docs/cloud/tutorials/chat-ui.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Cloud"
 title: Chat UI
 description: Build a chat interface for Browser Use with Next.js and the SDK.
 icon: messages

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -506,7 +506,7 @@
     {"source": "/usage/safety", "destination": "/cloud/guides/tasks"},
     {"source": "/usage/webhooks", "destination": "/cloud/guides/webhooks"},
     {"source": "/usage/authentication", "destination": "/cloud/guides/authentication"},
-    {"source": "/api-reference/browser-profiles/get-browser-profile", "destination": "/cloud/api-v2"},
+    {"source": "/api-reference/*", "destination": "/cloud/api-reference"},
     {"source": "/cloud/v2/quickstart", "destination": "/cloud/quickstart"},
     {"source": "/cloud/v1/*", "destination": "/cloud/introduction"}
   ]

--- a/docs/open-source/coding-agent-quickstart.mdx
+++ b/docs/open-source/coding-agent-quickstart.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Coding Agent Quickstart"
 description: "Complete Python SDK reference for AI coding agents. Paste into Claude Code, Cursor, or Copilot for instant integration."
 icon: "brain"

--- a/docs/open-source/customize/agent/all-parameters.mdx
+++ b/docs/open-source/customize/agent/all-parameters.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "All Parameters"
 description: "Complete reference for all agent configuration options — LLM settings, prompts, tools, output format, and callbacks."
 icon: "sliders"

--- a/docs/open-source/customize/agent/basics.mdx
+++ b/docs/open-source/customize/agent/basics.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Configuration"
 description: "Configure the agent — set your LLM, define tasks, add custom tools, and control behavior with Python."
 icon: "play"

--- a/docs/open-source/customize/agent/output-format.mdx
+++ b/docs/open-source/customize/agent/output-format.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Output Format"
 description: "Control agent output — structured results, step history, action logs, and extracted content from browser automation tasks."
 icon: "arrow-right-to-bracket"

--- a/docs/open-source/customize/agent/prompting-guide.mdx
+++ b/docs/open-source/customize/agent/prompting-guide.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Prompting Guide"
 description: "Write effective prompts for the agent. Tips for task descriptions, multi-step workflows, and getting reliable structured output."
 icon: "lightbulb"

--- a/docs/open-source/customize/browser/all-parameters.mdx
+++ b/docs/open-source/customize/browser/all-parameters.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "All Parameters"
 description: "Complete reference for all browser configuration options — launch args, proxy, viewport, user data, and CDP settings."
 icon: "sliders"

--- a/docs/open-source/customize/browser/authentication.mdx
+++ b/docs/open-source/customize/browser/authentication.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Authentication"
 description: "Log into websites using real browser profiles, saved storage state, and 2FA codes for authenticated automation."
 icon: "key"

--- a/docs/open-source/customize/browser/basics.mdx
+++ b/docs/open-source/customize/browser/basics.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Configuration"
 description: "Configure the browser instance — headless mode, viewport size, proxy settings, and Playwright launch options."
 icon: "play"

--- a/docs/open-source/customize/browser/real-browser.mdx
+++ b/docs/open-source/customize/browser/real-browser.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Real Browser"
 description: "Connect to your existing Chrome browser to preserve login sessions, cookies, and extensions for authenticated tasks."
 icon: "arrow-right-to-bracket"

--- a/docs/open-source/customize/browser/remote.mdx
+++ b/docs/open-source/customize/browser/remote.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Remote Browser"
 description: "Connect to remote browsers via CDP — use with the Cloud, Browserbase, or any remote Chrome instance."
 icon: "cloud"

--- a/docs/open-source/customize/hooks.mdx
+++ b/docs/open-source/customize/hooks.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Lifecycle Hooks"
 description: "Hook into agent lifecycle events — before/after actions, navigation, extraction, and error handling callbacks."
 icon: "wrench"

--- a/docs/open-source/customize/integrations/docs-mcp.mdx
+++ b/docs/open-source/customize/integrations/docs-mcp.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Documentation MCP"
 description: "Add documentation context to Claude Code and other MCP clients for AI-assisted browser automation development."
 icon: "book"

--- a/docs/open-source/customize/integrations/mcp-server.mdx
+++ b/docs/open-source/customize/integrations/mcp-server.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "MCP Server"
 description: "Run as a Model Context Protocol server. Connect AI models to browser automation through the MCP standard."
 ---

--- a/docs/open-source/customize/skills/basics.mdx
+++ b/docs/open-source/customize/skills/basics.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Basics"
 description: "Skills are your API for anything. Describe what you need in plain text, and get a production-ready API endpoint you can call repeatedly."
 icon: "wand-magic"

--- a/docs/open-source/customize/tools/add.mdx
+++ b/docs/open-source/customize/tools/add.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Add Tools"
 description: "Extend agents with custom Python functions. Add API calls, file operations, or any custom logic as agent tools."
 icon: "plus"

--- a/docs/open-source/customize/tools/available.mdx
+++ b/docs/open-source/customize/tools/available.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Available Tools"
 description: "Built-in tools — click, type, scroll, extract, navigate, and more. Full list of default agent actions."
 icon: "list"

--- a/docs/open-source/customize/tools/basics.mdx
+++ b/docs/open-source/customize/tools/basics.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Overview"
 description: "Learn about built-in browser actions and custom tools."
 icon: "play"

--- a/docs/open-source/customize/tools/remove.mdx
+++ b/docs/open-source/customize/tools/remove.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Remove Tools"
 description: "Exclude default tools to restrict agent capabilities."
 icon: "minus"

--- a/docs/open-source/customize/tools/response.mdx
+++ b/docs/open-source/customize/tools/response.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Response Format"
 description: "Customize how tools return data to the agent. Control response formatting, extraction, and content filtering."
 icon: "arrow-turn-down-left"

--- a/docs/open-source/development.mdx
+++ b/docs/open-source/development.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: 'Development'
 description: 'Preview changes locally to update your docs'
 mode: "wide"

--- a/docs/open-source/development/get-help.mdx
+++ b/docs/open-source/development/get-help.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Get Help"
 description: "Get help — join 20k+ developers on Discord, search GitHub issues, or ask the community."
 icon: "circle-question"

--- a/docs/open-source/development/monitoring/costs.mdx
+++ b/docs/open-source/development/monitoring/costs.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Costs"
 description: "Track token usage and API costs for your browser automation tasks"
 icon: "dollar-sign"

--- a/docs/open-source/development/monitoring/observability.mdx
+++ b/docs/open-source/development/monitoring/observability.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Observability"
 description: "Trace agent execution steps and capture browser session recordings."
 icon: "eye"

--- a/docs/open-source/development/monitoring/openlit.mdx
+++ b/docs/open-source/development/monitoring/openlit.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "OpenLIT"
 description: "Complete observability with OpenLIT tracing."
 icon: "chart-line"

--- a/docs/open-source/development/monitoring/telemetry.mdx
+++ b/docs/open-source/development/monitoring/telemetry.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Telemetry"
 description: "Understanding Browser Use's telemetry"
 icon: "chart-mixed"

--- a/docs/open-source/development/n8n-integration.mdx
+++ b/docs/open-source/development/n8n-integration.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: 'n8n Integration'
 description: 'Learn how to integrate Browser Use with n8n workflows'
 mode: "wide"

--- a/docs/open-source/development/roadmap.mdx
+++ b/docs/open-source/development/roadmap.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Roadmap"
 description: "Future plans and upcoming features for Browser Use."
 icon: "road"

--- a/docs/open-source/development/setup/contribution-guide.mdx
+++ b/docs/open-source/development/setup/contribution-guide.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Contribution Guide"
 description: "How to contribute — code standards, PR process, testing requirements, and submitting your first pull request."
 icon: "handshake"

--- a/docs/open-source/development/setup/local-setup.mdx
+++ b/docs/open-source/development/setup/local-setup.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Local Development Setup"
 description: "Set up for local development. Clone the repo, install dependencies, and run tests to start contributing."
 icon: "laptop-code"

--- a/docs/open-source/examples/apps/ad-use.mdx
+++ b/docs/open-source/examples/apps/ad-use.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Ad-Use (Ad Generator)"
 description: "Generate Instagram image ads and TikTok video ads from landing pages using browser agents, Google's Nano Banana 🍌, and Veo3."
 icon: "image"

--- a/docs/open-source/examples/apps/msg-use.mdx
+++ b/docs/open-source/examples/apps/msg-use.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Msg-Use (WhatsApp Sender)"
 description: "AI-powered WhatsApp message scheduler using browser agents and Gemini. Schedule personalized messages in natural language."
 icon: "message"

--- a/docs/open-source/examples/apps/news-use.mdx
+++ b/docs/open-source/examples/apps/news-use.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "News-Use (News Monitor)"
 description: "Monitor news websites and extract articles with sentiment analysis using browser agents and Google Gemini."
 icon: "newspaper"

--- a/docs/open-source/examples/apps/vibetest-use.mdx
+++ b/docs/open-source/examples/apps/vibetest-use.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Vibetest-Use (Automated QA)"
 description: "Run multi-agent Browser-Use tests to catch UI bugs, broken links, and accessibility issues before they ship."
 icon: "bug"

--- a/docs/open-source/examples/templates/fast-agent.mdx
+++ b/docs/open-source/examples/templates/fast-agent.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Fast Agent"
 description: "Optimize agent performance for maximum speed and efficiency."
 icon: "bolt"

--- a/docs/open-source/examples/templates/follow-up-tasks.mdx
+++ b/docs/open-source/examples/templates/follow-up-tasks.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Follow up tasks"
 description: "Follow up tasks with the same browser session."
 icon: "link"

--- a/docs/open-source/examples/templates/more-examples.mdx
+++ b/docs/open-source/examples/templates/more-examples.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "More Examples"
 description: "Explore additional examples and use cases on GitHub."
 icon: "arrow-up-right-from-square"

--- a/docs/open-source/examples/templates/parallel-browser.mdx
+++ b/docs/open-source/examples/templates/parallel-browser.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Parallel Agents"
 description: "Run multiple agents in parallel with separate browser instances"
 icon: "copy"

--- a/docs/open-source/examples/templates/playwright-integration.mdx
+++ b/docs/open-source/examples/templates/playwright-integration.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Playwright Integration"
 description: "Advanced example showing Playwright and Browser-Use working together"
 icon: "wand-magic-sparkles"

--- a/docs/open-source/examples/templates/secure.mdx
+++ b/docs/open-source/examples/templates/secure.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Secure Setup"
 description: "Azure OpenAI with data privacy and security configuration."
 icon: "shield-check"

--- a/docs/open-source/examples/templates/sensitive-data.mdx
+++ b/docs/open-source/examples/templates/sensitive-data.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Sensitive Data"
 description: "Handle secret information securely and avoid sending PII & passwords to the LLM."
 icon: "shield"

--- a/docs/open-source/introduction.mdx
+++ b/docs/open-source/introduction.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Browser Use Open Source"
 sidebarTitle: "Introduction"
 description: "Python library for AI browser automation with 79k+ GitHub stars. Connect any LLM and run locally or self-hosted."

--- a/docs/open-source/legacy/actor/all-parameters.mdx
+++ b/docs/open-source/legacy/actor/all-parameters.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "All Parameters"
 description: "Complete API reference for Browser Actor classes, methods, and parameters including BrowserSession, Page, Element, and Mouse"
 icon: "list"

--- a/docs/open-source/legacy/actor/basics.mdx
+++ b/docs/open-source/legacy/actor/basics.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Basics"
 description: "Low-level Playwright-like browser automation with direct and full CDP control and precise element interactions"
 icon: "code"

--- a/docs/open-source/legacy/actor/examples.mdx
+++ b/docs/open-source/legacy/actor/examples.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Examples"
 description: "Comprehensive examples for Browser Actor automation tasks including forms, JavaScript, mouse operations, and AI features"
 icon: "code-simple"

--- a/docs/open-source/legacy/code-agent/all-parameters.mdx
+++ b/docs/open-source/legacy/code-agent/all-parameters.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "All Parameters"
 description: "Complete reference for all CodeAgent configuration options"
 icon: "sliders"

--- a/docs/open-source/legacy/code-agent/basics.mdx
+++ b/docs/open-source/legacy/code-agent/basics.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Basics"
 description: "Write Python code locally with browser automation"
 icon: "code"

--- a/docs/open-source/legacy/code-agent/example-products.mdx
+++ b/docs/open-source/legacy/code-agent/example-products.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Example: Extract Products"
 description: "Collect thousands of products and save to CSV"
 icon: "database"

--- a/docs/open-source/legacy/code-agent/exporting.mdx
+++ b/docs/open-source/legacy/code-agent/exporting.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Exporting Sessions"
 description: "Save and share your CodeAgent sessions as Jupyter notebooks or Python scripts"
 icon: "download"

--- a/docs/open-source/legacy/code-agent/output-format.mdx
+++ b/docs/open-source/legacy/code-agent/output-format.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Output Format"
 description: "Understanding CodeAgent return values and how to access execution history"
 icon: "arrow-right-to-bracket"

--- a/docs/open-source/legacy/sandbox/all-parameters.mdx
+++ b/docs/open-source/legacy/sandbox/all-parameters.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "All Parameters"
 description: "Sandbox configuration reference"
 icon: "sliders"

--- a/docs/open-source/legacy/sandbox/events.mdx
+++ b/docs/open-source/legacy/sandbox/events.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Events"
 description: "Monitor execution with callbacks"
 icon: "bell"

--- a/docs/open-source/legacy/sandbox/quickstart.mdx
+++ b/docs/open-source/legacy/sandbox/quickstart.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Quickstart"
 description: "Run browser automation in the cloud"
 icon: "rocket"

--- a/docs/open-source/quickstart.mdx
+++ b/docs/open-source/quickstart.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Human Quickstart"
 description: "Install and run your first AI browser agent in minutes. Python setup with pip, environment variables, and a working example."
 icon: "rocket"

--- a/docs/open-source/supported-models.mdx
+++ b/docs/open-source/supported-models.mdx
@@ -1,4 +1,5 @@
 ---
+tag: "Open Source"
 title: "Supported Models"
 description: "Choose between Claude, Gemini, Llama, DeepSeek, and more. Configuration examples for each provider."
 icon: "microchip-ai"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added tag frontmatter to Cloud and Open Source docs to enable filterable categories in the docs UI, and standardized API reference redirects. Supports ENG-2699 by consolidating Cloud and Open Source documentation.

- **New Features**
  - Added tag: "Cloud" and "Open Source" to relevant MDX files for filter-based navigation.
  - Consolidated legacy redirects: route `/api-reference/*` to `/cloud/api-reference` in `docs/docs.json`.

<sup>Written for commit 94c3b149382081d28099adbac4e1ec8c52ae47b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

