### PR TITLE
docs: add WebSocket connect section to Browser Infrastructure page

### DIFF
--- a/docs/cloud/coding-agent-quickstart.mdx
+++ b/docs/cloud/coding-agent-quickstart.mdx
@@ -319,8 +319,9 @@ url_info = await client.files.session_url(session_id, file_name="input.pdf", con
 output = await client.files.task_output(task_id, file_id)
 
 # Browser API — direct CDP access
-browser = await client.browsers.create(proxy_country_code="de")
+browser = await client.browsers.create(proxy_country_code="us")
 # Connect via browser.cdp_url with Playwright/Puppeteer/Selenium
+# Or skip the SDK entirely: wss://connect.browser-use.com?apiKey=KEY&proxyCountryCode=us
 
 # Skills — turn websites into APIs
 skill = await client.skills.create(goal="Extract product data from Amazon", agent_prompt="...")

--- a/docs/cloud/guides/browser-api.mdx
+++ b/docs/cloud/guides/browser-api.mdx
@@ -74,16 +74,17 @@ await browser.close();
 | `timeout` | `int` | Session timeout in minutes. Max: 240 (4 hours). |
 | `browserScreenWidth` | `int` | Browser width in pixels. |
 | `browserScreenHeight` | `int` | Browser height in pixels. |
-| `proxyUrl` | `string` | Custom proxy URL (HTTP or SOCKS5). |
-| `proxyUsername` | `string` | Username for the custom proxy. |
-| `proxyPassword` | `string` | Password for the custom proxy. |
+| `customProxy.url` | `string` | Custom proxy URL (HTTP or SOCKS5). |
+| `customProxy.username` | `string` | Username for the custom proxy. |
+| `customProxy.password` | `string` | Password for the custom proxy. |
 
 ### How it works
 
 The browser is automatically created when you connect and automatically stopped when the WebSocket disconnects. No need to call any API to start or stop the browser.
 
 <Tip>
-  CDP discovery endpoints (`/json/version`, `/json/list`) are also exposed over HTTPS for tools that use HTTP auto-discovery.
+  CDP discovery endpoints are also exposed over HTTPS for tools that use HTTP auto-discovery:
+  `https://connect.browser-use.com/json/version?apiKey=YOUR_API_KEY`
 </Tip>
 
 ## SDK

--- a/docs/cloud/guides/browser-api.mdx
+++ b/docs/cloud/guides/browser-api.mdx
@@ -64,6 +64,23 @@ await browser.close();
 // Browser is automatically stopped when the WebSocket disconnects
 ```
 
+### Selenium
+
+```python
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+
+WSS_URL = "connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us"
+
+options = Options()
+options.debugger_address = WSS_URL
+driver = webdriver.Chrome(options=options)
+driver.get("https://example.com")
+print(driver.title)
+driver.quit()
+# Browser is automatically stopped when the connection closes
+```
+
 ### Query parameters
 
 | Parameter | Type | Description |

--- a/docs/cloud/guides/browser-api.mdx
+++ b/docs/cloud/guides/browser-api.mdx
@@ -64,22 +64,9 @@ await browser.close();
 // Browser is automatically stopped when the WebSocket disconnects
 ```
 
-### Selenium
-
-```python
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-
-WSS_URL = "connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us"
-
-options = Options()
-options.debugger_address = WSS_URL
-driver = webdriver.Chrome(options=options)
-driver.get("https://example.com")
-print(driver.title)
-driver.quit()
-# Browser is automatically stopped when the connection closes
-```
+<Note>
+  Selenium requires `host:port` for its debugger address and cannot pass query parameters like `apiKey`. Use the [SDK approach](#connect-with-selenium) for Selenium connections.
+</Note>
 
 ### Query parameters
 

--- a/docs/cloud/guides/browser-api.mdx
+++ b/docs/cloud/guides/browser-api.mdx
@@ -1,12 +1,94 @@
 ---
 title: Browser Infrastructure
-description: "Direct Chrome DevTools Protocol (CDP) access to stealth browsers. Connect with Playwright, Puppeteer, or Selenium."
+description: "Direct Chrome DevTools Protocol (CDP) access to stealth browsers. Connect via WebSocket URL or SDK with Playwright, Puppeteer, or Selenium."
 icon: globe
 ---
 
 The Browser API gives you a raw Chrome DevTools Protocol (CDP) connection to Browser Use's stealth infrastructure. No agent — you write the automation code, we provide the undetectable browser with proxies and CAPTCHA handling.
 
-## Create a browser session
+There are two ways to connect:
+
+- **WebSocket URL** — single `wss://` URL, no SDK needed. Pass config as query params, browser auto-stops on disconnect.
+- **SDK** — create a browser via the API, get a `cdp_url`, connect with your framework of choice.
+
+## WebSocket URL (no SDK)
+
+Connect to a cloud browser with a single WebSocket URL. All configuration is passed as query parameters — no SDK or REST calls needed.
+
+<Tip>
+  This is the simplest way to get a CDP connection. Just point Playwright, Puppeteer, or any CDP client at the URL.
+</Tip>
+
+### Playwright
+
+<CodeGroup>
+```python Python
+from playwright.async_api import async_playwright
+
+WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us"
+
+async with async_playwright() as p:
+    browser = await p.chromium.connect_over_cdp(WSS_URL)
+    page = browser.contexts[0].pages[0]
+    await page.goto("https://example.com")
+    print(await page.title())
+    await browser.close()
+# Browser is automatically stopped when the WebSocket disconnects
+```
+```typescript TypeScript
+import { chromium } from "playwright";
+
+const WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us";
+
+const browser = await chromium.connectOverCDP(WSS_URL);
+const page = browser.contexts()[0].pages()[0];
+await page.goto("https://example.com");
+console.log(await page.title());
+await browser.close();
+// Browser is automatically stopped when the WebSocket disconnects
+```
+</CodeGroup>
+
+### Puppeteer
+
+```typescript
+import puppeteer from "puppeteer-core";
+
+const WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us";
+
+const browser = await puppeteer.connect({ browserWSEndpoint: WSS_URL });
+const [page] = await browser.pages();
+await page.goto("https://example.com");
+console.log(await page.title());
+await browser.close();
+// Browser is automatically stopped when the WebSocket disconnects
+```
+
+### Query parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `apiKey` | `string` | **Required.** Your Browser Use API key. |
+| `proxyCountryCode` | `string` | Proxy country code (e.g. `us`, `de`, `jp`). 195+ countries. |
+| `profileId` | `string` | Load a saved browser profile (cookies, localStorage). |
+| `timeout` | `int` | Session timeout in minutes. Max: 240 (4 hours). |
+| `browserScreenWidth` | `int` | Browser width in pixels. |
+| `browserScreenHeight` | `int` | Browser height in pixels. |
+| `proxyUrl` | `string` | Custom proxy URL (HTTP or SOCKS5). |
+| `proxyUsername` | `string` | Username for the custom proxy. |
+| `proxyPassword` | `string` | Password for the custom proxy. |
+
+### How it works
+
+The browser is automatically created when you connect and automatically stopped when the WebSocket disconnects. No need to call any API to start or stop the browser.
+
+<Tip>
+  CDP discovery endpoints (`/json/version`, `/json/list`) are supported on the WebSocket URL for tools that use auto-discovery.
+</Tip>
+
+## SDK
+
+### Create a browser session
 
 <CodeGroup>
 ```python Python
@@ -27,7 +109,7 @@ console.log(browser.liveUrl);
 ```
 </CodeGroup>
 
-## Connect with Playwright
+### Connect with Playwright
 
 <CodeGroup>
 ```python Python
@@ -63,7 +145,7 @@ await client.browsers.stop(browser.id);
 ```
 </CodeGroup>
 
-## Connect with Puppeteer
+### Connect with Puppeteer
 
 ```typescript
 import puppeteer from "puppeteer-core";
@@ -81,7 +163,7 @@ await pw.close();
 await client.browsers.stop(browser.id);
 ```
 
-## Connect with Selenium
+### Connect with Selenium
 
 ```python
 from selenium import webdriver
@@ -101,7 +183,7 @@ driver.quit()
 await client.browsers.stop(browser.id)
 ```
 
-## Manage sessions
+### Manage sessions
 
 <CodeGroup>
 ```python Python
@@ -133,7 +215,7 @@ await client.browsers.stop(browserId);
   Always stop browser sessions when done. Sessions left running will continue to incur charges until the timeout expires.
 </Warning>
 
-## Parameters
+### Parameters
 
 | Parameter | Type | Description |
 |-----------|------|-------------|

--- a/docs/cloud/guides/browser-api.mdx
+++ b/docs/cloud/guides/browser-api.mdx
@@ -64,10 +64,6 @@ await browser.close();
 // Browser is automatically stopped when the WebSocket disconnects
 ```
 
-<Note>
-  Selenium requires `host:port` for its debugger address and cannot pass query parameters like `apiKey`. Use the [SDK approach](#connect-with-selenium) for Selenium connections.
-</Note>
-
 ### Query parameters
 
 | Parameter | Type | Description |

--- a/docs/cloud/guides/browser-api.mdx
+++ b/docs/cloud/guides/browser-api.mdx
@@ -83,7 +83,7 @@ await browser.close();
 The browser is automatically created when you connect and automatically stopped when the WebSocket disconnects. No need to call any API to start or stop the browser.
 
 <Tip>
-  CDP discovery endpoints (`/json/version`, `/json/list`) are supported on the WebSocket URL for tools that use auto-discovery.
+  CDP discovery endpoints (`/json/version`, `/json/list`) are also exposed over HTTPS for tools that use HTTP auto-discovery.
 </Tip>
 
 ## SDK

--- a/docs/cloud/guides/browser-api.mdx
+++ b/docs/cloud/guides/browser-api.mdx
@@ -84,8 +84,7 @@ await browser.close();
 The browser is automatically created when you connect and automatically stopped when the WebSocket disconnects. No need to call any API to start or stop the browser.
 
 <Tip>
-  CDP discovery endpoints are also exposed over HTTPS for tools that use HTTP auto-discovery:
-  `https://connect.browser-use.com/json/version?apiKey=YOUR_API_KEY`
+  CDP discovery endpoints are also exposed over HTTPS for tools that use HTTP auto-discovery — e.g. `https://connect.browser-use.com/json/version?apiKey=YOUR_API_KEY`.
 </Tip>
 
 ## SDK

--- a/docs/cloud/guides/browser-api.mdx
+++ b/docs/cloud/guides/browser-api.mdx
@@ -74,7 +74,8 @@ await browser.close();
 | `timeout` | `int` | Session timeout in minutes. Max: 240 (4 hours). |
 | `browserScreenWidth` | `int` | Browser width in pixels. |
 | `browserScreenHeight` | `int` | Browser height in pixels. |
-| `customProxy.url` | `string` | Custom proxy URL (HTTP or SOCKS5). |
+| `customProxy.host` | `string` | Custom proxy host. |
+| `customProxy.port` | `int` | Custom proxy port. |
 | `customProxy.username` | `string` | Username for the custom proxy. |
 | `customProxy.password` | `string` | Password for the custom proxy. |
 


### PR DESCRIPTION
Add wss://connect.browser-use.com as a no-SDK alternative for getting CDP connections. Includes Playwright/Puppeteer examples, query params table, and auto-create/auto-stop behavior notes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a no-SDK WebSocket option for CDP access via `wss://connect.browser-use.com`, with `Playwright`/`Puppeteer` examples and automatic create/stop. Quickstart now defaults to US proxies and shows a WSS connection hint.

- **New Features**
  - Page shows two connection paths and adds “WebSocket URL (no SDK)” with `Playwright` (Python/TS) and `Puppeteer` examples.
  - Query params include `apiKey`, `proxyCountryCode`, `profileId`, `timeout`, screen size, and `customProxy.host|port|username|password`; adds an HTTPS CDP discovery URL example.

- **Bug Fixes**
  - Corrected `customProxy` params to `customProxy.host` and `customProxy.port` (no `customProxy.url`) to match the API; collapsed a Tip to a single line to fix Mintlify build.

<sup>Written for commit 9bf8feb9e7fa4be0ec0a43a6365862a789734086. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

