### PR TITLE
updated webhook docs

### DIFF
--- a/docs/cloud/guides/webhooks.mdx
+++ b/docs/cloud/guides/webhooks.mdx
@@ -10,7 +10,7 @@ Set up webhooks at [cloud.browser-use.com/settings?tab=webhooks](https://cloud.b
 
 | Event | When |
 |-------|------|
-| `agent.task.status_update` | Task started, finished, or stopped |
+| `agent.task.status_update` | Task status changes (`started`, `finished`, or `stopped`) |
 | `test` | Webhook test ping |
 
 ## Payload
@@ -20,34 +20,61 @@ Set up webhooks at [cloud.browser-use.com/settings?tab=webhooks](https://cloud.b
   "type": "agent.task.status_update",
   "timestamp": "2025-01-15T10:30:00Z",
   "payload": {
-    "taskId": "task_abc123",
+    "task_id": "task_abc123",
+    "session_id": "session_xyz",
     "status": "finished",
-    "sessionId": "session_xyz"
+    "metadata": {}
   }
 }
 ```
 
-Possible `status` values: `started`, `finished`, `stopped`.
-
 ## Signature verification
 
-Every webhook includes an `X-Webhook-Signature` header. Verify it to ensure the request is authentic and sent from Browser Use.
+Every webhook request includes two headers:
+
+- `X-Browser-Use-Signature` — HMAC-SHA256 signature of the payload
+- `X-Browser-Use-Timestamp` — Unix timestamp (seconds) when the request was sent
+
+The signature is computed over `{timestamp}.{body}`, where `body` is the JSON-serialized payload with keys sorted alphabetically and no extra whitespace. Verify it to ensure the request is authentic and to prevent replay attacks.
 
 <CodeGroup>
 ```python Python
 import hashlib
 import hmac
+import json
+import time
 
-def verify_webhook(payload: bytes, signature: str, secret: str) -> bool:
-    expected = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+def verify_webhook(body: bytes, signature: str, timestamp: str, secret: str) -> bool:
+    # Reject requests older than 5 minutes
+    if abs(time.time() - int(timestamp)) > 300:
+        return False
+    payload = json.loads(body)
+    message = f"{timestamp}.{json.dumps(payload, separators=(',', ':'), sort_keys=True)}"
+    expected = hmac.new(secret.encode(), message.encode(), hashlib.sha256).hexdigest()
     return hmac.compare_digest(expected, signature)
 ```
 ```typescript TypeScript
 import { createHmac, timingSafeEqual } from "crypto";
 
-function verifyWebhook(payload: string, signature: string, secret: string): boolean {
-  const expected = createHmac("sha256", secret).update(payload).digest("hex");
-  if (expected.length !== signature.length) return false;
+function sortKeys(obj: unknown): unknown {
+  if (Array.isArray(obj)) return obj.map(sortKeys);
+  if (obj !== null && typeof obj === "object") {
+    return Object.keys(obj as object)
+      .sort()
+      .reduce((acc, key) => {
+        (acc as Record<string, unknown>)[key] = sortKeys((obj as Record<string, unknown>)[key]);
+        return acc;
+      }, {} as Record<string, unknown>);
+  }
+  return obj;
+}
+
+function verifyWebhook(body: string, signature: string, timestamp: string, secret: string): boolean {
+  // Reject requests older than 5 minutes
+  if (Math.abs(Date.now() / 1000 - parseInt(timestamp)) > 300) return false;
+  const payload = JSON.parse(body);
+  const message = `${timestamp}.${JSON.stringify(sortKeys(payload))}`;
+  const expected = createHmac("sha256", secret).update(message).digest("hex");
   return timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
 }
 ```
@@ -64,19 +91,41 @@ app.use(express.raw({ type: "application/json" }));
 
 const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET!;
 
+function sortKeys(obj: unknown): unknown {
+  if (Array.isArray(obj)) return obj.map(sortKeys);
+  if (obj !== null && typeof obj === "object") {
+    return Object.keys(obj as object)
+      .sort()
+      .reduce((acc, key) => {
+        (acc as Record<string, unknown>)[key] = sortKeys((obj as Record<string, unknown>)[key]);
+        return acc;
+      }, {} as Record<string, unknown>);
+  }
+  return obj;
+}
+
 app.post("/webhook", (req, res) => {
-  const signature = req.headers["x-webhook-signature"] as string;
-  const expected = createHmac("sha256", WEBHOOK_SECRET).update(req.body).digest("hex");
+  const signature = req.headers["x-browser-use-signature"] as string;
+  const timestamp = req.headers["x-browser-use-timestamp"] as string;
+
+  if (Math.abs(Date.now() / 1000 - parseInt(timestamp)) > 300) {
+    return res.status(401).send("Request too old");
+  }
+
+  const body = req.body.toString();
+  const payload = JSON.parse(body);
+  const message = `${timestamp}.${JSON.stringify(sortKeys(payload))}`;
+  const expected = createHmac("sha256", WEBHOOK_SECRET).update(message).digest("hex");
 
   if (!timingSafeEqual(Buffer.from(expected), Buffer.from(signature))) {
     return res.status(401).send("Invalid signature");
   }
 
-  const event = JSON.parse(req.body.toString());
+  const event = JSON.parse(body);
 
   if (event.type === "agent.task.status_update") {
-    const { taskId, status, sessionId } = event.payload;
-    console.log(`Task ${taskId} is now ${status}`);
+    const { task_id, status, session_id } = event.payload;
+    console.log(`Task ${task_id} is now ${status}`);
   }
 
   res.status(200).send("OK");
@@ -91,7 +140,9 @@ app.listen(3000);
 from fastapi import FastAPI, Request, HTTPException
 import hashlib
 import hmac
+import json
 import os
+import time
 
 app = FastAPI()
 
@@ -100,8 +151,16 @@ WEBHOOK_SECRET = os.environ["WEBHOOK_SECRET"]
 @app.post("/webhook")
 async def handle_webhook(request: Request):
     body = await request.body()
-    signature = request.headers.get("x-webhook-signature", "")
-    expected = hmac.new(WEBHOOK_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    signature = request.headers.get("x-browser-use-signature", "")
+    timestamp = request.headers.get("x-browser-use-timestamp", "")
+
+    # Reject requests older than 5 minutes
+    if abs(time.time() - int(timestamp)) > 300:
+        raise HTTPException(status_code=401, detail="Request too old")
+
+    payload = json.loads(body)
+    message = f"{timestamp}.{json.dumps(payload, separators=(',', ':'), sort_keys=True)}"
+    expected = hmac.new(WEBHOOK_SECRET.encode(), message.encode(), hashlib.sha256).hexdigest()
 
     if not hmac.compare_digest(expected, signature):
         raise HTTPException(status_code=401, detail="Invalid signature")
@@ -109,7 +168,7 @@ async def handle_webhook(request: Request):
     event = await request.json()
 
     if event["type"] == "agent.task.status_update":
-        task_id = event["payload"]["taskId"]
+        task_id = event["payload"]["task_id"]
         status = event["payload"]["status"]
         print(f"Task {task_id} is now {status}")
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update webhook docs to reflect the new HMAC signing scheme and payload format. Adds timestamped signatures, canonical JSON serialization, and replay-attack guidance with updated TypeScript and Python examples.

- **Migration**
  - Use `X-Browser-Use-Signature` and `X-Browser-Use-Timestamp` headers (replaces `X-Webhook-Signature`).
  - Sign `${timestamp}.${canonicalJson}` where `canonicalJson` is JSON with sorted keys and no extra whitespace.
  - Reject requests older than 5 minutes.
  - Update payload keys to snake_case: `task_id`, `session_id`; includes `metadata` object.
  - Keep `agent.task.status_update` and handle `status` values `started`, `finished`, `stopped`.

<sup>Written for commit 0945293fa146290352ecae2efd662586cc2b07fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

