### PR TITLE
docs: rename coding-agent-quickstart to vibecoding

### DIFF
--- a/docs/cloud/vibecoding.mdx
+++ b/docs/cloud/vibecoding.mdx
@@ -1,5 +1,5 @@
 ---
-title: Coding Agent Quickstart
+title: Vibecoding
 description: "Complete Cloud SDK reference for AI coding agents. Copy one blob into Claude Code, Cursor, or Copilot for instant API integration."
 icon: brain
 ---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -55,7 +55,7 @@
                 "pages": [
                   "cloud/introduction",
                   "cloud/quickstart",
-                  "cloud/coding-agent-quickstart",
+                  "cloud/vibecoding",
                   "cloud/pricing"
                 ]
               },
@@ -174,7 +174,7 @@
             "pages": [
               "open-source/introduction",
               "open-source/quickstart",
-              "open-source/coding-agent-quickstart",
+              "open-source/vibecoding",
               "open-source/supported-models",
               "open-source/browser-use-cli"
             ]
@@ -339,7 +339,7 @@
     {"source": "/", "destination": "/cloud/introduction"},
     {"source": "/introduction", "destination": "/cloud/introduction"},
     {"source": "/quickstart", "destination": "/open-source/quickstart"},
-    {"source": "/quickstart_llm", "destination": "/open-source/coding-agent-quickstart"},
+    {"source": "/quickstart_llm", "destination": "/open-source/vibecoding"},
     {"source": "/supported-models", "destination": "/open-source/supported-models"},
 
     {"source": "/customize/agent/basics", "destination": "/open-source/customize/agent/basics"},
@@ -428,8 +428,12 @@
     {"source": "/customize/examples/prompting-guide", "destination": "/open-source/customize/agent/prompting-guide"},
 
     {"source": "/pricing", "destination": "/cloud/pricing"},
-    {"source": "/llm-quickstart", "destination": "/cloud/coding-agent-quickstart"},
-    {"source": "/cloud/llm-quickstart", "destination": "/cloud/coding-agent-quickstart"},
+    {"source": "/llm-quickstart", "destination": "/cloud/vibecoding"},
+    {"source": "/cloud/llm-quickstart", "destination": "/cloud/vibecoding"},
+    {"source": "/cloud/coding-agent-quickstart", "destination": "/cloud/vibecoding"},
+    {"source": "/cloud/write-code", "destination": "/cloud/vibecoding"},
+    {"source": "/open-source/coding-agent-quickstart", "destination": "/open-source/vibecoding"},
+    {"source": "/open-source/write-code", "destination": "/open-source/vibecoding"},
     {"source": "/faq", "destination": "/cloud/faq"},
     {"source": "/open-source", "destination": "/open-source/introduction"},
     {"source": "/examples", "destination": "/cloud/tips/data/structured-output"},
@@ -471,8 +475,8 @@
 
     {"source": "/get-started/human-quickstart", "destination": "/cloud/quickstart"},
     {"source": "/human-quickstart", "destination": "/cloud/quickstart"},
-    {"source": "/get-started/llm-quickstart", "destination": "/cloud/coding-agent-quickstart"},
-    {"source": "/open-source/quickstart_llm", "destination": "/open-source/coding-agent-quickstart"},
+    {"source": "/get-started/llm-quickstart", "destination": "/cloud/vibecoding"},
+    {"source": "/open-source/quickstart_llm", "destination": "/open-source/vibecoding"},
     {"source": "/get-started/models-and-pricing", "destination": "/cloud/pricing"},
     {"source": "/get-started/pricing", "destination": "/cloud/pricing"},
     {"source": "/concepts/overview", "destination": "/cloud/quickstart"},

--- a/docs/open-source/vibecoding.mdx
+++ b/docs/open-source/vibecoding.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Coding Agent Quickstart"
+title: "Vibecoding"
 description: "Complete Python SDK reference for AI coding agents. Paste into Claude Code, Cursor, or Copilot for instant integration."
 icon: "brain"
 ---


### PR DESCRIPTION
## Summary
- Renames `coding-agent-quickstart` → `vibecoding` in both Cloud and Open Source docs
- Updates all navigation references in `docs.json`
- Adds redirects from old paths (`coding-agent-quickstart`, `write-code`, `llm-quickstart`)

## Test plan
- [ ] Verify http://localhost:3002/cloud/vibecoding loads correctly
- [ ] Verify old URLs redirect (e.g. `/cloud/coding-agent-quickstart` → `/cloud/vibecoding`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed `coding-agent-quickstart` to `vibecoding` across Cloud and Open Source docs to improve clarity. Updated navigation and added redirects so old links continue to work.

- **Refactors**
  - Renamed pages to `cloud/vibecoding` and `open-source/vibecoding` and updated titles to "Vibecoding".
  - Updated `docs.json` navigation to the new paths.
  - Added redirects from legacy routes (e.g., `/cloud/coding-agent-quickstart`, `/cloud/write-code`, `/cloud/llm-quickstart` and Open Source equivalents) to the new `vibecoding` pages.

<sup>Written for commit e9a8ff7344bcfcf20fa1f5377341ef52c911bcdf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

