### PR TITLE
Update webhook docs on SDK

### DIFF
--- a/docs/guides/webhooks.mdx
+++ b/docs/guides/webhooks.mdx
@@ -10,7 +10,7 @@ Set up webhooks at [cloud.browser-use.com/settings?tab=webhooks](https://cloud.b
 
 | Event | When |
 |-------|------|
-| `agent.task.status_update` | Task started, finished, or stopped |
+| `agent.task.status_update` | Task status changes (`started`, `finished`, or `stopped`) |
 | `test` | Webhook test ping |
 
 ## Payload
@@ -20,31 +20,61 @@ Set up webhooks at [cloud.browser-use.com/settings?tab=webhooks](https://cloud.b
   "type": "agent.task.status_update",
   "timestamp": "2025-01-15T10:30:00Z",
   "payload": {
-    "taskId": "task_abc123",
+    "task_id": "task_abc123",
+    "session_id": "session_xyz",
     "status": "finished",
-    "sessionId": "session_xyz"
+    "metadata": {}
   }
 }
 ```
 
 ## Signature verification
 
-Every webhook includes an `X-Webhook-Signature` header. Verify it to ensure the request is authentic.
+Every webhook request includes two headers:
+
+- `X-Browser-Use-Signature` — HMAC-SHA256 signature of the payload
+- `X-Browser-Use-Timestamp` — Unix timestamp (seconds) when the request was sent
+
+The signature is computed over `{timestamp}.{body}`, where `body` is the JSON-serialized payload with keys sorted alphabetically and no extra whitespace. Verify it to ensure the request is authentic and to prevent replay attacks.
 
 <CodeGroup>
 ```python Python
 import hashlib
 import hmac
+import json
+import time
 
-def verify_webhook(payload: bytes, signature: str, secret: str) -> bool:
-    expected = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+def verify_webhook(body: bytes, signature: str, timestamp: str, secret: str) -> bool:
+    # Reject requests older than 5 minutes
+    if abs(time.time() - int(timestamp)) > 300:
+        return False
+    payload = json.loads(body)
+    message = f"{timestamp}.{json.dumps(payload, separators=(',', ':'), sort_keys=True)}"
+    expected = hmac.new(secret.encode(), message.encode(), hashlib.sha256).hexdigest()
     return hmac.compare_digest(expected, signature)
 ```
 ```typescript TypeScript
 import { createHmac, timingSafeEqual } from "crypto";
 
-function verifyWebhook(payload: string, signature: string, secret: string): boolean {
-  const expected = createHmac("sha256", secret).update(payload).digest("hex");
+function sortKeys(obj: unknown): unknown {
+  if (Array.isArray(obj)) return obj.map(sortKeys);
+  if (obj !== null && typeof obj === "object") {
+    return Object.keys(obj as object)
+      .sort()
+      .reduce((acc, key) => {
+        (acc as Record<string, unknown>)[key] = sortKeys((obj as Record<string, unknown>)[key]);
+        return acc;
+      }, {} as Record<string, unknown>);
+  }
+  return obj;
+}
+
+function verifyWebhook(body: string, signature: string, timestamp: string, secret: string): boolean {
+  // Reject requests older than 5 minutes
+  if (Math.abs(Date.now() / 1000 - parseInt(timestamp)) > 300) return false;
+  const payload = JSON.parse(body);
+  const message = `${timestamp}.${JSON.stringify(sortKeys(payload))}`;
+  const expected = createHmac("sha256", secret).update(message).digest("hex");
   return timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
 }
 ```


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the webhook guide to document the new HMAC signature scheme with timestamp and canonical JSON, and to switch payload fields to snake_case. Clarifies `agent.task.status_update` statuses and adds Python/TypeScript verification examples.

- **Migration**
  - Verify using `X-Browser-Use-Signature` and `X-Browser-Use-Timestamp`; compute HMAC over "{timestamp}.{sorted-keys JSON}" and reject requests older than 5 minutes.
  - Expect `task_id`, `session_id`, and optional `metadata` instead of `taskId`/`sessionId`.

<sup>Written for commit 3486667a1eda39b1e0c92d3fef09165a0bc957ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

