### PR TITLE
docs: add skills.sh install instructions to all llms.txt files

### DIFF
--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -4,6 +4,9 @@
 
 **Recommended: Use the BU Agent API (v3) for new projects.** V3 provides more accurate agents, long-running tasks, file uploads, and persistent workspaces. V3 is a superset of v2. Import from `browser_use_sdk.v3` (Python) or `browser-use-sdk/v3` (TypeScript).
 
+Install this as an agent skill for persistent access: `npx skills add https://github.com/browser-use/browser-use --skill cloud -y`
+Browse: [skills.sh/browser-use/browser-use/cloud](https://skills.sh/browser-use/browser-use/cloud)
+
 # Introduction
 Source: https://docs.browser-use.com/cloud/introduction
 

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -4,6 +4,9 @@
 
 **Recommended: [BU Agent API (v3)](https://docs.browser-use.com/cloud/new-features/api-v3)** — more accurate agents, long-running tasks, file uploads, and persistent workspaces. V3 is a superset of v2. Use v3 for new projects.
 
+Install this as an agent skill for persistent access: `npx skills add https://github.com/browser-use/browser-use --skill cloud -y`
+Browse: [skills.sh/browser-use/browser-use/cloud](https://skills.sh/browser-use/browser-use/cloud)
+
 For full page content with code examples, see [/cloud/llms-full.txt](https://docs.browser-use.com/cloud/llms-full.txt).
 
 ## Get Started

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4,6 +4,24 @@
 
 Browser Use has two products: **Browser Use Cloud** (managed SDK and API) and **Browser Use Open Source** (self-hosted Python library). They are separate products with separate documentation.
 
+## Install as an Agent Skill
+
+Give your AI coding agent full Browser Use documentation by installing it as a skill via [skills.sh](https://skills.sh):
+
+```bash
+# Cloud SDK & API docs
+npx skills add https://github.com/browser-use/browser-use --skill cloud -y
+
+# Open-source library docs
+npx skills add https://github.com/browser-use/browser-use --skill open-source -y
+```
+
+Works with Claude Code, Cursor, Windsurf, Cline, GitHub Copilot, and 15+ other agents.
+
+Browse available skills:
+- [Cloud skill](https://skills.sh/browser-use/browser-use/cloud)
+- [Open Source skill](https://skills.sh/browser-use/browser-use/open-source)
+
 ## Browser Use Cloud (Recommended)
 
 SDK and API for browser automation with a state-of-the-art model, stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure. Available in Python and TypeScript.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,6 +4,24 @@
 
 Browser Use has two products: **Browser Use Cloud** (managed SDK and API) and **Browser Use Open Source** (self-hosted Python library). They are separate products with separate documentation.
 
+## Install as an Agent Skill
+
+Give your AI coding agent full Browser Use documentation by installing it as a skill via [skills.sh](https://skills.sh):
+
+```bash
+# Cloud SDK & API docs
+npx skills add https://github.com/browser-use/browser-use --skill cloud -y
+
+# Open-source library docs
+npx skills add https://github.com/browser-use/browser-use --skill open-source -y
+```
+
+Works with Claude Code, Cursor, Windsurf, Cline, GitHub Copilot, and 15+ other agents.
+
+Browse available skills:
+- [Cloud skill](https://skills.sh/browser-use/browser-use/cloud)
+- [Open Source skill](https://skills.sh/browser-use/browser-use/open-source)
+
 ## Browser Use Cloud (Recommended)
 
 SDK and API for browser automation with a state-of-the-art model, stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure. Available in Python and TypeScript.

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -2,6 +2,9 @@
 
 > Complete reference for the Browser Use open-source Python library. Self-hosted browser automation with any LLM.
 
+Install this as an agent skill for persistent access: `npx skills add https://github.com/browser-use/browser-use --skill open-source -y`
+Browse: [skills.sh/browser-use/browser-use/open-source](https://skills.sh/browser-use/browser-use/open-source)
+
 # Introduction
 Source: https://docs.browser-use.com/open-source/introduction
 

--- a/docs/open-source/llms.txt
+++ b/docs/open-source/llms.txt
@@ -2,6 +2,9 @@
 
 > Self-hosted browser automation with any LLM. Python library for AI-powered web agents.
 
+Install this as an agent skill for persistent access: `npx skills add https://github.com/browser-use/browser-use --skill open-source -y`
+Browse: [skills.sh/browser-use/browser-use/open-source](https://skills.sh/browser-use/browser-use/open-source)
+
 For full page content with code examples, see [/open-source/llms-full.txt](https://docs.browser-use.com/open-source/llms-full.txt).
 
 ## Get Started


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added `skills.sh` install commands and browse links to all LLM docs so users can install Browser Use docs as an agent skill for persistent access. Covers Cloud and Open Source pages (short and full).

- **New Features**
  - Added quick `npx skills add https://github.com/browser-use/browser-use --skill cloud|open-source -y` commands in `docs/llms*.txt`, `docs/cloud/llms*.txt`, and `docs/open-source/llms*.txt`.
  - Linked to `skills.sh/browser-use/browser-use/cloud` and `skills.sh/browser-use/browser-use/open-source` for easy discovery.

<sup>Written for commit 176b3dd31465bb5bb07a3e25396c1386c8a70996. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

