### PR TITLE
docs: update MCP server docs with v2/v3 endpoints and fix Claude Code…

### DIFF
--- a/docs/cloud/guides/mcp-server.mdx
+++ b/docs/cloud/guides/mcp-server.mdx
@@ -4,18 +4,42 @@ description: "Run browser automation tasks from your AI coding assistant. Connec
 icon: plug
 ---
 
-Browser Use provides a [Model Context Protocol](https://modelcontextprotocol.io) server at `https://api.browser-use.com/mcp`.
+Browser Use provides two [Model Context Protocol](https://modelcontextprotocol.io) server endpoints:
+
+| Endpoint | URL |
+|----------|-----|
+| **v2** | `https://api.browser-use.com/mcp` |
+| **v3** | `https://api.browser-use.com/v3/mcp` |
+
+The **v2** endpoint uses a task-based agent — each task runs independently and is dispatched to a queue. The **v3** endpoint uses a session-based agent that runs in a persistent sandbox container, supporting keep-alive for multi-turn interactions, model selection (`bu-mini`, `bu-max`, `bu-ultra`), structured output, and shared workspaces for file persistence across sessions.
+
+Get your API key from the [Browser Use Dashboard](https://cloud.browser-use.com/settings?tab=api-keys).
 
 ## Claude Code
 
+<Tabs>
+<Tab title="v2">
 ```bash
-claude mcp add --transport http browser-use https://api.browser-use.com/mcp
+claude mcp add -t http -H "x-browser-use-api-key: YOUR_API_KEY" browser-use https://api.browser-use.com/mcp
 ```
+</Tab>
+<Tab title="v3">
+```bash
+claude mcp add -t http -H "x-browser-use-api-key: YOUR_API_KEY" browser-use https://api.browser-use.com/v3/mcp
+```
+</Tab>
+</Tabs>
+
+<Note>
+Replace `YOUR_API_KEY` with your actual API key. Claude Code requires the API key to be passed via the `-H` (header) flag.
+</Note>
 
 ## Claude Desktop
 
 Add to `claude_desktop_config.json`:
 
+<Tabs>
+<Tab title="v2">
 ```json
 {
   "mcpServers": {
@@ -28,11 +52,29 @@ Add to `claude_desktop_config.json`:
   }
 }
 ```
+</Tab>
+<Tab title="v3">
+```json
+{
+  "mcpServers": {
+    "browser-use": {
+      "url": "https://api.browser-use.com/v3/mcp",
+      "headers": {
+        "x-browser-use-api-key": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+</Tab>
+</Tabs>
 
 ## Cursor
 
 Add to `.cursor/mcp.json`:
 
+<Tabs>
+<Tab title="v2">
 ```json
 {
   "mcpServers": {
@@ -45,11 +87,29 @@ Add to `.cursor/mcp.json`:
   }
 }
 ```
+</Tab>
+<Tab title="v3">
+```json
+{
+  "mcpServers": {
+    "browser-use": {
+      "url": "https://api.browser-use.com/v3/mcp",
+      "headers": {
+        "x-browser-use-api-key": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+</Tab>
+</Tabs>
 
 ## Windsurf
 
 Add to `~/.codeium/windsurf/mcp_config.json`:
 
+<Tabs>
+<Tab title="v2">
 ```json
 {
   "mcpServers": {
@@ -62,9 +122,27 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
   }
 }
 ```
+</Tab>
+<Tab title="v3">
+```json
+{
+  "mcpServers": {
+    "browser-use": {
+      "serverUrl": "https://api.browser-use.com/v3/mcp",
+      "headers": {
+        "x-browser-use-api-key": "YOUR_API_KEY"
+      }
+    }
+  }
+}
+```
+</Tab>
+</Tabs>
 
-## Available tools
+## Available Tools
 
+<Tabs>
+<Tab title="v2">
 | Tool | Description | Cost |
 |------|-------------|------|
 | `browser_task` | Run a full automation task | $0.01 init + per-step (default $0.006/step). See [Pricing](/cloud/pricing). |
@@ -73,3 +151,16 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 | `get_cookies` | Extract cookies for auth | Free |
 | `list_browser_profiles` | List profiles | Free |
 | `monitor_task` | Check task progress | Free |
+</Tab>
+<Tab title="v3">
+| Tool | Description |
+|------|-------------|
+| `run_session` | Create a new browser session and run a task. Supports `keep_alive` to reuse the session, `model` selection (`bu-mini`, `bu-max`, `bu-ultra`), `output_schema` for structured output, and `profile_id` for authenticated browsing. |
+| `get_session` | Poll a session for status and output. Returns status (`running`, `idle`, `stopped`, `error`), step count, cost breakdown, and a live URL to watch the browser. |
+| `send_task` | Send a follow-up task to an idle keep-alive session. Enables multi-turn interactions that reuse the same browser context. |
+| `stop_session` | Stop a running session. Use `strategy: "task"` to stop only the current task (session stays idle), or `"session"` to destroy the sandbox. |
+| `get_session_messages` | Get the agent's step-by-step messages for a session, including browser actions, reasoning, and results. |
+| `list_sessions` | List recent sessions with status and cost info. |
+| `list_browser_profiles` | List cloud browser profiles for authenticated tasks. |
+</Tab>
+</Tabs>

--- a/docs/open-source/customize/integrations/mcp-server.mdx
+++ b/docs/open-source/customize/integrations/mcp-server.mdx
@@ -1,187 +1,15 @@
 ---
 title: "MCP Server"
-description: "Run as a Model Context Protocol server. Connect AI models to browser automation through the MCP standard."
+description: "Run browser-use as a local Model Context Protocol server. Connect AI models to browser automation through the MCP standard."
 ---
 
-Browser Use provides a hosted **Model Context Protocol (MCP)** server that enables AI assistants to control browser automation. Works with any HTTP-based MCP client, including Claude Code.
+Browser Use can run as a local **Model Context Protocol (MCP)** server on your machine via stdio. This is the **free, open-source option** that gives you direct, low-level control over browser automation but requires your own LLM API keys.
 
-**MCP Server URL:** `https://api.browser-use.com/mcp`
+<Note>
+Looking for a hosted solution? Use the [Cloud MCP Server](/cloud/guides/mcp-server) instead — no setup required, just an API key.
+</Note>
 
-This is an **HTTP-based MCP server** designed for cloud integrations and remote access. If you need a local stdio-based MCP server for Claude Desktop, use the free open-source version: `uvx browser-use --mcp`
-
-## Quick Setup
-
-### 1. Get API Key
-Get your API key from the [Browser Use Dashboard](https://cloud.browser-use.com)
-
-### 2. Connect Your AI
-
-<Tabs>
-<Tab title="Claude Code">
-```bash
-claude mcp add --transport http browser-use https://api.browser-use.com/mcp
-```
-</Tab>
-<Tab title="Claude Desktop">
-Add to your Claude Desktop config file:
-
-**macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
-**Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
-
-```json
-{
-  "mcpServers": {
-    "browser-use": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://api.browser-use.com/mcp",
-        "--header",
-        "X-Browser-Use-API-Key: your-api-key"
-      ]
-    }
-  }
-}
-```
-
-Restart Claude Desktop after saving.
-</Tab>
-<Tab title="Cursor">
-Add to `~/.cursor/mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "browser-use": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://api.browser-use.com/mcp",
-        "--header",
-        "X-Browser-Use-API-Key: your-api-key"
-      ]
-    }
-  }
-}
-```
-</Tab>
-<Tab title="Windsurf">
-Add to `~/.codeium/windsurf/mcp_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "browser-use": {
-      "serverUrl": "https://api.browser-use.com/mcp",
-      "headers": {
-        "X-Browser-Use-API-Key": "your-api-key"
-      }
-    }
-  }
-}
-```
-</Tab>
-<Tab title="ChatGPT">
-**Step 1: Register an OAuth client**
-
-Call the dynamic client registration endpoint with ChatGPT's redirect URI:
-
-```bash
-curl -X POST https://api.browser-use.com/oauth/register \
-  -H "Content-Type: application/json" \
-  -d '{
-    "client_name": "ChatGPT Integration",
-    "redirect_uris": ["https://chatgpt.com/connector_platform_oauth_redirect"]
-  }'
-```
-
-Save the `client_id` from the response (43-character random string).
-
-**Step 2: Configure ChatGPT**
-
-In ChatGPT, add a custom MCP connector:
-- **MCP Server URL**: `https://api.browser-use.com/mcp/chatgpt`
-- **Client ID**: Paste the `client_id` from step 1
-
-**Step 3: Authorize**
-
-ChatGPT will redirect you to Browser Use's authorization page. Sign in and grant permission.
-
-**Note:** ChatGPT uses OAuth 2.1 authentication instead of API keys. You only need to register your client once.
-</Tab>
-</Tabs>
-
-## Available Tools
-
-The MCP server provides three tools:
-
-### `browser_task`
-Creates and runs a browser automation task.
-- **task** (required): What you want the browser to do
-- **max_steps** (optional): Max actions to take (1-10, default: 8)
-- **profile_id** (optional): UUID of the cloud profile to use for persistent authentication
-
-### `list_browser_profiles`
-Lists all available cloud browser profiles for the authenticated project. Profiles store persistent authentication (cookies, sessions) for websites requiring login.
-
-### `monitor_task`
-Checks the current status and progress of a browser automation task. Returns immediately with a snapshot of the task state.
-- **task_id** (required): UUID of the task to monitor (returned by browser_task)
-
-## Example Usage
-
-Once connected, ask your AI to perform web tasks:
-
-> "Search Google for the latest iPhone reviews and summarize the top 3 results"
-
-> "Go to Hacker News and get me the titles of the top 5 posts"
-
-> "Fill out the contact form on example.com with my information"
-
-The AI will use the browser tools automatically to complete these tasks.
-
-## Smart Features
-
-### Cloud Profiles for Authentication
-Use cloud browser profiles to maintain persistent login sessions across tasks. Profiles store cookies and authentication state for:
-- Social media (X/Twitter, LinkedIn, Facebook)
-- Email (Gmail, Outlook)
-- Online banking and shopping sites
-- Any website requiring login
-
-List available profiles with `list_browser_profiles`, then pass the `profile_id` to `browser_task`.
-
-### Real-time Task Monitoring
-Use `monitor_task` to check task progress while it is running. The tool returns immediately with the current status, latest step details, and agent reasoning. Call it repeatedly to track progress live.
-
-### Conversational Progress Summaries
-When you monitor tasks, the AI automatically interprets step data into natural language updates, explaining what the browser has completed and what it is currently working on.
-
-## Troubleshooting
-
-**Connection issues?**
-- Verify your API key is correct
-- Check that you are using the right headers
-
-**Task taking too long?**
-- Check the live_url to see progress
-- Increase max_steps for complex tasks (max: 10)
-- Use clearer, more specific instructions
-
-**Need help?**
-Check our [Cloud Documentation](/cloud/quickstart) for detailed specifications.
-
----
-
-## Local Self-Hosted Alternative
-
-For users who want a free, self-hosted option, browser-use can run as a local MCP server on your machine. This requires your own OpenAI or Anthropic API keys but provides direct, low-level control over browser automation.
-
-### Quick Start
-
-The local MCP server runs as a stdio-based process on your machine. This is the **free, open-source option** but requires your own LLM API keys.
-
-#### Start MCP Server Manually
+## Quick Start
 
 ```bash
 uvx --from 'browser-use[cli]' browser-use --mcp
@@ -189,9 +17,16 @@ uvx --from 'browser-use[cli]' browser-use --mcp
 
 The server will start in stdio mode, ready to accept MCP connections.
 
-#### Claude Desktop Integration
+## Client Setup
 
-The most common use case is integrating with Claude Desktop. Add this configuration to your Claude Desktop config file:
+<Tabs>
+<Tab title="Claude Code">
+```bash
+claude mcp add browser-use -- uvx --from 'browser-use[cli]' browser-use --mcp
+```
+</Tab>
+<Tab title="Claude Desktop">
+Add to your Claude Desktop config file:
 
 **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
 
@@ -225,6 +60,8 @@ The most common use case is integrating with Claude Desktop. Add this configurat
 }
 ```
 
+Restart Claude Desktop after saving.
+
 <Note>
 **macOS/Linux PATH Issue:** Claude Desktop may not find `uvx` in your PATH. Use the full path to `uvx` instead:
 - Run `which uvx` in your terminal to find the location (usually `/Users/username/.local/bin/uvx` or `~/.local/bin/uvx`)
@@ -233,17 +70,51 @@ The most common use case is integrating with Claude Desktop. Add this configurat
 
 **CLI Extras Required:** The `--from browser-use[cli]` flag installs the CLI extras needed for MCP server support.
 </Note>
+</Tab>
+<Tab title="Cursor">
+Add to `~/.cursor/mcp.json`:
 
-#### Environment Variables
+```json
+{
+  "mcpServers": {
+    "browser-use": {
+      "command": "uvx",
+      "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
+      "env": {
+        "OPENAI_API_KEY": "your-openai-api-key-here"
+      }
+    }
+  }
+}
+```
+</Tab>
+<Tab title="Windsurf">
+Add to `~/.codeium/windsurf/mcp_config.json`:
 
-You can configure browser-use through environment variables:
+```json
+{
+  "mcpServers": {
+    "browser-use": {
+      "command": "uvx",
+      "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
+      "env": {
+        "OPENAI_API_KEY": "your-openai-api-key-here"
+      }
+    }
+  }
+}
+```
+</Tab>
+</Tabs>
+
+## Environment Variables
 
 - `OPENAI_API_KEY` - Your OpenAI API key (required)
 - `ANTHROPIC_API_KEY` - Your Anthropic API key (alternative to OpenAI)
 - `BROWSER_USE_HEADLESS` - Set to `false` to show browser window
 - `BROWSER_USE_DISABLE_SECURITY` - Set to `true` to disable browser security features
 
-### Available Tools
+## Available Tools
 
 The local MCP server exposes these low-level browser automation tools for direct control:
 
@@ -271,9 +142,9 @@ The local MCP server exposes these low-level browser automation tools for direct
 - **`browser_close_session`** - Close a specific browser session by ID
 - **`browser_close_all`** - Close all active browser sessions
 
-### Example Usage
+## Example Usage
 
-Once configured with Claude Desktop, you can ask Claude to perform browser automation tasks:
+Once configured, you can ask your AI to perform browser automation tasks:
 
 ```
 "Please navigate to example.com and take a screenshot"
@@ -283,9 +154,7 @@ Once configured with Claude Desktop, you can ask Claude to perform browser autom
 "Go to GitHub, find the browser-use repository, and tell me about the latest release"
 ```
 
-Claude will use the MCP server to execute these tasks through browser-use.
-
-### Programmatic Usage
+## Programmatic Usage
 
 You can also connect to the MCP server programmatically:
 
@@ -322,9 +191,7 @@ async def use_browser_mcp():
 asyncio.run(use_browser_mcp())
 ```
 
-### Troubleshooting
-
-#### Common Issues
+## Troubleshooting
 
 **"CLI addon is not installed" Error**
 Make sure you are using `--from 'browser-use[cli]'` in your uvx command:
@@ -353,7 +220,7 @@ Claude Desktop cannot find `uvx` in its PATH. Use the full path in your config:
 - Verify the file path is correct for your OS
 - Check logs at `~/Library/Logs/Claude/` (macOS) or `%APPDATA%\Claude\Logs\` (Windows)
 
-#### Debug Mode
+**Debug Mode**
 
 Enable debug logging by setting:
 ```bash
@@ -361,14 +228,14 @@ export BROWSER_USE_LOGGING_LEVEL=DEBUG
 uvx --from 'browser-use[cli]' browser-use --mcp
 ```
 
-### Security Considerations
+## Security Considerations
 
 - The MCP server has access to your browser and file system
 - Only connect trusted MCP clients
 - Be cautious with sensitive websites and data
 - Consider running in a sandboxed environment for untrusted automation
 
-### Next Steps
+## Next Steps
 
 - Explore the [examples directory](https://github.com/browser-use/browser-use/tree/main/examples/mcp) for more usage patterns
 - Check out [MCP documentation](https://modelcontextprotocol.io/) to learn more about the protocol


### PR DESCRIPTION
… setup

- Add v2/v3 endpoint tabs for all clients (Claude Code, Claude Desktop, Cursor, Windsurf)
- Fix Claude Code command to include -H flag for API key auth (was missing)
- Document v3 tools (run_session, get_session, send_task, stop_session, etc.)
- Describe architectural difference between v2 (task queue) and v3 (session sandbox)
- Clean up open-source MCP doc to only cover local self-hosted server
- Link to cloud MCP doc from open-source page instead of duplicating content

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated MCP server docs to add v2/v3 endpoints and v3 session tools, and fixed the Claude Code setup header. The open‑source page now focuses on the local stdio server and links to the cloud guide.

- **New Features**
  - Added v2/v3 endpoint tabs for `Claude Code`, `Claude Desktop`, `Cursor`, and `Windsurf` with API key header examples.
  - Documented v3 session tools (`run_session`, `get_session`, `send_task`, `stop_session`, etc.) and explained v2 (task queue) vs v3 (session sandbox).
  - Refreshed cloud guide with model selection, structured output, keep‑alive, profiles, and separate “Available Tools” for v2 and v3.
  - Simplified open‑source doc: quick start using `uvx --from 'browser-use[cli]' browser-use --mcp`, client configs, env vars, examples, troubleshooting, and a link to the cloud MCP guide.

- **Bug Fixes**
  - Fixed `claude mcp add` by adding `-t http` and `-H "x-browser-use-api-key: ..."` for API auth.

<sup>Written for commit e3c29497f7cf27b123ceedd961d102fa1477af7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

