### PR TITLE
docs: remove "to try it out" filler from free tasks messaging

### DIFF
--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -202,7 +202,7 @@ Required environment variables:
 BROWSER_USE_API_KEY=
 ```
 
-Get your API key from the [Browser Use Cloud](https://cloud.browser-use.com/new-api-key). New users get 5 free tasks to try it out.
+Get your API key from the [Browser Use Cloud](https://cloud.browser-use.com/new-api-key). New users get 5 free tasks.
 
 #### Available Models
 

--- a/docs/open-source/supported-models.mdx
+++ b/docs/open-source/supported-models.mdx
@@ -31,7 +31,7 @@ Required environment variables:
 BROWSER_USE_API_KEY=
 ```
 
-Get your API key from the [Browser Use Cloud](https://cloud.browser-use.com/new-api-key). New users get 5 free tasks to try it out.
+Get your API key from the [Browser Use Cloud](https://cloud.browser-use.com/new-api-key). New users get 5 free tasks.
 
 #### Available Models
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed “to try it out” from the free tasks sentence in API key instructions to make the wording concise and consistent. Updated docs now read: “New users get 5 free tasks.”

<sup>Written for commit 4a0763fd4a27912cb6a9e723c6e06919f29f7de0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

