### PR TITLE
docs: update proxy_country_code examples from de to us

### DIFF
--- a/docs/cloud/guides/proxies-and-stealth.mdx
+++ b/docs/cloud/guides/proxies-and-stealth.mdx
@@ -27,14 +27,14 @@ from browser_use_sdk import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 
-# Via session — US proxy is the default, override to route through Germany
-session = await client.sessions.create(proxy_country_code="de")
-result = await client.run("Get the price of iPhone 16 on amazon.de", session_id=session.id)
+# Via session — US proxy is the default
+session = await client.sessions.create(proxy_country_code="us")
+result = await client.run("Get the price of iPhone 16 on amazon.com", session_id=session.id)
 
 # Or inline via session_settings (auto-creates session)
 result = await client.run(
-    "Get the price of iPhone 16 on amazon.de",
-    session_settings={"proxyCountryCode": "de"},
+    "Get the price of iPhone 16 on amazon.com",
+    session_settings={"proxyCountryCode": "us"},
 )
 ```
 ```typescript TypeScript
@@ -42,15 +42,15 @@ import { BrowserUse } from "browser-use-sdk";
 
 const client = new BrowserUse();
 
-// Via session — US proxy is the default, override to route through Germany
-const session = await client.sessions.create({ proxyCountryCode: "de" });
-const result = await client.run("Get the price of iPhone 16 on amazon.de", {
+// Via session — US proxy is the default
+const session = await client.sessions.create({ proxyCountryCode: "us" });
+const result = await client.run("Get the price of iPhone 16 on amazon.com", {
   sessionId: session.id,
 });
 
 // Or inline
-const result = await client.run("Get the price of iPhone 16 on amazon.de", {
-  sessionSettings: { proxyCountryCode: "de" },
+const result = await client.run("Get the price of iPhone 16 on amazon.com", {
+  sessionSettings: { proxyCountryCode: "us" },
 });
 ```
 </CodeGroup>

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1551,13 +1551,13 @@ from browser_use_sdk import AsyncBrowserUse
 client = AsyncBrowserUse()
 
 # Via session
-session = await client.sessions.create(proxy_country_code="de")
-result = await client.run("Get the price of iPhone 16 on amazon.de", session_id=session.id)
+session = await client.sessions.create(proxy_country_code="us")
+result = await client.run("Get the price of iPhone 16 on amazon.com", session_id=session.id)
 
 # Or inline via session_settings (auto-creates session)
 result = await client.run(
-    "Get the price of iPhone 16 on amazon.de",
-    session_settings={"proxyCountryCode": "de"},
+    "Get the price of iPhone 16 on amazon.com",
+    session_settings={"proxyCountryCode": "us"},
 )
 ```
 ```typescript TypeScript
@@ -1566,14 +1566,14 @@ import { BrowserUse } from "browser-use-sdk";
 const client = new BrowserUse();
 
 // Via session
-const session = await client.sessions.create({ proxyCountryCode: "de" });
-const result = await client.run("Get the price of iPhone 16 on amazon.de", {
+const session = await client.sessions.create({ proxyCountryCode: "us" });
+const result = await client.run("Get the price of iPhone 16 on amazon.com", {
   sessionId: session.id,
 });
 
 // Or inline
-const result = await client.run("Get the price of iPhone 16 on amazon.de", {
-  sessionSettings: { proxyCountryCode: "de" },
+const result = await client.run("Get the price of iPhone 16 on amazon.com", {
+  sessionSettings: { proxyCountryCode: "us" },
 });
 ```
 


### PR DESCRIPTION
Updated the proxy country code examples in the SDK documentation from "de" (Germany) to "us" (United States), along with changing the example URLs from amazon.de to amazon.com for consistency.

https://claude.ai/code/session_01RRNuC3WPRsu5NjKVtGvRXQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated SDK docs to use proxy country code "us" instead of "de" and switched example URLs from amazon.de to amazon.com. This aligns with the default US proxy and avoids regional inconsistencies in examples.

<sup>Written for commit 6ed5e78aab3563ced6fad2e1da6526e5a879ce3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

