### PR TITLE
Add V3 token-based pricing section and fix Gemini 3 Flash step price

### DIFF
--- a/docs/cloud/pricing.mdx
+++ b/docs/cloud/pricing.mdx
@@ -31,7 +31,7 @@ Task pricing consists of two components:
 | Browser Use LLM | `browser-use-llm` | \$0.002 |
 | O3 | `o3` | \$0.03 |
 | Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$0.03 |
-| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.015 |
+| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.01 |
 | Gemini Flash Latest | `gemini-flash-latest` | \$0.0075 |
 | Gemini Flash Lite Latest | `gemini-flash-lite-latest` | \$0.005 |
 | Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$0.05 |
@@ -63,6 +63,19 @@ Using Browser Use LLM for a 10 step task:
 - Task initialization: \$0.01
 - 10 steps x \$0.002 per step = \$0.02
 - **Total cost: \$0.03** (~33 tasks per dollar)
+
+---
+
+## V3 API Pricing (Token-Based)
+
+V3 uses token-based billing instead of flat per-step costs.
+
+| Model | Input per 1M | Output per 1M |
+| ----- | ------------ | ------------- |
+| BU Mini (Gemini 3 Flash) | ~\$0.72 | ~\$4.20 |
+| BU Max (Claude Sonnet 4.6) | ~\$3.60 | ~\$18.00 |
+
+Includes a 1.2x markup over raw provider costs. Task initialization (\$0.01) and browser sessions are billed separately.
 
 ---
 


### PR DESCRIPTION
Add BU Mini/Max token-based pricing to match website PR #172. Fix Gemini 3 Flash step price from $0.015 to $0.01 to match backend.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a V3 token-based pricing section and corrects the Gemini 3 Flash Preview per-step price to $0.01. Aligns docs with backend and website pricing.

- **New Features**
  - Added "V3 API Pricing (Token-Based)" with BU Mini (Gemini 3 Flash) and BU Max (Claude Sonnet 4.6) rates (~$0.72/$4.20 and ~$3.60/$18.00 per 1M tokens).
  - Noted 1.2x provider markup and separate billing for task init ($0.01) and browser sessions.

- **Bug Fixes**
  - Updated Gemini 3 Flash Preview step price from $0.015 to $0.01 (slug `gemini-3-flash-preview` unchanged).

<sup>Written for commit 526cac460d1e1948c3920b782421c958c3d2fc88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

