### PR TITLE
Proxy indicator and text

### DIFF
--- a/docs/cloud/guides/proxies-and-stealth.mdx
+++ b/docs/cloud/guides/proxies-and-stealth.mdx
@@ -57,9 +57,9 @@ const result = await client.run("Get the price of iPhone 16 on amazon.de", {
 
 Common country codes: `us`, `gb`, `de`, `fr`, `jp`, `au`, `br`, `in`, `kr`, `ca`, `es`, `it`, `nl`, `se`, `sg`.
 
-<Info>
+<Note color="#FFC107">
   The default is always `us`. This applies to auto-sessions (`run()` without a `session_id`), manually created sessions, and browser sessions — unless you explicitly set a different country code.
-</Info>
+</Note>
 
 ## Custom proxy
 
@@ -97,10 +97,10 @@ Proxy is a session-level setting. All tasks in the same session use the same pro
 ## Disabling proxies
 
 <Warning>
-  Disabling the proxy is not recommended. Residential proxies are a core part of Browser Use's stealth infrastructure and significantly reduce the chance of being blocked or fingerprinted. Only disable them if you have a specific reason (e.g. testing against localhost, or your target site allowlists your server IP).
+  Only disable proxies for localhost testing or sites that allowlist your server IP. They reduce blocks and fingerprinting.
 </Warning>
 
-To opt out of the built-in proxy, pass `proxyCountryCode` as `null` explicitly. This works for sessions, tasks (via `sessionSettings`), and browser sessions.
+To disable the built-in proxy, set `proxyCountryCode` to `null` on sessions, tasks (via `sessionSettings`), or browser sessions.
 
 <CodeGroup>
 ```python Python

--- a/docs/cloud/guides/proxies-and-stealth.mdx
+++ b/docs/cloud/guides/proxies-and-stealth.mdx
@@ -57,9 +57,9 @@ const result = await client.run("Get the price of iPhone 16 on amazon.de", {
 
 Common country codes: `us`, `gb`, `de`, `fr`, `jp`, `au`, `br`, `in`, `kr`, `ca`, `es`, `it`, `nl`, `se`, `sg`.
 
-<Note color="#FFC107">
+<Warning>
   The default is always `us`. This applies to auto-sessions (`run()` without a `session_id`), manually created sessions, and browser sessions — unless you explicitly set a different country code.
-</Note>
+</Warning>
 
 ## Custom proxy
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Emphasize default proxy behavior with a yellow callout and reduce text in the 'Disabling proxies' section.

[Slack Thread](https://browser-use.slack.com/archives/C08MBPLKM0X/p1773201605930149?thread_ts=1773201605.930149&cid=C08MBPLKM0X)

<div><a href="https://cursor.com/agents/bc-94b05be4-3f70-5762-9637-37cf149c39fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94b05be4-3f70-5762-9637-37cf149c39fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a Warning callout to highlight that the default proxy country is `us` across auto-sessions, manual sessions, and browser sessions. Shortened “Disabling proxies” guidance to recommend disabling only for localhost or allowlisted IPs, and show setting `proxyCountryCode` to `null` on sessions, tasks (`sessionSettings`), and browser sessions.

<sup>Written for commit 917d3b32a8f992656a2fb1ae815d48d9da0c8dbc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

