### PR TITLE
docs: replace $10 free credits with 5 free tasks

### DIFF
--- a/docs/open-source/customize/skills/basics.mdx
+++ b/docs/open-source/customize/skills/basics.mdx
@@ -37,7 +37,7 @@ BROWSER_USE_API_KEY=your-api-key
 ```
 
 <Note>
-Get your API key on [cloud](https://cloud.browser-use.com/new-api-key).
+Get your API key on [cloud](https://cloud.browser-use.com/new-api-key) — new users get 5 free tasks.
 </Note>
 
 ## Cookie Handling

--- a/docs/open-source/legacy/code-agent/basics.mdx
+++ b/docs/open-source/legacy/code-agent/basics.mdx
@@ -35,7 +35,7 @@ BROWSER_USE_API_KEY=your-api-key
 
 <Note>
 CodeAgent currently only works with [ChatBrowserUse](/open-source/supported-models) which is optimized for this use case.
-Get your API key [here](https://cloud.browser-use.com/new-api-key).
+Get your API key [here](https://cloud.browser-use.com/new-api-key) — new users get 5 free tasks.
 </Note>
 
 ## When to Use

--- a/docs/open-source/legacy/sandbox/quickstart.mdx
+++ b/docs/open-source/legacy/sandbox/quickstart.mdx
@@ -7,7 +7,7 @@ icon: "rocket"
 Sandboxes are the **easiest way to run Browser-Use in production**. We handle agents, browsers, persistence, auth, cookies, and LLMs. It is also the **fastest way to deploy** - the agent runs right next to the browser, so latency is minimal.
 
 <Note>
-Get your API key at [cloud.browser-use.com/new-api-key](https://cloud.browser-use.com/new-api-key).
+Get your API key at [cloud.browser-use.com/new-api-key](https://cloud.browser-use.com/new-api-key) — new users get 5 free tasks.
 </Note>
 
 ## Basic Example

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -14,7 +14,7 @@ Source: https://docs.browser-use.com/open-source/quickstart
 
 To get started with Browser Use you need to install the package and create an `.env` file with your API key.
 
-> **Note:** `ChatBrowserUse` offers the [fastest and most cost-effective models](https://browser-use.com/posts/speed-matters/), completing tasks 3-5x faster. Get started with $10 of [free LLM credits](https://cloud.browser-use.com/new-api-key).
+> **Note:** `ChatBrowserUse` offers the [fastest and most cost-effective models](https://browser-use.com/posts/speed-matters/), completing tasks 3-5x faster. New users get 5 free tasks. Get your API key [here](https://cloud.browser-use.com/new-api-key).
 
 ## 1. Installing Browser-Use
 
@@ -36,7 +36,7 @@ uvx browser-use install
 ## 2. Choose your favorite LLM
 Create a `.env` file and add your API key. 
 
-> **Note:** We recommend using ChatBrowserUse which is optimized for browser automation tasks (highest accuracy + fastest speed + lowest token cost). Do not have one? We provide you **$10** to try it out [here](https://cloud.browser-use.com/new-api-key).
+> **Note:** We recommend using ChatBrowserUse which is optimized for browser automation tasks (highest accuracy + fastest speed + lowest token cost). Get your API key [here](https://cloud.browser-use.com/new-api-key) — new users get 5 free tasks.
 
 ```bash .env
 touch .env
@@ -50,7 +50,7 @@ Then add your API key to the file.
 ```bash Browser Use
 # add your key to .env file
 BROWSER_USE_API_KEY=
-# Get 10$ of free credits at https://cloud.browser-use.com/new-api-key
+# Get your API key at https://cloud.browser-use.com/new-api-key - new users get 5 free tasks
 ```
 ```bash Google
 # add your key to .env file
@@ -202,7 +202,7 @@ Required environment variables:
 BROWSER_USE_API_KEY=
 ```
 
-Get your API key from the [Browser Use Cloud](https://cloud.browser-use.com/new-api-key). New signups get $10 free credit via OAuth or $1 via email.
+Get your API key from the [Browser Use Cloud](https://cloud.browser-use.com/new-api-key). New users get 5 free tasks to try it out.
 
 #### Available Models
 
@@ -1957,7 +1957,7 @@ Remember to add your API key to `.env`:
 BROWSER_USE_API_KEY=your-api-key
 ```
 
-> **Note:** Get your API key on [cloud](https://cloud.browser-use.com/new-api-key) - new signups get \$10 free.
+> **Note:** Get your API key on [cloud](https://cloud.browser-use.com/new-api-key) - new users get 5 free tasks.
 
 ## Cookie Handling
 
@@ -4076,7 +4076,7 @@ BROWSER_USE_API_KEY=your-api-key
 ```
 
 > **Note:** CodeAgent currently only works with [ChatBrowserUse](/open-source/supported-models) which is optimized for this use case.
-> Do not have one? We provide you $10 to try it out [here](https://cloud.browser-use.com/new-api-key).
+> Get your API key [here](https://cloud.browser-use.com/new-api-key) — new users get 5 free tasks.
 
 ## When to Use
 
@@ -4772,7 +4772,7 @@ Source: https://docs.browser-use.com/open-source/legacy/sandbox/quickstart
 
 Sandboxes are the **easiest way to run Browser-Use in production**. We handle agents, browsers, persistence, auth, cookies, and LLMs. It is also the **fastest way to deploy** - the agent runs right next to the browser, so latency is minimal.
 
-> **Note:** Get your API key at [cloud.browser-use.com/new-api-key](https://cloud.browser-use.com/new-api-key) - new signups get $10 free.
+> **Note:** Get your API key at [cloud.browser-use.com/new-api-key](https://cloud.browser-use.com/new-api-key) - new users get 5 free tasks.
 
 ## Basic Example
 

--- a/docs/open-source/quickstart.mdx
+++ b/docs/open-source/quickstart.mdx
@@ -7,7 +7,7 @@ icon: "rocket"
 To get started with Browser Use you need to install the package and create an `.env` file with your API key.
 
 <Note icon="key" color="#FFC107" iconType="regular">
-`ChatBrowserUse` offers the [fastest and most cost-effective models](https://browser-use.com/posts/speed-matters/), completing tasks 3-5x faster. Get your API key [here](https://cloud.browser-use.com/new-api-key).
+`ChatBrowserUse` offers the [fastest and most cost-effective models](https://browser-use.com/posts/speed-matters/), completing tasks 3-5x faster. New users get 5 free tasks. Get your API key [here](https://cloud.browser-use.com/new-api-key).
 </Note>
 
 ## 1. Installing Browser-Use
@@ -31,7 +31,7 @@ uvx browser-use install
 Create a `.env` file and add your API key. 
 
 <Callout icon="key" iconType="regular">
-We recommend using ChatBrowserUse which is optimized for browser automation tasks (highest accuracy + fastest speed + lowest token cost). Get your API key [here](https://cloud.browser-use.com/new-api-key).
+We recommend using ChatBrowserUse which is optimized for browser automation tasks (highest accuracy + fastest speed + lowest token cost). Get your API key [here](https://cloud.browser-use.com/new-api-key) — new users get 5 free tasks.
 </Callout>
 
 ```bash .env
@@ -46,7 +46,7 @@ Then add your API key to the file.
 ```bash Browser Use
 # add your key to .env file
 BROWSER_USE_API_KEY=
-# Get your API key at https://cloud.browser-use.com/new-api-key
+# Get your API key at https://cloud.browser-use.com/new-api-key - new users get 5 free tasks
 ```
 ```bash Google
 # add your key to .env file

--- a/docs/open-source/supported-models.mdx
+++ b/docs/open-source/supported-models.mdx
@@ -31,7 +31,7 @@ Required environment variables:
 BROWSER_USE_API_KEY=
 ```
 
-Get your API key from the [Browser Use Cloud](https://cloud.browser-use.com/new-api-key).
+Get your API key from the [Browser Use Cloud](https://cloud.browser-use.com/new-api-key). New users get 5 free tasks to try it out.
 
 #### Available Models
 


### PR DESCRIPTION
## Summary
- Replaces all "$10 free credits" promotional language with "5 free tasks" messaging across 7 docs files
- The free tier changed from $10 signup credits to 5 free tasks (cloud PR #3429, Mar 17)
- PR #34 cleaned the `.mdx` sources but `llms-full.txt` was reverted in `838fe75` — this fixes that and also updates the `.mdx` files to mention the new offer instead of neutral text

## Files changed (7 files, 14 replacements)
- `docs/open-source/llms-full.txt` — 7 replacements (stale $10 refs from revert)
- `docs/open-source/quickstart.mdx` — 3 replacements
- `docs/open-source/supported-models.mdx` — 1 replacement
- `docs/open-source/customize/skills/basics.mdx` — 1 replacement
- `docs/open-source/legacy/code-agent/basics.mdx` — 1 replacement
- `docs/open-source/legacy/sandbox/quickstart.mdx` — 1 replacement

## Test plan
- [ ] Verify no `$10` promotional credit mentions remain in `docs/open-source/` (`grep -rn '\$10' docs/open-source/` returns nothing)
- [ ] Verify all 14 "free tasks" mentions are present (`grep -rn 'free task' docs/` returns 14 matches)
- [ ] Confirm `$10/GB` proxy pricing in `docs/cloud/` is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces all "$10 free credits" language with "5 free tasks" across seven open-source docs to match the new free tier. Also fixes a prior revert by updating `docs/open-source/llms-full.txt` so all references are consistent.

<sup>Written for commit 4c76dc7f98e48e52372438521186f9ce42c2837d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

