### PR TITLE
docs: rename "Coding Agent Quickstart" to "Prompts for Vibecoders"

### DIFF
--- a/docs/cloud/introduction.mdx
+++ b/docs/cloud/introduction.mdx
@@ -14,7 +14,7 @@ icon: house
   <Card title="Quickstart" icon="rocket" href="/cloud/quickstart">
     Run your first task in Python or TypeScript.
   </Card>
-  <Card title="Coding Agent Quickstart" icon="brain" href="/cloud/coding-agent-quickstart">
+  <Card title="Prompts for Vibecoders" icon="brain" href="/cloud/vibecoding">
     Full SDK and API reference for Claude Code, Cursor, or Copilot.
   </Card>
 </CardGroup>

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -260,11 +260,11 @@ const result = await client.run("Get my latest order status", {
 
 See [Tasks](/cloud/guides/tasks) for all parameters, or browse [Tips](/cloud/tips/data/structured-output) for copy-paste recipes.
 
-- **Coding Agent Quickstart** — Paste one blob into your AI editor. Your agent knows the entire API. [/cloud/coding-agent-quickstart]
+- **Prompts for Vibecoders** — Paste one blob into your AI editor. Your agent knows the entire API. [/cloud/vibecoding]
 - **Overview** — Four ways to automate the web — pick the one that fits. [/cloud/introduction]
 
-# Coding Agent Quickstart
-Source: https://docs.browser-use.com/cloud/coding-agent-quickstart
+# Prompts for Vibecoders
+Source: https://docs.browser-use.com/cloud/vibecoding
 
 Paste the following into **Claude Code**, **Codex**, **Cursor**, or any coding agent. It contains the full SDK reference for both BU Agent API (v3) and v2 API — every method, every parameter, working examples.
 

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -1,66 +1,33 @@
-# Browser Use Cloud
+# cloud docs
 
-> SDK and API for AI-powered browser automation. Custom models, stealth browsers, CAPTCHA solving, residential proxies, and scalable infrastructure.
-
-**Recommended: [BU Agent API (v3)](https://docs.browser-use.com/cloud/new-features/api-v3)** — more accurate agents, long-running tasks, file uploads, and persistent workspaces. V3 is a superset of v2. Use v3 for new projects.
-
-Install this as an agent skill for persistent access: `npx skills add https://github.com/browser-use/browser-use --skill cloud -y`
-Browse: [skills.sh/browser-use/browser-use/cloud](https://skills.sh/browser-use/browser-use/cloud)
-
-For full page content with code examples, see [/cloud/llms-full.txt](https://docs.browser-use.com/cloud/llms-full.txt).
-
-## Get Started
-
-- [Introduction](https://docs.browser-use.com/cloud/introduction): Product overview and four approaches to browser automation (tasks, skills, browser infra, open-source hybrid).
-- [Quickstart](https://docs.browser-use.com/cloud/quickstart): Install the SDK, set your API key, and run your first task in Python or TypeScript.
-- [Coding Agent Quickstart](https://docs.browser-use.com/cloud/coding-agent-quickstart): Complete SDK reference in a single page. Designed for AI coding agents.
-- [BU Agent API (v3)](https://docs.browser-use.com/cloud/new-features/api-v3): Next-generation agent API with structured output, file uploads, workspaces, and faster agents.
-- [Pricing](https://docs.browser-use.com/cloud/pricing): Models, pricing tiers, and cost breakdown.
-
-## Concepts
-
-- [Agent Tasks](https://docs.browser-use.com/cloud/guides/tasks): Run AI agent tasks with natural language, get structured output, stream progress.
-- [Sessions & Profiles](https://docs.browser-use.com/cloud/guides/sessions): Stateful browsers, persistent login state, and profile sync.
-- [Workspaces](https://docs.browser-use.com/cloud/guides/workspaces): Persistent file storage across sessions. Upload inputs, download outputs.
-- [Browser Infrastructure](https://docs.browser-use.com/cloud/guides/browser-api): Direct CDP access to stealth browsers for Playwright, Puppeteer, or Selenium.
-- [Proxies & Stealth](https://docs.browser-use.com/cloud/guides/proxies-and-stealth): Anti-detect browsers, CAPTCHA solving, 195+ country residential proxies.
-- [Skills](https://docs.browser-use.com/cloud/guides/skills): Turn any website into a deterministic, repeatable API endpoint.
-- [Authentication](https://docs.browser-use.com/cloud/guides/authentication): Profile sync, secrets, and 1Password with TOTP/2FA.
-- [MCP Server](https://docs.browser-use.com/cloud/guides/mcp-server): Use Browser Use from Claude, Cursor, Windsurf, or any MCP client.
-- [Webhooks](https://docs.browser-use.com/cloud/guides/webhooks): Get notified when tasks complete.
-
-## Tutorials
-
-- [Chat UI](https://docs.browser-use.com/cloud/tutorials/chat-ui): Build a chat interface for browser automation.
-
-## Tips
-
-### Authentication
-- [Profiles & Secrets](https://docs.browser-use.com/cloud/tips/authentication/profiles-and-secrets): Run tasks on authenticated sites using saved browser profiles and domain-scoped credentials.
+- [API Reference](https://docs.browser-use.com/cloud/api-reference): Complete REST API reference for v2 and v3. Endpoints, authentication, SDKs, and request/response examples.
+- [Troubleshooting & FAQ](https://docs.browser-use.com/cloud/faq): Fix common issues — slow tasks, failed agents, login problems, blocked sites, and unexpected costs.
+- [Authentication & 2FA](https://docs.browser-use.com/cloud/guides/authentication): Authenticate browser automation tasks using profile sync, domain-scoped secrets, and the 1Password integration with TOTP/2FA.
+- [Browser Infrastructure](https://docs.browser-use.com/cloud/guides/browser-api): Direct Chrome DevTools Protocol (CDP) access to stealth browsers. Connect via WebSocket URL or SDK with Playwright, Puppeteer, or Selenium.
+- [MCP Server](https://docs.browser-use.com/cloud/guides/mcp-server): Run browser automation tasks from your AI coding assistant. Connect to Claude, Cursor, Windsurf, or any MCP client.
+- [Proxies & Stealth](https://docs.browser-use.com/cloud/guides/proxies-and-stealth): Configure anti-detect browsers with CAPTCHA solving and residential proxies in 195+ countries.
+- [Sessions & Profiles](https://docs.browser-use.com/cloud/guides/sessions): Manage stateful browser sessions. Persistent login with profile sync, multi-step workflows, and cookie management.
+- [Skills](https://docs.browser-use.com/cloud/guides/skills): Turn any website into a deterministic API endpoint. Create once, call repeatedly.
+- [Tasks](https://docs.browser-use.com/cloud/guides/tasks): Run AI browser automation tasks with structured output, configurable models, real-time streaming, cost controls, and natural language instructions.
+- [Webhooks](https://docs.browser-use.com/cloud/guides/webhooks): Receive real-time notifications when tasks complete. Configure webhook endpoints for async task monitoring.
+- [Workspaces](https://docs.browser-use.com/cloud/guides/workspaces): Persistent file storage across sessions. Upload input files, download results, and share data across tasks.
+- [Browser Use Cloud](https://docs.browser-use.com/cloud/introduction): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.
+- [BU Agent API](https://docs.browser-use.com/cloud/new-features/api-v3): BU Agent API (v3) — a next-generation AI browser agent for web scraping, data extraction, file manipulation, and multi-step workflows in a single API call.
+- [Models and Pricing](https://docs.browser-use.com/cloud/pricing): Cloud API pricing, models, and cost breakdown.
+- [Quickstart](https://docs.browser-use.com/cloud/quickstart): Install the SDK, set your API key, and run your first AI browser automation task with Python or TypeScript.
 - [1Password Login with 2FA](https://docs.browser-use.com/cloud/tips/authentication/1password-2fa): Auto-fill passwords and TOTP codes from your 1Password vault during agent tasks.
-- [Social Media Platforms](https://docs.browser-use.com/cloud/tips/authentication/social-media): Use browser profiles and residential proxies to automate social media and job platforms.
-
-### Live View
-- [Embed Live View](https://docs.browser-use.com/cloud/tips/live-view/iframe-embed): Embed the agent's live browser view in your app using an iframe.
-- [Human Takeover](https://docs.browser-use.com/cloud/tips/live-view/human-takeover): Combine human judgment with agent automation in the same session.
-
-### Parallel
-- [Parallel Extraction](https://docs.browser-use.com/cloud/tips/parallel/concurrent-extraction): Run multiple extraction tasks concurrently with asyncio.gather or Promise.all.
-- [Shared Auth](https://docs.browser-use.com/cloud/tips/parallel/shared-config): Run concurrent sessions that share the same profile and proxy.
-
-### Data
-- [Structured Output](https://docs.browser-use.com/cloud/tips/data/structured-output): Extract typed data from any website using Pydantic models or Zod schemas.
-- [File Downloads](https://docs.browser-use.com/cloud/tips/data/file-downloads): Download files the agent saves during a task.
+- [Profiles & Secrets](https://docs.browser-use.com/cloud/tips/authentication/profiles-and-secrets): Run tasks on authenticated sites using saved browser profiles and domain-scoped credentials.
+- [Social Media Platforms](https://docs.browser-use.com/cloud/tips/authentication/social-media): Use browser profiles and residential proxies to automate social media and job platforms reliably.
+- [File Downloads](https://docs.browser-use.com/cloud/tips/data/file-downloads): Download files the agent saves during a task — PDFs, CSVs, images, and more.
 - [Geo-Specific Scraping](https://docs.browser-use.com/cloud/tips/data/geo-scraping): Scrape location-dependent content using residential proxies in 195+ countries.
-- [Streaming](https://docs.browser-use.com/cloud/tips/data/streaming): Stream agent steps in real time as the task executes.
-
-## Integrations
-
-- [OpenClaw](https://docs.browser-use.com/cloud/tutorials/integrations/openclaw): Give OpenClaw agents browser automation with Browser Use — via CDP or the CLI skill.
+- [Stream Task Progress](https://docs.browser-use.com/cloud/tips/data/streaming): Stream agent steps in real time as the task executes.
+- [Structured Output](https://docs.browser-use.com/cloud/tips/data/structured-output): Extract typed data from any website using Pydantic models or Zod schemas.
+- [Human Takeover](https://docs.browser-use.com/cloud/tips/live-view/human-takeover): Combine human judgment with agent automation — hand control back and forth in the same session.
+- [Embed Live View](https://docs.browser-use.com/cloud/tips/live-view/iframe-embed): Embed the agent's live browser view in your app using an iframe.
+- [Parallel Extraction](https://docs.browser-use.com/cloud/tips/parallel/concurrent-extraction): Run multiple extraction tasks concurrently with asyncio.gather or Promise.all.
+- [Parallel Browsers with Shared Auth](https://docs.browser-use.com/cloud/tips/parallel/shared-config): Run concurrent sessions that share the same profile and proxy for authenticated parallel tasks.
+- [Chat UI](https://docs.browser-use.com/cloud/tutorials/chat-ui): Build a chat interface for Browser Use with Next.js and the SDK.
 - [n8n](https://docs.browser-use.com/cloud/tutorials/integrations/n8n): Use Browser Use as an HTTP node in n8n workflows.
+- [OpenClaw](https://docs.browser-use.com/cloud/tutorials/integrations/openclaw): Give OpenClaw agents browser automation with Browser Use — via CDP or the CLI skill.
 - [Playwright](https://docs.browser-use.com/cloud/tutorials/integrations/playwright): Connect Playwright to a cloud browser via CDP for full programmatic control.
-
-## Resources
-
-- [FAQ](https://docs.browser-use.com/cloud/faq): Common issues and quick fixes.
-- [API Reference](https://docs.browser-use.com/cloud/api-reference): Full REST API endpoint overview for v2 and v3.
+- [Prompts for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents. Copy one blob into Claude Code, Cursor, or Copilot for instant API integration.

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -162,7 +162,7 @@ const result = await client.run("Get my latest order status", {
 See [Tasks](/cloud/guides/tasks) for all parameters, or browse [Tips](/cloud/tips/data/structured-output) for copy-paste recipes.
 
 <CardGroup cols={2}>
-  <Card title="Coding Agent Quickstart" icon="brain" href="/cloud/coding-agent-quickstart">
+  <Card title="Prompts for Vibecoders" icon="brain" href="/cloud/vibecoding">
     Paste one blob into your AI editor. Your agent knows the entire API.
   </Card>
   <Card title="Agent Tasks" icon="play" href="/cloud/guides/tasks">

--- a/docs/cloud/vibecoding.mdx
+++ b/docs/cloud/vibecoding.mdx
@@ -1,5 +1,5 @@
 ---
-title: Vibecoding
+title: Prompts for Vibecoders
 description: "Complete Cloud SDK reference for AI coding agents. Copy one blob into Claude Code, Cursor, or Copilot for instant API integration."
 icon: brain
 ---

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -30,7 +30,7 @@ SDK and API for browser automation with a state-of-the-art model, stealth browse
 
 - [Cloud Full Reference](https://docs.browser-use.com/cloud/llms-full.txt) — Complete cloud SDK and API documentation with all pages.
 - [Cloud Documentation Index](https://docs.browser-use.com/cloud/llms.txt) — Concise page index.
-- [Coding Agent Quickstart](https://docs.browser-use.com/cloud/coding-agent-quickstart) — Every SDK method, parameter, and response type in one page.
+- [Prompts for Vibecoders](https://docs.browser-use.com/cloud/vibecoding) — Every SDK method, parameter, and response type in one page.
 
 ## Browser Use Open Source
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -28,7 +28,7 @@ SDK and API for browser automation with a state-of-the-art model, stealth browse
 
 - [Cloud Documentation Index](/cloud/llms.txt): Concise page index for all cloud docs.
 - [Cloud Full Reference](/cloud/llms-full.txt): Complete cloud documentation with full page content.
-- [Coding Agent Quickstart](https://docs.browser-use.com/cloud/coding-agent-quickstart): Every SDK method, parameter, and response type in one page.
+- [Prompts for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Every SDK method, parameter, and response type in one page.
 
 ## Browser Use Open Source
 
@@ -273,5 +273,5 @@ result = await agent.run()
 
 ## Full SDK Reference
 
-For the complete SDK reference with every method, parameter, and response type, see the Coding Agent Quickstart page. It is designed to be copy-pasted into AI coding agents:
-https://docs.browser-use.com/cloud/coding-agent-quickstart
+For the complete SDK reference with every method, parameter, and response type, see the Prompts for Vibecoders page. It is designed to be copy-pasted into AI coding agents:
+https://docs.browser-use.com/cloud/vibecoding

--- a/docs/open-source/introduction.mdx
+++ b/docs/open-source/introduction.mdx
@@ -12,7 +12,7 @@ icon: "house"
   <Card title="Human Quickstart" icon="rocket" href="/open-source/quickstart">
     Install and run your first agent.
   </Card>
-  <Card title="Coding Agent Quickstart" icon="microchip" href="/open-source/coding-agent-quickstart">
+  <Card title="Prompts for Vibecoders" icon="microchip" href="/open-source/vibecoding">
     Full SDK reference in a single page.
   </Card>
 </CardGroup>

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -169,8 +169,8 @@ if __name__ == "__main__":
 
 See [Browser Use Cloud](/cloud/introduction) for how to sync your cookies to the cloud.
 
-# Coding Agent Quickstart
-Source: https://docs.browser-use.com/open-source/coding-agent-quickstart
+# Prompts for Vibecoders
+Source: https://docs.browser-use.com/open-source/vibecoding
 
 1. Copy all content [🔗  from here](https://github.com/browser-use/browser-use/blob/main/AGENTS.md) (~9k tokens)
 2. Paste it into your project

--- a/docs/open-source/llms.txt
+++ b/docs/open-source/llms.txt
@@ -1,87 +1,51 @@
-# Browser Use Open Source
+# open-source docs
 
-> Self-hosted browser automation with any LLM. Python library for AI-powered web agents.
-
-Install this as an agent skill for persistent access: `npx skills add https://github.com/browser-use/browser-use --skill open-source -y`
-Browse: [skills.sh/browser-use/browser-use/open-source](https://skills.sh/browser-use/browser-use/open-source)
-
-For full page content with code examples, see [/open-source/llms-full.txt](https://docs.browser-use.com/open-source/llms-full.txt).
-
-## Get Started
-
-- [Introduction](https://docs.browser-use.com/open-source/introduction): Overview of the open-source browser automation library.
-- [Human Quickstart](https://docs.browser-use.com/open-source/quickstart): Install and run your first agent with step-by-step instructions.
-- [Coding Agent Quickstart](https://docs.browser-use.com/open-source/coding-agent-quickstart): Quick-start reference designed for AI coding agents.
-- [Supported Models](https://docs.browser-use.com/open-source/supported-models): Compatible LLMs including GPT-4o, Claude, Gemini, DeepSeek, and more.
-
-## Customize
-
-### Agent
-- [Agent Basics](https://docs.browser-use.com/open-source/customize/agent/basics): Configure the agent with tasks, LLMs, and browser instances.
-- [Prompting Guide](https://docs.browser-use.com/open-source/customize/agent/prompting-guide): Write effective agent prompts for reliable results.
-- [Output Format](https://docs.browser-use.com/open-source/customize/agent/output-format): Understanding agent return values and result extraction.
-- [All Agent Parameters](https://docs.browser-use.com/open-source/customize/agent/all-parameters): Complete reference for all agent configuration options.
-
-### Browser
-- [Browser Basics](https://docs.browser-use.com/open-source/customize/browser/basics): Browser configuration and setup.
-- [Authentication](https://docs.browser-use.com/open-source/customize/browser/authentication): Login to websites using real browser profiles, storage state, and 2FA codes.
-- [Real Browser](https://docs.browser-use.com/open-source/customize/browser/real-browser): Connect your existing Chrome browser to preserve authentication.
-- [Remote Browser](https://docs.browser-use.com/open-source/customize/browser/remote): Connect to cloud or remote browsers.
-- [All Browser Parameters](https://docs.browser-use.com/open-source/customize/browser/all-parameters): Complete reference for all browser configuration options.
-
-### Tools
-- [Tools Basics](https://docs.browser-use.com/open-source/customize/tools/basics): Tools are the functions the agent uses to interact with the browser.
-- [Available Tools](https://docs.browser-use.com/open-source/customize/tools/available): Built-in tools reference and source code.
-- [Add Custom Tools](https://docs.browser-use.com/open-source/customize/tools/add): Add custom tools to extend agent capabilities.
-- [Remove Tools](https://docs.browser-use.com/open-source/customize/tools/remove): Exclude default tools from the agent.
-- [Tool Response](https://docs.browser-use.com/open-source/customize/tools/response): Customize tool response handling.
-
-### Integration
-- [Documentation MCP](https://docs.browser-use.com/open-source/customize/integrations/docs-mcp): Add browser-use documentation context to Claude Code and other MCP clients.
-- [MCP Server](https://docs.browser-use.com/open-source/customize/integrations/mcp-server): Connect AI models to Browser Use through the Model Context Protocol.
-
-## Examples
-
-### Templates
-- [Fast Agent](https://docs.browser-use.com/open-source/examples/templates/fast-agent): Optimize agent performance for maximum speed.
-- [Follow-up Tasks](https://docs.browser-use.com/open-source/examples/templates/follow-up-tasks): Chain tasks with the same browser session.
-- [Parallel Agents](https://docs.browser-use.com/open-source/examples/templates/parallel-browser): Run multiple agents in parallel with separate browser instances.
-- [Playwright Integration](https://docs.browser-use.com/open-source/examples/templates/playwright-integration): Advanced Playwright and Browser-Use interop example.
-- [Sensitive Data](https://docs.browser-use.com/open-source/examples/templates/sensitive-data): Handle secrets securely without sending PII to the LLM.
-- [Secure Setup](https://docs.browser-use.com/open-source/examples/templates/secure): Azure OpenAI with data privacy and security configuration.
-- [More Examples](https://docs.browser-use.com/open-source/examples/templates/more-examples): Additional examples and use cases on GitHub.
-
-### Apps
-- [Ad-Use (Ad Generator)](https://docs.browser-use.com/open-source/examples/apps/ad-use): Generate Instagram image ads and TikTok video ads from landing pages.
-- [Vibetest-Use (Automated QA)](https://docs.browser-use.com/open-source/examples/apps/vibetest-use): Multi-agent tests to catch UI bugs, broken links, and accessibility issues.
-- [News-Use (News Monitor)](https://docs.browser-use.com/open-source/examples/apps/news-use): Monitor news websites and extract articles with sentiment analysis.
-- [Msg-Use (WhatsApp Sender)](https://docs.browser-use.com/open-source/examples/apps/msg-use): AI-powered WhatsApp message scheduler using browser agents.
-
-## Development
-
-### Contribution
-- [Local Setup](https://docs.browser-use.com/open-source/development/setup/local-setup): Set up the development environment.
-- [Contribution Guide](https://docs.browser-use.com/open-source/development/setup/contribution-guide): How to contribute to Browser Use.
-
-### Advanced
-- [Lifecycle Hooks](https://docs.browser-use.com/open-source/customize/hooks): Customize agent behavior with lifecycle hooks.
-
-### Monitoring
-- [Observability](https://docs.browser-use.com/open-source/development/monitoring/observability): Trace agent execution and capture browser session recordings.
+- [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli): Fast, persistent browser automation from the command line.
+- [All Parameters](https://docs.browser-use.com/open-source/customize/agent/all-parameters): Complete reference for all agent configuration options — LLM settings, prompts, tools, output format, and callbacks.
+- [Configuration](https://docs.browser-use.com/open-source/customize/agent/basics): Configure the agent — set your LLM, define tasks, add custom tools, and control behavior with Python.
+- [Output Format](https://docs.browser-use.com/open-source/customize/agent/output-format): Control agent output — structured results, step history, action logs, and extracted content from browser automation tasks.
+- [Prompting Guide](https://docs.browser-use.com/open-source/customize/agent/prompting-guide): Write effective prompts for the agent. Tips for task descriptions, multi-step workflows, and getting reliable structured output.
+- [All Parameters](https://docs.browser-use.com/open-source/customize/browser/all-parameters): Complete reference for all browser configuration options — launch args, proxy, viewport, user data, and CDP settings.
+- [Authentication](https://docs.browser-use.com/open-source/customize/browser/authentication): Log into websites using real browser profiles, saved storage state, and 2FA codes for authenticated automation.
+- [Configuration](https://docs.browser-use.com/open-source/customize/browser/basics): Configure the browser instance — headless mode, viewport size, proxy settings, and Playwright launch options.
+- [Real Browser](https://docs.browser-use.com/open-source/customize/browser/real-browser): Connect to your existing Chrome browser to preserve login sessions, cookies, and extensions for authenticated tasks.
+- [Remote Browser](https://docs.browser-use.com/open-source/customize/browser/remote): Connect to remote browsers via CDP — use with the Cloud, Browserbase, or any remote Chrome instance.
+- [Lifecycle Hooks](https://docs.browser-use.com/open-source/customize/hooks): Hook into agent lifecycle events — before/after actions, navigation, extraction, and error handling callbacks.
+- [MCP Server](https://docs.browser-use.com/open-source/customize/integrations/mcp-server): Run browser-use as a local Model Context Protocol server. Connect AI models to browser automation through the MCP standard.
+- [Basics](https://docs.browser-use.com/open-source/customize/skills/basics): Skills are your API for anything. Describe what you need in plain text, and get a production-ready API endpoint you can call repeatedly.
+- [Add Tools](https://docs.browser-use.com/open-source/customize/tools/add): Extend agents with custom Python functions. Add API calls, file operations, or any custom logic as agent tools.
+- [Available Tools](https://docs.browser-use.com/open-source/customize/tools/available): Built-in tools — click, type, scroll, extract, navigate, and more. Full list of default agent actions.
+- [Overview](https://docs.browser-use.com/open-source/customize/tools/basics): Learn about built-in browser actions and custom tools.
+- [Remove Tools](https://docs.browser-use.com/open-source/customize/tools/remove): Exclude default tools to restrict agent capabilities.
+- [Response Format](https://docs.browser-use.com/open-source/customize/tools/response): Customize how tools return data to the agent. Control response formatting, extraction, and content filtering.
+- [Development](https://docs.browser-use.com/open-source/development): Preview changes locally to update your docs
+- [Get Help](https://docs.browser-use.com/open-source/development/get-help): Get help — join 20k+ developers on Discord, search GitHub issues, or ask the community.
+- [Costs](https://docs.browser-use.com/open-source/development/monitoring/costs): Track token usage and API costs for your browser automation tasks
+- [Observability](https://docs.browser-use.com/open-source/development/monitoring/observability): Trace agent execution steps and capture browser session recordings.
 - [OpenLIT](https://docs.browser-use.com/open-source/development/monitoring/openlit): Complete observability with OpenLIT tracing.
-- [Telemetry](https://docs.browser-use.com/open-source/development/monitoring/telemetry): Understanding Browser Use telemetry.
-- [Costs](https://docs.browser-use.com/open-source/development/monitoring/costs): Track token usage and API costs.
-
-- [Get Help](https://docs.browser-use.com/open-source/development/get-help): Community support with 20k+ developers.
-
-## Legacy
-
-### Actor
-- [Actor Basics](https://docs.browser-use.com/open-source/legacy/actor/basics): Low-level Playwright-like browser automation with full CDP control.
-- [Actor Examples](https://docs.browser-use.com/open-source/legacy/actor/examples): Forms, JavaScript, mouse operations, and AI features.
-- [All Parameters](https://docs.browser-use.com/open-source/legacy/actor/all-parameters): Complete Browser Actor API reference.
-
-### Sandbox
-- [Sandbox Quickstart](https://docs.browser-use.com/open-source/legacy/sandbox/quickstart): Run browser automation in the cloud.
-- [Events](https://docs.browser-use.com/open-source/legacy/sandbox/events): Monitor execution with callbacks.
-- [All Parameters](https://docs.browser-use.com/open-source/legacy/sandbox/all-parameters): Sandbox configuration reference.
+- [Telemetry](https://docs.browser-use.com/open-source/development/monitoring/telemetry): Understanding Browser Use's telemetry
+- [n8n Integration](https://docs.browser-use.com/open-source/development/n8n-integration): Learn how to integrate Browser Use with n8n workflows
+- [Roadmap](https://docs.browser-use.com/open-source/development/roadmap): Future plans and upcoming features for Browser Use.
+- [Contribution Guide](https://docs.browser-use.com/open-source/development/setup/contribution-guide): How to contribute — code standards, PR process, testing requirements, and submitting your first pull request.
+- [Local Development Setup](https://docs.browser-use.com/open-source/development/setup/local-setup): Set up for local development. Clone the repo, install dependencies, and run tests to start contributing.
+- [Ad-Use (Ad Generator)](https://docs.browser-use.com/open-source/examples/apps/ad-use): Generate Instagram image ads and TikTok video ads from landing pages using browser agents, Google's Nano Banana 🍌, and Veo3.
+- [Msg-Use (WhatsApp Sender)](https://docs.browser-use.com/open-source/examples/apps/msg-use): AI-powered WhatsApp message scheduler using browser agents and Gemini. Schedule personalized messages in natural language.
+- [News-Use (News Monitor)](https://docs.browser-use.com/open-source/examples/apps/news-use): Monitor news websites and extract articles with sentiment analysis using browser agents and Google Gemini.
+- [Vibetest-Use (Automated QA)](https://docs.browser-use.com/open-source/examples/apps/vibetest-use): Run multi-agent Browser-Use tests to catch UI bugs, broken links, and accessibility issues before they ship.
+- [Fast Agent](https://docs.browser-use.com/open-source/examples/templates/fast-agent): Optimize agent performance for maximum speed and efficiency.
+- [Follow up tasks](https://docs.browser-use.com/open-source/examples/templates/follow-up-tasks): Follow up tasks with the same browser session.
+- [More Examples](https://docs.browser-use.com/open-source/examples/templates/more-examples): Explore additional examples and use cases on GitHub.
+- [Parallel Agents](https://docs.browser-use.com/open-source/examples/templates/parallel-browser): Run multiple agents in parallel with separate browser instances
+- [Playwright Integration](https://docs.browser-use.com/open-source/examples/templates/playwright-integration): Advanced example showing Playwright and Browser-Use working together
+- [Secure Setup](https://docs.browser-use.com/open-source/examples/templates/secure): Azure OpenAI with data privacy and security configuration.
+- [Sensitive Data](https://docs.browser-use.com/open-source/examples/templates/sensitive-data): Handle secret information securely and avoid sending PII & passwords to the LLM.
+- [Browser Use Open Source](https://docs.browser-use.com/open-source/introduction): Python library for AI browser automation with 79k+ GitHub stars. Connect any LLM and run locally or self-hosted.
+- [All Parameters](https://docs.browser-use.com/open-source/legacy/actor/all-parameters): Complete API reference for Browser Actor classes, methods, and parameters including BrowserSession, Page, Element, and Mouse
+- [Basics](https://docs.browser-use.com/open-source/legacy/actor/basics): Low-level Playwright-like browser automation with direct and full CDP control and precise element interactions
+- [Examples](https://docs.browser-use.com/open-source/legacy/actor/examples): Comprehensive examples for Browser Actor automation tasks including forms, JavaScript, mouse operations, and AI features
+- [All Parameters](https://docs.browser-use.com/open-source/legacy/sandbox/all-parameters): Sandbox configuration reference
+- [Events](https://docs.browser-use.com/open-source/legacy/sandbox/events): Monitor execution with callbacks
+- [Quickstart](https://docs.browser-use.com/open-source/legacy/sandbox/quickstart): Run browser automation in the cloud
+- [Human Quickstart](https://docs.browser-use.com/open-source/quickstart): Install and run your first AI browser agent in minutes. Python setup with pip, environment variables, and a working example.
+- [Supported Models](https://docs.browser-use.com/open-source/supported-models): Choose between Claude, Gemini, Llama, DeepSeek, and more. Configuration examples for each provider.
+- [Prompts for Vibecoders](https://docs.browser-use.com/open-source/vibecoding): Complete Python SDK reference for AI coding agents. Paste into Claude Code, Cursor, or Copilot for instant integration.

--- a/docs/open-source/vibecoding.mdx
+++ b/docs/open-source/vibecoding.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Vibecoding"
+title: "Prompts for Vibecoders"
 description: "Complete Python SDK reference for AI coding agents. Paste into Claude Code, Cursor, or Copilot for instant integration."
 icon: "brain"
 ---


### PR DESCRIPTION
## Summary
- Renames `coding-agent-quickstart.mdx` → `vibecoding.mdx` (Cloud + Open Source)
- Title: "Prompts for Vibecoders"
- Updates nav, cards in introduction/quickstart, all llms.txt files
- Regenerated auto-generated llms.txt via `generate-llms-txt.sh`
- Redirects from all old paths

Supersedes #44.

## Test plan
- [ ] Verify `/cloud/vibecoding` and `/open-source/vibecoding` load
- [ ] Verify old URLs redirect (`/cloud/coding-agent-quickstart`, `/llm-quickstart`, etc.)
- [ ] Check cards on introduction and quickstart pages show new name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed “Coding Agent Quickstart” to “Prompts for Vibecoders” across Cloud and Open Source docs, and updated all references. Old URLs now redirect to `/cloud/vibecoding` and `/open-source/vibecoding`.

- **Refactors**
  - Renamed pages to `vibecoding.mdx` with title “Prompts for Vibecoders” (Cloud + OSS).
  - Updated intro and quickstart cards to link to `/cloud/vibecoding` and `/open-source/vibecoding`.
  - Updated `llms.txt` and `llms-full.txt` (root, cloud, open-source) to use the new name and links; regenerated via `generate-llms-txt.sh`.
  - Added redirects for legacy paths (e.g., `/llm-quickstart`, `/cloud/coding-agent-quickstart`, `/open-source/coding-agent-quickstart`).

<sup>Written for commit a3a395fce7f2b69527e05b0282834318073b1b6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

