### PR TITLE
Simplify all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,66 +4,13 @@
 
 # Browser Use SDKs
 
-Official SDKs for the [Browser Use](https://browser-use.com) cloud API.
+Official SDKs for [Browser Use Cloud](https://browser-use.com).
 
-## Packages
+| Package | Language | Registry |
+|---------|----------|----------|
+| [browser-use-sdk](browser-use-python/) | Python | PyPI |
+| [browser-use-sdk](browser-use-node/) | TypeScript | npm |
 
-| Package | Language | Registry | Version |
-|---------|----------|----------|---------|
-| [browser-use-sdk](browser-use-node/) | TypeScript | npm | 3.3.1 |
-| [browser-use-sdk](browser-use-python/) | Python | PyPI | 3.3.1 |
+## Docs
 
-Both packages support **v2** (default, stable) and **v3** (via subpath import).
-
-## Quick Start
-
-### TypeScript
-
-```bash
-npm install browser-use-sdk
-```
-
-```typescript
-import { BrowserUse } from "browser-use-sdk";
-
-const client = new BrowserUse();
-const output = await client.run("Go to google.com");
-```
-
-### Python
-
-```bash
-pip install browser-use-sdk
-```
-
-```python
-from browser_use_sdk import AsyncBrowserUse
-
-client = AsyncBrowserUse()
-output = await client.run("Go to google.com")
-```
-
-
-
-## V3
-
-```typescript
-import { BrowserUse } from "browser-use-sdk/v3";
-```
-
-```python
-from browser_use_sdk.v3 import BrowserUse
-```
-
-## Development
-
-Requires [Task](https://taskfile.dev) runner.
-
-```bash
-task gen:types   # regenerate types from OpenAPI specs
-task build       # build both SDKs
-task check       # type-check both SDKs
-task test        # run tests
-```
-
-See [RUNBOOK.md](RUNBOOK.md) for the full update workflow.
+[docs.browser-use.com](https://docs.browser-use.com)

--- a/browser-use-node/README.md
+++ b/browser-use-node/README.md
@@ -1,213 +1,32 @@
 # browser-use-sdk
 
-Official TypeScript SDK for the [Browser Use](https://browser-use.com) API -- run AI-powered browser agents in the cloud.
+Official TypeScript SDK for [Browser Use Cloud](https://browser-use.com).
 
-## Installation
+## Install
 
 ```bash
 npm install browser-use-sdk
-# or
-pnpm add browser-use-sdk
-# or
-yarn add browser-use-sdk
-# or
-bun add browser-use-sdk
 ```
 
-## Quick Start (v2)
+## Quick Start
 
-The default import exposes the **v2** API client.
+Get your API key at [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1).
 
-```ts
+```bash
+export BROWSER_USE_API_KEY=your_key
+```
+
+```typescript
 import { BrowserUse } from "browser-use-sdk";
 
 const client = new BrowserUse();
-
-const result = await client.run("Find the top post on Hacker News");
+const result = await client.run("Find the top 3 trending repos on GitHub today");
 console.log(result.output);
-console.log(result.id, result.status);
 ```
 
-## V3
+## Docs
 
-The v3 API uses a unified session model. Import from `browser-use-sdk/v3`:
-
-```ts
-import { BrowserUse } from "browser-use-sdk/v3";
-
-const client = new BrowserUse();
-
-const output = await client.run("Find the top post on HN");
-console.log(output);
-```
-
-## Client Options
-
-```ts
-const client = new BrowserUse({
-  apiKey: "bu_...",           // Or set BROWSER_USE_API_KEY env var
-  baseUrl: "https://...",     // Override API base URL
-  maxRetries: 3,              // Retry on 429 (default: 3)
-  timeout: 30_000,            // Request timeout in ms (default: 30s)
-});
-```
-
-## Structured Output
-
-Pass a Zod schema to get typed results:
-
-```ts
-import { z } from "zod";
-
-const Product = z.object({ name: z.string(), price: z.number() });
-
-const result = await client.run("Find the price of the MacBook Air", { schema: Product });
-console.log(`${result.output.name}: $${result.output.price}`);
-```
-
-## Polling and Streaming
-
-`client.run()` returns a dual-purpose handle: `await` it for the output, or `for await...of` it for step-by-step progress.
-
-### Wait for Result
-
-```ts
-const result = await client.run("Search for AI news");
-console.log(result.output, result.id, result.status);
-```
-
-### Stream Steps
-
-```ts
-for await (const step of client.run("Search for AI news")) {
-  console.log(`[${step.number}] ${step.nextGoal} — ${step.url}`);
-}
-```
-
-## V2 API Reference
-
-### Billing
-
-| Method                | Description                          |
-|-----------------------|--------------------------------------|
-| `billing.account()`  | Get account info and credit balance  |
-
-### Tasks
-
-| Method                       | Description                             |
-|------------------------------|-----------------------------------------|
-| `tasks.create(body)`        | Create and start a new task             |
-| `tasks.list(params?)`       | List tasks with optional filtering      |
-| `tasks.get(taskId)`         | Get detailed task information           |
-| `tasks.stop(taskId)`        | Stop a running task                     |
-| `tasks.status(taskId)`      | Lightweight status for polling          |
-| `tasks.wait(taskId, opts?)` | Poll until terminal, return TaskView    |
-| `tasks.logs(taskId)`        | Get download URL for task logs          |
-
-### Sessions
-
-| Method                             | Description                          |
-|------------------------------------|--------------------------------------|
-| `sessions.create(body?)`          | Create a new session                 |
-| `sessions.list(params?)`          | List sessions                        |
-| `sessions.get(sessionId)`         | Get session details                  |
-| `sessions.stop(sessionId)`        | Stop session and running tasks       |
-| `sessions.delete(sessionId)`      | Delete session and all tasks         |
-| `sessions.getShare(sessionId)`    | Get public share info                |
-| `sessions.createShare(sessionId)` | Create public share link             |
-| `sessions.deleteShare(sessionId)` | Remove public share                  |
-
-### Files
-
-| Method                                  | Description                            |
-|-----------------------------------------|----------------------------------------|
-| `files.sessionUrl(sessionId, body)`    | Presigned URL for session file upload  |
-| `files.browserUrl(sessionId, body)`    | Presigned URL for browser file upload  |
-| `files.taskOutput(taskId, fileId)`     | Download URL for task output file      |
-
-### Profiles
-
-| Method                            | Description                  |
-|-----------------------------------|------------------------------|
-| `profiles.create(body?)`         | Create a browser profile     |
-| `profiles.list(params?)`         | List profiles                |
-| `profiles.get(profileId)`        | Get profile details          |
-| `profiles.update(profileId, body)` | Update a profile           |
-| `profiles.delete(profileId)`     | Delete a profile             |
-
-### Browsers
-
-| Method                        | Description                        |
-|-------------------------------|------------------------------------|
-| `browsers.create(body)`      | Create a browser session           |
-| `browsers.list(params?)`     | List browser sessions              |
-| `browsers.get(sessionId)`    | Get browser session details        |
-| `browsers.stop(sessionId)`   | Stop a browser session             |
-
-### Skills
-
-| Method                                         | Description                          |
-|------------------------------------------------|--------------------------------------|
-| `skills.create(body)`                         | Create a skill via generation        |
-| `skills.list(params?)`                        | List skills                          |
-| `skills.get(skillId)`                         | Get skill details                    |
-| `skills.delete(skillId)`                      | Delete a skill                       |
-| `skills.update(skillId, body)`                | Update skill metadata                |
-| `skills.cancel(skillId)`                      | Cancel in-progress generation        |
-| `skills.execute(skillId, body)`               | Execute a skill                      |
-| `skills.refine(skillId, body)`                | Refine a skill with feedback         |
-| `skills.rollback(skillId)`                    | Rollback to previous version         |
-| `skills.executions(skillId, params?)`         | List skill executions                |
-| `skills.executionOutput(skillId, executionId)` | Download execution output           |
-
-### Marketplace
-
-| Method                              | Description                         |
-|-------------------------------------|-------------------------------------|
-| `marketplace.list(params?)`        | List public marketplace skills      |
-| `marketplace.get(skillSlug)`       | Get marketplace skill by slug       |
-| `marketplace.clone(skillId)`       | Clone a marketplace skill           |
-| `marketplace.execute(skillId, body)` | Execute a marketplace skill       |
-
-## V3 API Reference
-
-### Sessions
-
-| Method                               | Description                          |
-|--------------------------------------|--------------------------------------|
-| `sessions.create(body)`             | Create session and run a task        |
-| `sessions.list(params?)`            | List sessions                        |
-| `sessions.get(sessionId)`           | Get session details                  |
-| `sessions.stop(sessionId)`          | Stop a session                       |
-| `sessions.files(sessionId, params?)` | List files in session workspace     |
-
-## Error Handling
-
-All API errors throw `BrowserUseError`:
-
-```ts
-import { BrowserUse, BrowserUseError } from "browser-use-sdk";
-
-try {
-  await client.tasks.get("nonexistent-id");
-} catch (err) {
-  if (err instanceof BrowserUseError) {
-    console.error(err.statusCode); // 404
-    console.error(err.message);    // "Task not found"
-    console.error(err.detail);     // Raw error body
-  }
-}
-```
-
-The client automatically retries on `429` (rate limit) with exponential backoff.
-
-## TypeScript
-
-Types are re-exported from `browser-use-sdk` and `browser-use-sdk/v3`. The SDK ships with full type definitions for all request/response shapes.
-
-```ts
-import type { TaskView, CreateTaskRequest } from "browser-use-sdk";
-```
+[docs.browser-use.com](https://docs.browser-use.com)
 
 ## License
 

--- a/browser-use-python/README.md
+++ b/browser-use-python/README.md
@@ -1,234 +1,32 @@
 # browser-use-sdk
 
-Official Python SDK for the [Browser Use](https://browser-use.com) cloud API.
+Official Python SDK for [Browser Use Cloud](https://browser-use.com).
 
-Run AI-powered browser agents, manage sessions, profiles, skills, and more --
-all from Python with both sync and async interfaces. Fully typed with Pydantic models.
-
-## Installation
+## Install
 
 ```bash
-pip install browser-use-sdk
-```
-
-Or with your preferred package manager:
-
-```bash
-# uv
 uv add browser-use-sdk
-
-# poetry
-poetry add browser-use-sdk
 ```
 
 ## Quick Start
 
+Get your API key at [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1).
+
+```bash
+export BROWSER_USE_API_KEY=your_key
+```
+
 ```python
 from browser_use_sdk import AsyncBrowserUse
 
 client = AsyncBrowserUse()
-result = await client.run("Go to google.com and search for 'browser use'")
+result = await client.run("Find the top 3 trending repos on GitHub today")
 print(result.output)
-print(result.id, result.status)
 ```
 
-## v2 API (default)
+## Docs
 
-The default import gives you the v2 client with access to all resources:
-
-```python
-from browser_use_sdk import AsyncBrowserUse, BrowserUseError
-
-client = AsyncBrowserUse()
-
-result = await client.run("Navigate to example.com and get the title")
-
-# Or use the tasks resource directly
-task = await client.tasks.create("Navigate to example.com and get the title")
-result = await client.tasks.get(str(task.id))
-await client.tasks.stop(str(task.id))
-
-# Sessions
-session = await client.sessions.create()
-sessions = await client.sessions.list(page_size=20)
-await client.sessions.stop(str(session.id))
-await client.sessions.delete(str(session.id))
-
-# Profiles
-profile = await client.profiles.create(name="my-profile")
-await client.profiles.update(str(profile.id), name="renamed")
-await client.profiles.delete(str(profile.id))
-
-# Browsers
-browser = await client.browsers.create()
-await client.browsers.stop(str(browser.id))
-
-# Billing
-account = await client.billing.account()
-print(account.total_credits_balance_usd)
-
-# Skills
-skills = await client.skills.list()
-await client.skills.execute(skill_id, input="some input")
-
-# Marketplace
-marketplace_skills = await client.marketplace.list()
-
-# Files
-url_info = await client.files.session_url(session_id, file_name="doc.pdf", content_type="application/pdf", size_bytes=1024)
-output = await client.files.task_output(task_id, file_id)
-```
-
-## Structured Output
-
-Pass a Pydantic model to get typed results:
-
-```python
-from pydantic import BaseModel
-from browser_use_sdk import AsyncBrowserUse
-
-class Product(BaseModel):
-    name: str
-    price: float
-
-client = AsyncBrowserUse()
-result = await client.run("Find the price of the MacBook Air", schema=Product)
-print(f"{result.output.name}: ${result.output.price}")
-```
-
-## Streaming
-
-`client.run()` returns a dual-purpose handle: `await` it for the output, or `async for` it for step-by-step progress.
-
-```python
-from browser_use_sdk import AsyncBrowserUse
-
-client = AsyncBrowserUse()
-async for step in client.run("Scrape the front page of HN"):
-    print(f"[{step.number}] {step.next_goal} — {step.url}")
-```
-
-## v3 API
-
-The v3 API uses a simplified session-based model:
-
-```python
-from browser_use_sdk.v3 import AsyncBrowserUse
-
-client = AsyncBrowserUse()
-output = await client.run("Search for Browser Use on Google")
-print(output)
-
-# Or use sessions resource directly
-session = await client.sessions.create("Search for Browser Use on Google")
-result = await client.sessions.get(str(session.id))
-files = await client.sessions.files(str(session.id))
-await client.sessions.stop(str(session.id))
-```
-
-## Sync Usage
-
-A synchronous client is also available:
-
-```python
-from browser_use_sdk import BrowserUse
-
-client = BrowserUse()
-result = client.run("Go to example.com")
-
-# Streaming (sync)
-for step in client.stream("Scrape the front page of HN"):
-    print(f"[{step.number}] {step.next_goal} — {step.url}")
-```
-
-## Error Handling
-
-All non-2xx responses raise `BrowserUseError`:
-
-```python
-from browser_use_sdk import AsyncBrowserUse, BrowserUseError
-
-client = AsyncBrowserUse()
-try:
-    await client.tasks.get("nonexistent-id")
-except BrowserUseError as e:
-    print(e.status_code)  # 404
-    print(e.message)      # "Task not found"
-    print(e.detail)       # Full response body (dict or None)
-```
-
-Retries are automatic: the SDK retries up to 3 times with exponential backoff
-on 429 (rate limit) responses.
-
-## Resource Methods
-
-### v2
-
-| Resource      | Method              | HTTP                                          |
-|---------------|---------------------|-----------------------------------------------|
-| billing       | `account()`         | `GET /billing/account`                        |
-| tasks         | `create(task, **kw)`| `POST /tasks`                                 |
-| tasks         | `list(**kw)`        | `GET /tasks`                                  |
-| tasks         | `get(id)`           | `GET /tasks/{id}`                             |
-| tasks         | `stop(id)`          | `PATCH /tasks/{id}`                           |
-| tasks         | `status(id)`        | `GET /tasks/{id}/status`                      |
-| tasks         | `wait(id, **kw)`    | Poll until terminal, return TaskView          |
-| tasks         | `logs(id)`          | `GET /tasks/{id}/logs`                        |
-| sessions      | `create(**kw)`      | `POST /sessions`                              |
-| sessions      | `list(**kw)`        | `GET /sessions`                               |
-| sessions      | `get(id)`           | `GET /sessions/{id}`                          |
-| sessions      | `stop(id)`          | `PATCH /sessions/{id}`                        |
-| sessions      | `delete(id)`        | `DELETE /sessions/{id}`                       |
-| sessions      | `get_share(id)`     | `GET /sessions/{id}/public-share`             |
-| sessions      | `create_share(id)`  | `POST /sessions/{id}/public-share`            |
-| sessions      | `delete_share(id)`  | `DELETE /sessions/{id}/public-share`          |
-| files         | `session_url(id)`   | `POST /files/sessions/{id}/presigned-url`     |
-| files         | `browser_url(id)`   | `POST /files/browsers/{id}/presigned-url`     |
-| files         | `task_output(t, f)` | `GET /files/tasks/{t}/output-files/{f}`       |
-| profiles      | `create(**kw)`      | `POST /profiles`                              |
-| profiles      | `list(**kw)`        | `GET /profiles`                               |
-| profiles      | `get(id)`           | `GET /profiles/{id}`                          |
-| profiles      | `update(id, **kw)`  | `PATCH /profiles/{id}`                        |
-| profiles      | `delete(id)`        | `DELETE /profiles/{id}`                       |
-| browsers      | `create(**kw)`      | `POST /browsers`                              |
-| browsers      | `list(**kw)`        | `GET /browsers`                               |
-| browsers      | `get(id)`           | `GET /browsers/{id}`                          |
-| browsers      | `stop(id)`          | `PATCH /browsers/{id}`                        |
-| skills        | `create(**kw)`      | `POST /skills`                                |
-| skills        | `list(**kw)`        | `GET /skills`                                 |
-| skills        | `get(id)`           | `GET /skills/{id}`                            |
-| skills        | `update(id, **kw)`  | `PATCH /skills/{id}`                          |
-| skills        | `delete(id)`        | `DELETE /skills/{id}`                         |
-| skills        | `cancel(id)`        | `POST /skills/{id}/cancel`                    |
-| skills        | `execute(id, **kw)` | `POST /skills/{id}/execute`                   |
-| skills        | `refine(id, **kw)`  | `POST /skills/{id}/refine`                    |
-| skills        | `rollback(id)`      | `POST /skills/{id}/rollback`                  |
-| skills        | `executions(id)`    | `GET /skills/{id}/executions`                 |
-| skills        | `execution_output()`| `GET /skills/{id}/executions/{eid}/output`    |
-| marketplace   | `list(**kw)`        | `GET /marketplace/skills`                     |
-| marketplace   | `get(slug)`         | `GET /marketplace/skills/{slug}`              |
-| marketplace   | `clone(id)`         | `POST /marketplace/skills/{id}/clone`         |
-| marketplace   | `execute(id, **kw)` | `POST /marketplace/skills/{id}/execute`       |
-
-### v3
-
-| Resource  | Method            | HTTP                             |
-|-----------|-------------------|----------------------------------|
-| sessions  | `create(task, **kw)` | `POST /sessions`              |
-| sessions  | `list(**kw)`      | `GET /sessions`                  |
-| sessions  | `get(id)`         | `GET /sessions/{id}`             |
-| sessions  | `stop(id)`        | `POST /sessions/{id}/stop`       |
-| sessions  | `files(id, **kw)` | `GET /sessions/{id}/files`       |
-
-## Configuration
-
-```python
-client = BrowserUse(
-    api_key="bu_...",
-    base_url="https://custom-endpoint.example.com/api/v2",  # override base URL
-    timeout=60.0,  # request timeout in seconds (default: 30)
-)
-```
+[docs.browser-use.com](https://docs.browser-use.com)
 
 ## License
 


### PR DESCRIPTION
Stripped all three READMEs down to: install, API key, quick start example, link to docs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the root, Node, and Python READMEs for the `browser-use-sdk` packages to focus on install, API key setup, a short Quick Start, and a single link to the docs. Removed long API references and version notes, and standardized wording to “Browser Use Cloud” for consistency and easier onboarding.

<sup>Written for commit a4af99ea38cb7a91c3c85f655a1ff9721e0f7db2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

