### PR TITLE
docs: add multi-domain auth examples for OAuth/SSO redirects

### DIFF
--- a/docs/cloud/guides/authentication.mdx
+++ b/docs/cloud/guides/authentication.mdx
@@ -142,7 +142,7 @@ If your login flow redirects through an identity provider (e.g., Okta, Auth0), i
 ```python Python
 result = await client.run(
     "Log into the company portal and download the Q4 report",
-    secrets={"portal.example.com": "username:password123"},
+    secrets={"username": "user@company.com", "password": "password123"},
     allowed_domains=["portal.example.com", "*.okta.com"],
 )
 ```
@@ -150,7 +150,7 @@ result = await client.run(
 const result = await client.run(
   "Log into the company portal and download the Q4 report",
   {
-    secrets: { "portal.example.com": "username:password123" },
+    secrets: { username: "user@company.com", password: "password123" },
     allowedDomains: ["portal.example.com", "*.okta.com"],
   },
 );

--- a/docs/cloud/guides/authentication.mdx
+++ b/docs/cloud/guides/authentication.mdx
@@ -134,6 +134,29 @@ const result = await client.run(
   **Domain restrictions:** Use `allowed_domains` with any auth method to restrict the agent to specific domains. Supports wildcards: `example.com`, `*.example.com`, `http*://example.com`.
 </Info>
 
+### Multiple Domains (OAuth/SSO Redirects)
+
+If your login flow redirects through an identity provider (e.g., Okta, Auth0), include both domains:
+
+<CodeGroup>
+```python Python
+result = await client.run(
+    "Log into the company portal and download the Q4 report",
+    secrets={"portal.example.com": "username:password123"},
+    allowed_domains=["portal.example.com", "*.okta.com"],
+)
+```
+```typescript TypeScript
+const result = await client.run(
+  "Log into the company portal and download the Q4 report",
+  {
+    secrets: { "portal.example.com": "username:password123" },
+    allowedDomains: ["portal.example.com", "*.okta.com"],
+  },
+);
+```
+</CodeGroup>
+
 ---
 
 ## 1Password Integration
@@ -205,6 +228,27 @@ const result = await client.run(
   },
 );
 console.log(result.output);
+```
+</CodeGroup>
+
+For login flows with SSO/OAuth redirects, include all required domains:
+
+<CodeGroup>
+```python Python
+result = await client.run(
+    "Log into Jira and create a ticket for the Q4 release",
+    op_vault_id="your-vault-id",
+    allowed_domains=["*.atlassian.net", "*.okta.com"],
+)
+```
+```typescript TypeScript
+const result = await client.run(
+  "Log into Jira and create a ticket for the Q4 release",
+  {
+    opVaultId: "your-vault-id",
+    allowedDomains: ["*.atlassian.net", "*.okta.com"],
+  },
+);
 ```
 </CodeGroup>
 


### PR DESCRIPTION
## Summary
- Adds examples showing how to use multiple `allowed_domains` for login flows that redirect through identity providers (Okta, Auth0, etc.)
- Covers both Secrets and 1Password sections

## Context
Users with SSO/OAuth login flows need to allow both their app domain and the IdP domain (e.g., `*.okta.com`). This was undocumented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add multi-domain auth examples for OAuth/SSO redirects so users include both their app and IdP domains (e.g., `*.okta.com`). Updates Cloud Authentication and 1Password docs with Python/TypeScript snippets using `allowed_domains`/`allowedDomains` and `op_vault_id`/`opVaultId`, and switches to flat `secrets` so credentials are available on IdP redirect pages.

<sup>Written for commit b0f2e1d3b49172807dbed0495ec372960d0c6d8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

