### PR TITLE
Improve llms.txt with grouped sections, links, and install

### DIFF
--- a/docs/cloud/agent/human-in-the-loop.mdx
+++ b/docs/cloud/agent/human-in-the-loop.mdx
@@ -1,6 +1,6 @@
 ---
 title: Human in the loop
-description: "Combine human judgment with agent automation — hand control back and forth in the same session."
+description: "Let a human interact with the live browser while the agent is running. Useful for approvals, payments, complex auth flows, or reviewing agent work before continuing."
 icon: hand
 ---
 

--- a/docs/cloud/tutorials/chat-ui.mdx
+++ b/docs/cloud/tutorials/chat-ui.mdx
@@ -1,6 +1,6 @@
 ---
 title: Chat UI
-description: Build a chat interface for Browser Use with Next.js and the SDK.
+description: "Full end-to-end example. Build a chat UI with live browser preview, authentication, streaming messages, and session management. Best starting point for integrating Browser Use as a main agent or sub-agent into your app."
 icon: messages
 ---
 

--- a/docs/generate-llms-txt.sh
+++ b/docs/generate-llms-txt.sh
@@ -172,7 +172,7 @@ CLOUD_FULL="$SCRIPT_DIR/llms-full.txt"
 
 # Header
 cat > "$CLOUD_INDEX" << 'HEADER'
-# Browser Use Cloud
+# Browser Use Cloud SDK
 
 > Easiest way to automate the web. Tell an agent in natural language what to do.
 
@@ -181,7 +181,6 @@ cat > "$CLOUD_INDEX" << 'HEADER'
 - API key: https://cloud.browser-use.com/settings?tab=api-keys&new=1
 - Open Source: https://github.com/browser-use/browser-use
 - Docs: https://docs.browser-use.com
-- API v3 Reference: https://docs.browser-use.com/cloud/api-reference
 - OpenAPI spec (v3): https://docs.browser-use.com/cloud/openapi/v3.json
 - API v2 Reference: https://docs.browser-use.com/cloud/api-v2-overview
 

--- a/docs/generate-llms-txt.sh
+++ b/docs/generate-llms-txt.sh
@@ -174,7 +174,7 @@ CLOUD_FULL="$SCRIPT_DIR/llms-full.txt"
 cat > "$CLOUD_INDEX" << 'HEADER'
 # Browser Use Cloud SDK
 
-> Easiest way to automate the web. Tell an agent in natural language what to do.
+> The most SOTA browser agent and the most scalable browser infrastructure. Built on the largest AI browser automation open-source library on GitHub with almost 100k stars.
 
 - GitHub: https://github.com/browser-use/browser-use
 - Dashboard: https://cloud.browser-use.com
@@ -182,6 +182,9 @@ cat > "$CLOUD_INDEX" << 'HEADER'
 - Open Source: https://github.com/browser-use/browser-use
 - Docs: https://docs.browser-use.com
 - OpenAPI spec (v3): https://docs.browser-use.com/cloud/openapi/v3.json
+- Stealth benchmark: https://browser-use.com/posts/stealth-benchmark
+- Agent benchmark (online Mind2Web): https://browser-use.com/posts/online-mind2web-benchmark
+- Blog: https://browser-use.com/posts
 - API v2 Reference: https://docs.browser-use.com/cloud/api-v2-overview
 
 Install:

--- a/docs/generate-llms-txt.sh
+++ b/docs/generate-llms-txt.sh
@@ -1,17 +1,125 @@
 #!/usr/bin/env bash
 # Generates llms.txt and llms-full.txt for cloud and open-source docs.
 # Only includes pages listed in docs.json navigation.
+# Groups pages by nav structure with section headers.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BASE_URL="https://docs.browser-use.com"
 
-# Extract all page slugs from docs.json for a given product
-get_nav_pages() {
-  local product="$1"
+# Extract frontmatter fields from an .mdx file
+extract_frontmatter() {
+  local file="$1"
+  local field="$2"
+  local value=""
+  local in_frontmatter=false
+
+  while IFS= read -r line; do
+    if [[ "$line" == "---" ]]; then
+      if $in_frontmatter; then break; else in_frontmatter=true; continue; fi
+    fi
+    if $in_frontmatter; then
+      if [[ "$line" =~ ^${field}:[[:space:]]*[\"\']?(.+)[\"\']?$ ]]; then
+        value="${BASH_REMATCH[1]}"
+        value="${value%\"}"
+        value="${value%\'}"
+        value="${value#\"}"
+        value="${value#\'}"
+      fi
+    fi
+  done < "$file"
+  echo "$value"
+}
+
+# Generate grouped llms.txt index from docs.json nav structure
+generate_index() {
+  local section="$1"
+  local product="$2"
+  local out="$3"
+
   python3 -c "
-import json, sys
+import json
+
+with open('$SCRIPT_DIR/docs.json') as f:
+    d = json.load(f)
+
+BASE_URL = '$BASE_URL'
+SCRIPT_DIR = '$SCRIPT_DIR'
+
+def get_frontmatter(slug):
+    import os
+    filepath = os.path.join(SCRIPT_DIR, slug + '.mdx')
+    if not os.path.exists(filepath):
+        return None, None
+    title = desc = ''
+    in_fm = False
+    with open(filepath) as f:
+        for line in f:
+            line = line.rstrip()
+            if line == '---':
+                if in_fm: break
+                else: in_fm = True; continue
+            if in_fm:
+                if line.startswith('title:'):
+                    title = line.split(':', 1)[1].strip().strip('\"').strip(\"'\")
+                elif line.startswith('description:'):
+                    desc = line.split(':', 1)[1].strip().strip('\"').strip(\"'\")
+    return title, desc
+
+def format_entry(slug):
+    title, desc = get_frontmatter(slug)
+    if not title:
+        return None
+    if desc:
+        return f'- [{title}]({BASE_URL}/{slug}): {desc}'
+    return f'- [{title}]({BASE_URL}/{slug})'
+
+def process_group(group, indent=0):
+    lines = []
+    if isinstance(group, str):
+        entry = format_entry(group)
+        if entry:
+            lines.append(entry)
+    elif isinstance(group, dict):
+        name = group.get('group', '')
+        if name:
+            lines.append(f'')
+            lines.append(f'## {name}')
+        for page in group.get('pages', []):
+            lines.extend(process_group(page, indent+1))
+    return lines
+
+lines = []
+for product_nav in d['navigation']['products']:
+    if product_nav['product'].lower() == '$product'.lower():
+        if 'tabs' in product_nav:
+            for tab in product_nav['tabs']:
+                if isinstance(tab, dict):
+                    for g in tab.get('groups', []):
+                        lines.extend(process_group(g))
+        if 'groups' in product_nav:
+            for g in product_nav['groups']:
+                lines.extend(process_group(g))
+
+for line in lines:
+    print(line)
+" > "$out"
+
+  echo "Generated $out ($(wc -l < "$out") lines)"
+}
+
+# Generate llms-full.txt with all page content
+generate_full() {
+  local section="$1"
+  local product="$2"
+  local out="$3"
+
+  echo "# Browser Use ${product} — Full Documentation" > "$out"
+  echo "" >> "$out"
+
+  python3 -c "
+import json
 
 with open('$SCRIPT_DIR/docs.json') as f:
     d = json.load(f)
@@ -23,8 +131,6 @@ def extract_pages(obj):
     elif isinstance(obj, dict):
         for p in obj.get('pages', []):
             pages.extend(extract_pages(p))
-        if 'openapi' in obj:
-            pass  # skip openapi auto-generated pages
     elif isinstance(obj, list):
         for item in obj:
             pages.extend(extract_pages(item))
@@ -42,86 +148,76 @@ for product_nav in d['navigation']['products']:
             for g in product_nav['groups']:
                 for p in extract_pages(g):
                     print(p)
-"
-}
-
-generate() {
-  local section="$1"
-  local product="$2"
-  local dir="$SCRIPT_DIR/$section"
-  local out_index="$SCRIPT_DIR/llms.txt"
-  local out_full="$SCRIPT_DIR/llms-full.txt"
-
-  # For open-source, output to its own directory
-  if [[ "$section" == "open-source" ]]; then
-    out_index="$dir/llms.txt"
-    out_full="$dir/llms-full.txt"
-  fi
-
-  echo "# ${section} docs" > "$out_index"
-  echo "" >> "$out_index"
-
-  echo "# Browser Use ${product} — Full Documentation" > "$out_full"
-  echo "" >> "$out_full"
-
-  get_nav_pages "$product" | while read -r slug; do
+" | while read -r slug; do
     local file="$SCRIPT_DIR/${slug}.mdx"
     [ -f "$file" ] || continue
 
-    # Extract frontmatter
-    title=""
-    description=""
-    in_frontmatter=false
+    local title
+    title=$(extract_frontmatter "$file" "title")
 
-    while IFS= read -r line; do
-      if [[ "$line" == "---" ]]; then
-        if $in_frontmatter; then
-          break
-        else
-          in_frontmatter=true
-          continue
-        fi
-      fi
-      if $in_frontmatter; then
-        if [[ "$line" =~ ^title:[[:space:]]*[\"\']?(.+)[\"\']?$ ]]; then
-          title="${BASH_REMATCH[1]}"
-          title="${title%\"}"
-          title="${title%\'}"
-          title="${title#\"}"
-          title="${title#\'}"
-        elif [[ "$line" =~ ^description:[[:space:]]*[\"\']?(.+)[\"\']?$ ]]; then
-          description="${BASH_REMATCH[1]}"
-          description="${description%\"}"
-          description="${description%\'}"
-          description="${description#\"}"
-          description="${description#\'}"
-        fi
-      fi
-    done < "$file"
-
-    # llms.txt: index entry
-    if [[ -n "$title" ]]; then
-      if [[ -n "$description" ]]; then
-        echo "- [${title}](${BASE_URL}/${slug}): ${description}" >> "$out_index"
-      else
-        echo "- [${title}](${BASE_URL}/${slug})" >> "$out_index"
-      fi
-    fi
-
-    # llms-full.txt: full page content (strip frontmatter)
-    echo "" >> "$out_full"
-    echo "# ${title:-$slug}" >> "$out_full"
-    echo "Source: ${BASE_URL}/${slug}" >> "$out_full"
-    echo "" >> "$out_full"
-    # Output everything after the closing --- of frontmatter
-    awk 'BEGIN{n=0} /^---$/{n++; if(n==2){found=1; next}} found{print}' "$file" >> "$out_full"
-    echo "" >> "$out_full"
-
+    echo "" >> "$out"
+    echo "# ${title:-$slug}" >> "$out"
+    echo "Source: ${BASE_URL}/${slug}" >> "$out"
+    echo "" >> "$out"
+    awk 'BEGIN{n=0} /^---$/{n++; if(n==2){found=1; next}} found{print}' "$file" >> "$out"
+    echo "" >> "$out"
   done
 
-  echo "Generated $out_index ($(wc -l < "$out_index") lines)"
-  echo "Generated $out_full ($(wc -l < "$out_full") lines)"
+  echo "Generated $out ($(wc -l < "$out") lines)"
 }
 
-generate "cloud" "Cloud"
-generate "open-source" "Open Source"
+# --- Cloud ---
+CLOUD_INDEX="$SCRIPT_DIR/llms.txt"
+CLOUD_FULL="$SCRIPT_DIR/llms-full.txt"
+
+# Header
+cat > "$CLOUD_INDEX" << 'HEADER'
+# Browser Use Cloud
+
+> Easiest way to automate the web. Tell an agent in natural language what to do.
+
+- GitHub: https://github.com/browser-use/browser-use
+- Dashboard: https://cloud.browser-use.com
+- API key: https://cloud.browser-use.com/settings?tab=api-keys&new=1
+- Open Source: https://github.com/browser-use/browser-use
+- Docs: https://docs.browser-use.com
+- API v3 Reference: https://docs.browser-use.com/cloud/api-reference
+- API v2 Reference: https://docs.browser-use.com/cloud/api-v2-overview
+
+Install:
+- Python: `pip install browser-use-sdk`
+- TypeScript: `npm install browser-use-sdk`
+
+HEADER
+
+# Append grouped nav entries
+generate_index "cloud" "Cloud" "/tmp/cloud_index_body.txt"
+cat /tmp/cloud_index_body.txt >> "$CLOUD_INDEX"
+echo "" >> "$CLOUD_INDEX"
+echo "Generated $CLOUD_INDEX ($(wc -l < "$CLOUD_INDEX") lines)"
+
+# Full content
+generate_full "cloud" "Cloud" "$CLOUD_FULL"
+
+# --- Open Source ---
+OS_INDEX="$SCRIPT_DIR/open-source/llms.txt"
+OS_FULL="$SCRIPT_DIR/open-source/llms-full.txt"
+
+cat > "$OS_INDEX" << 'HEADER'
+# Browser Use Open Source
+
+> Self-hosted Python library for AI browser automation.
+
+- GitHub: https://github.com/browser-use/browser-use
+- Docs: https://docs.browser-use.com/open-source/introduction
+
+Install: `pip install browser-use`
+
+HEADER
+
+generate_index "open-source" "Open Source" "/tmp/os_index_body.txt"
+cat /tmp/os_index_body.txt >> "$OS_INDEX"
+echo "" >> "$OS_INDEX"
+echo "Generated $OS_INDEX ($(wc -l < "$OS_INDEX") lines)"
+
+generate_full "open-source" "Open Source" "$OS_FULL"

--- a/docs/generate-llms-txt.sh
+++ b/docs/generate-llms-txt.sh
@@ -182,6 +182,7 @@ cat > "$CLOUD_INDEX" << 'HEADER'
 - Open Source: https://github.com/browser-use/browser-use
 - Docs: https://docs.browser-use.com
 - API v3 Reference: https://docs.browser-use.com/cloud/api-reference
+- OpenAPI spec (v3): https://docs.browser-use.com/cloud/openapi/v3.json
 - API v2 Reference: https://docs.browser-use.com/cloud/api-v2-overview
 
 Install:

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # Browser Use Cloud SDK
 
-> Easiest way to automate the web. Tell an agent in natural language what to do.
+> The most SOTA browser agent and the most scalable browser infrastructure. Built on the largest AI browser automation open-source library on GitHub with almost 100k stars.
 
 - GitHub: https://github.com/browser-use/browser-use
 - Dashboard: https://cloud.browser-use.com
@@ -8,6 +8,9 @@
 - Open Source: https://github.com/browser-use/browser-use
 - Docs: https://docs.browser-use.com
 - OpenAPI spec (v3): https://docs.browser-use.com/cloud/openapi/v3.json
+- Stealth benchmark: https://browser-use.com/posts/stealth-benchmark
+- Agent benchmark (online Mind2Web): https://browser-use.com/posts/online-mind2web-benchmark
+- Blog: https://browser-use.com/posts
 
 Install:
 - Python: `pip install browser-use-sdk`

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,4 +1,4 @@
-# Browser Use Cloud
+# Browser Use Cloud SDK
 
 > Easiest way to automate the web. Tell an agent in natural language what to do.
 
@@ -7,7 +7,6 @@
 - API key: https://cloud.browser-use.com/settings?tab=api-keys&new=1
 - Open Source: https://github.com/browser-use/browser-use
 - Docs: https://docs.browser-use.com
-- API v3 Reference: https://docs.browser-use.com/cloud/api-reference
 - OpenAPI spec (v3): https://docs.browser-use.com/cloud/openapi/v3.json
 
 Install:
@@ -48,7 +47,7 @@ Install:
 - [n8n](https://docs.browser-use.com/cloud/tutorials/integrations/n8n): Use Browser Use as an HTTP node in n8n workflows.
 
 ## Tutorials
-- [Chat UI](https://docs.browser-use.com/cloud/tutorials/chat-ui): Build a chat interface for Browser Use with Next.js and the SDK.
+- [Chat UI](https://docs.browser-use.com/cloud/tutorials/chat-ui): Full end-to-end example. Build a chat UI with live browser preview, authentication, streaming messages, and session management. Best starting point for integrating Browser Use as a main agent or sub-agent into your app.
 - [FAQ](https://docs.browser-use.com/cloud/faq): Fix common issues — slow tasks, failed agents, login problems, blocked sites, and unexpected costs.
 
 ## Legacy (v2)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -8,6 +8,7 @@
 - Open Source: https://github.com/browser-use/browser-use
 - Docs: https://docs.browser-use.com
 - API v3 Reference: https://docs.browser-use.com/cloud/api-reference
+- OpenAPI spec (v3): https://docs.browser-use.com/cloud/openapi/v3.json
 
 Install:
 - Python: `pip install browser-use-sdk`

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,28 +1,56 @@
-# cloud docs
+# Browser Use Cloud
 
+> Easiest way to automate the web. Tell an agent in natural language what to do.
+
+- GitHub: https://github.com/browser-use/browser-use
+- Dashboard: https://cloud.browser-use.com
+- API key: https://cloud.browser-use.com/settings?tab=api-keys&new=1
+- Open Source: https://github.com/browser-use/browser-use
+- Docs: https://docs.browser-use.com
+- API v3 Reference: https://docs.browser-use.com/cloud/api-reference
+
+Install:
+- Python: `pip install browser-use-sdk`
+- TypeScript: `npm install browser-use-sdk`
+
+
+## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): Install the SDK, set your API key, and run your first AI browser automation task.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
+
+
+## Agent
 - [Introduction](https://docs.browser-use.com/cloud/agent/quickstart): Easiest way to automate the web. Tell this agent in natural language what it should do, and it can interact with the web like a human.
 - [Structured output](https://docs.browser-use.com/cloud/agent/structured-output): Get validated, typed data back from agent tasks.
 - [Follow-up tasks](https://docs.browser-use.com/cloud/agent/follow-up-tasks): Run multiple tasks in the same browser session.
 - [Live messages](https://docs.browser-use.com/cloud/agent/streaming): Poll the agent's message history in real time to build custom UIs or monitor progress.
 - [Workspaces & files](https://docs.browser-use.com/cloud/agent/workspaces): Persistent file storage across sessions. Upload input files, download results, and share data across tasks.
 - [Human in the loop](https://docs.browser-use.com/cloud/agent/human-in-the-loop): Combine human judgment with agent automation — hand control back and forth in the same session.
+
+## Browser
 - [Introduction Stealth](https://docs.browser-use.com/cloud/browser/stealth): Best stealth on the planet. We fork Chromium to give agents access to all websites.
 - [Proxies](https://docs.browser-use.com/cloud/browser/proxies): Residential proxies in 195+ countries. On by default.
 - [Live preview & recording](https://docs.browser-use.com/cloud/browser/live-preview): Watch the agent's browser in real time. Embed it in your app.
+
+## Authentication
 - [Profiles](https://docs.browser-use.com/cloud/guides/authentication): Persistent browser state — cookies, localStorage, saved passwords. Login once, reuse across sessions.
 - [Sync local and cloud cookies](https://docs.browser-use.com/cloud/guides/profile-sync): Sync your local browser cookies to the cloud — instantly authenticate without managing credentials.
 - [Secrets](https://docs.browser-use.com/cloud/guides/secrets): Pass domain-scoped credentials to the agent securely.
 - [1Password & 2FA](https://docs.browser-use.com/cloud/guides/1password): Auto-fill passwords and TOTP codes from 1Password during agent tasks.
 - [Playwright, Puppeteer, Selenium](https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium): Connect your automation framework to Browser Use's stealth infrastructure via CDP.
+
+
+## Integrations
 - [OpenClaw](https://docs.browser-use.com/cloud/tutorials/integrations/openclaw): Give OpenClaw agents browser automation with Browser Use — via CDP or the CLI skill.
 - [MCP Server](https://docs.browser-use.com/cloud/guides/mcp-server): Run browser automation tasks from your AI coding assistant. Connect to Claude, Cursor, Windsurf, or any MCP client.
 - [Webhooks](https://docs.browser-use.com/cloud/guides/webhooks): Receive real-time notifications when tasks complete. Configure webhook endpoints for async task monitoring.
 - [n8n](https://docs.browser-use.com/cloud/tutorials/integrations/n8n): Use Browser Use as an HTTP node in n8n workflows.
+
+## Tutorials
 - [Chat UI](https://docs.browser-use.com/cloud/tutorials/chat-ui): Build a chat interface for Browser Use with Next.js and the SDK.
 - [FAQ](https://docs.browser-use.com/cloud/faq): Fix common issues — slow tasks, failed agents, login problems, blocked sites, and unexpected costs.
+
+## Legacy (v2)
 - [Agent (v2)](https://docs.browser-use.com/cloud/legacy/agent): V2 agent models and file handling.
 - [Skills](https://docs.browser-use.com/cloud/legacy/skills): Turn any website into a deterministic API endpoint. Create once, call repeatedly.
-- [API key](https://docs.browser-use.com/cloud/api-reference): Set your API key to access the Browser Use REST API.
-- [API key](https://docs.browser-use.com/cloud/api-v2-overview): Set your API key to access the Browser Use v2 REST API.
+

--- a/docs/open-source/llms.txt
+++ b/docs/open-source/llms.txt
@@ -1,31 +1,60 @@
-# open-source docs
+# Browser Use Open Source
 
+> Self-hosted Python library for AI browser automation.
+
+- GitHub: https://github.com/browser-use/browser-use
+- Docs: https://docs.browser-use.com/open-source/introduction
+
+Install: `pip install browser-use`
+
+
+## Get Started
 - [Browser Use Open Source](https://docs.browser-use.com/open-source/introduction): Python library for AI browser automation with 79k+ GitHub stars. Connect any LLM and run locally or self-hosted.
 - [Human Quickstart](https://docs.browser-use.com/open-source/quickstart): Install and run your first AI browser agent in minutes. Python setup with pip, environment variables, and a working example.
 - [Prompts for Vibecoders](https://docs.browser-use.com/open-source/vibecoding): Complete Python SDK reference for AI coding agents. Paste into Claude Code, Cursor, or Copilot for instant integration.
 - [Supported Models](https://docs.browser-use.com/open-source/supported-models): Choose between Claude, Gemini, Llama, DeepSeek, and more. Configuration examples for each provider.
 - [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli): Fast, persistent browser automation from the command line.
+
+## Customize
+
+## Agent
 - [Configuration](https://docs.browser-use.com/open-source/customize/agent/basics): Configure the agent — set your LLM, define tasks, add custom tools, and control behavior with Python.
 - [Prompting Guide](https://docs.browser-use.com/open-source/customize/agent/prompting-guide): Write effective prompts for the agent. Tips for task descriptions, multi-step workflows, and getting reliable structured output.
 - [Output Format](https://docs.browser-use.com/open-source/customize/agent/output-format): Control agent output — structured results, step history, action logs, and extracted content from browser automation tasks.
 - [All Parameters](https://docs.browser-use.com/open-source/customize/agent/all-parameters): Complete reference for all agent configuration options — LLM settings, prompts, tools, output format, and callbacks.
+
+## Browser
 - [Configuration](https://docs.browser-use.com/open-source/customize/browser/basics): Configure the browser instance — headless mode, viewport size, proxy settings, and Playwright launch options.
 - [Authentication](https://docs.browser-use.com/open-source/customize/browser/authentication): Log into websites using real browser profiles, saved storage state, and 2FA codes for authenticated automation.
 - [Real Browser](https://docs.browser-use.com/open-source/customize/browser/real-browser): Connect to your existing Chrome browser to preserve login sessions, cookies, and extensions for authenticated tasks.
 - [Remote Browser](https://docs.browser-use.com/open-source/customize/browser/remote): Connect to remote browsers via CDP — use with the Cloud, Browserbase, or any remote Chrome instance.
 - [All Parameters](https://docs.browser-use.com/open-source/customize/browser/all-parameters): Complete reference for all browser configuration options — launch args, proxy, viewport, user data, and CDP settings.
+
+## Tools
 - [Overview](https://docs.browser-use.com/open-source/customize/tools/basics): Learn about built-in browser actions and custom tools.
 - [Available Tools](https://docs.browser-use.com/open-source/customize/tools/available): Built-in tools — click, type, scroll, extract, navigate, and more. Full list of default agent actions.
 - [Add Tools](https://docs.browser-use.com/open-source/customize/tools/add): Extend agents with custom Python functions. Add API calls, file operations, or any custom logic as agent tools.
 - [Remove Tools](https://docs.browser-use.com/open-source/customize/tools/remove): Exclude default tools to restrict agent capabilities.
 - [Response Format](https://docs.browser-use.com/open-source/customize/tools/response): Customize how tools return data to the agent. Control response formatting, extraction, and content filtering.
+
+## Integration
 - [MCP Server](https://docs.browser-use.com/open-source/customize/integrations/mcp-server): Run browser-use as a local Model Context Protocol server. Connect AI models to browser automation through the MCP standard.
+
+## Legacy
+
+## Actor
 - [Basics](https://docs.browser-use.com/open-source/legacy/actor/basics): Low-level Playwright-like browser automation with direct and full CDP control and precise element interactions
 - [Examples](https://docs.browser-use.com/open-source/legacy/actor/examples): Comprehensive examples for Browser Actor automation tasks including forms, JavaScript, mouse operations, and AI features
 - [All Parameters](https://docs.browser-use.com/open-source/legacy/actor/all-parameters): Complete API reference for Browser Actor classes, methods, and parameters including BrowserSession, Page, Element, and Mouse
+
+## Sandbox
 - [Quickstart](https://docs.browser-use.com/open-source/legacy/sandbox/quickstart): Run browser automation in the cloud
 - [Events](https://docs.browser-use.com/open-source/legacy/sandbox/events): Monitor execution with callbacks
 - [All Parameters](https://docs.browser-use.com/open-source/legacy/sandbox/all-parameters): Sandbox configuration reference
+
+## Examples
+
+## Templates
 - [Fast Agent](https://docs.browser-use.com/open-source/examples/templates/fast-agent): Optimize agent performance for maximum speed and efficiency.
 - [Follow up tasks](https://docs.browser-use.com/open-source/examples/templates/follow-up-tasks): Follow up tasks with the same browser session.
 - [Parallel Agents](https://docs.browser-use.com/open-source/examples/templates/parallel-browser): Run multiple agents in parallel with separate browser instances
@@ -33,15 +62,26 @@
 - [Sensitive Data](https://docs.browser-use.com/open-source/examples/templates/sensitive-data): Handle secret information securely and avoid sending PII & passwords to the LLM.
 - [Secure Setup](https://docs.browser-use.com/open-source/examples/templates/secure): Azure OpenAI with data privacy and security configuration.
 - [More Examples](https://docs.browser-use.com/open-source/examples/templates/more-examples): Explore additional examples and use cases on GitHub.
+
+## Apps
 - [Ad-Use (Ad Generator)](https://docs.browser-use.com/open-source/examples/apps/ad-use): Generate Instagram image ads and TikTok video ads from landing pages using browser agents, Google's Nano Banana 🍌, and Veo3.
 - [Vibetest-Use (Automated QA)](https://docs.browser-use.com/open-source/examples/apps/vibetest-use): Run multi-agent Browser-Use tests to catch UI bugs, broken links, and accessibility issues before they ship.
 - [News-Use (News Monitor)](https://docs.browser-use.com/open-source/examples/apps/news-use): Monitor news websites and extract articles with sentiment analysis using browser agents and Google Gemini.
 - [Msg-Use (WhatsApp Sender)](https://docs.browser-use.com/open-source/examples/apps/msg-use): AI-powered WhatsApp message scheduler using browser agents and Gemini. Schedule personalized messages in natural language.
+
+## Development
+
+## Contribution
 - [Local Development Setup](https://docs.browser-use.com/open-source/development/setup/local-setup): Set up for local development. Clone the repo, install dependencies, and run tests to start contributing.
 - [Contribution Guide](https://docs.browser-use.com/open-source/development/setup/contribution-guide): How to contribute — code standards, PR process, testing requirements, and submitting your first pull request.
+
+## Advanced
 - [Lifecycle Hooks](https://docs.browser-use.com/open-source/customize/hooks): Hook into agent lifecycle events — before/after actions, navigation, extraction, and error handling callbacks.
+
+## Monitoring
 - [Observability](https://docs.browser-use.com/open-source/development/monitoring/observability): Trace agent execution steps and capture browser session recordings.
 - [OpenLIT](https://docs.browser-use.com/open-source/development/monitoring/openlit): Complete observability with OpenLIT tracing.
 - [Telemetry](https://docs.browser-use.com/open-source/development/monitoring/telemetry): Understanding Browser Use's telemetry
 - [Costs](https://docs.browser-use.com/open-source/development/monitoring/costs): Track token usage and API costs for your browser automation tasks
 - [Get Help](https://docs.browser-use.com/open-source/development/get-help): Get help — join 20k+ developers on Discord, search GitHub issues, or ask the community.
+


### PR DESCRIPTION
- Header: GitHub, Dashboard, API key, Docs, API v3/v2 reference links + install commands
- Grouped sections matching docs nav: Agent, Browser, Authentication, Integrations, Tutorials, Legacy (v2)
- Script updated to generate grouped index from docs.json structure
- No more flat list of all pages

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt llms.txt for Cloud and Open Source with grouped sections, clear headers, and install commands. Added SOTA positioning with benchmark and blog links, the OpenAPI v3 spec link, and refreshed Chat UI and Human‑in‑the‑loop descriptions.

- **New Features**
  - Grouped index per product from docs.json (Get Started, Agent, Browser, Authentication, Integrations, Tutorials, Legacy) with section headers and install for `browser-use-sdk` (Python/TypeScript) and `browser-use`.
  - Cloud header adds GitHub, Dashboard, API key, Docs/Open Source links, OpenAPI v3, SOTA positioning, Stealth and online Mind2Web benchmarks, and Blog.
  - Removed the API v2 reference; updated frontmatter descriptions for Chat UI and Human‑in‑the‑loop.

- **Refactors**
  - Rewrote `docs/generate-llms-txt.sh` to parse MDX frontmatter, build grouped indexes, and generate separate Cloud/Open Source `llms.txt` and `llms-full.txt` (titles, source links, body).
  - Removed the old flat-list generator.

<sup>Written for commit 821eaa343f6f016cce6f7d6ab0da130867c841f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

