### PR TITLE
Update MCP server to v3 only

### DIFF
--- a/docs/cloud/guides/mcp-server.mdx
+++ b/docs/cloud/guides/mcp-server.mdx
@@ -3,56 +3,22 @@ title: MCP Server
 description: "Run browser automation tasks from your AI coding assistant. Connect to Claude, Cursor, Windsurf, or any MCP client."
 ---
 
-Browser Use provides two [Model Context Protocol](https://modelcontextprotocol.io) server endpoints:
+```
+https://api.browser-use.com/v3/mcp
+```
 
-| Endpoint | URL |
-|----------|-----|
-| **v2** | `https://api.browser-use.com/mcp` |
-| **v3** | `https://api.browser-use.com/v3/mcp` |
-
-The **v2** endpoint uses a task-based agent — each task runs independently and is dispatched to a queue. The **v3** endpoint uses a session-based agent that runs in a persistent sandbox container, supporting keep-alive for multi-turn interactions, model selection (`bu-mini`, `bu-max`, `bu-ultra`), structured output, and shared workspaces for file persistence across sessions.
-
-Get your API key from the [Browser Use Dashboard](https://cloud.browser-use.com/settings?tab=api-keys&new=1).
+Get your API key at [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1).
 
 ## Claude Code
 
-<Tabs>
-<Tab title="v2">
-```bash
-claude mcp add -t http -H "x-browser-use-api-key: YOUR_API_KEY" browser-use https://api.browser-use.com/mcp
-```
-</Tab>
-<Tab title="v3">
 ```bash
 claude mcp add -t http -H "x-browser-use-api-key: YOUR_API_KEY" browser-use https://api.browser-use.com/v3/mcp
 ```
-</Tab>
-</Tabs>
-
-<Note>
-Replace `YOUR_API_KEY` with your actual API key. Claude Code requires the API key to be passed via the `-H` (header) flag.
-</Note>
 
 ## Claude Desktop
 
 Add to `claude_desktop_config.json`:
 
-<Tabs>
-<Tab title="v2">
-```json
-{
-  "mcpServers": {
-    "browser-use": {
-      "url": "https://api.browser-use.com/mcp",
-      "headers": {
-        "x-browser-use-api-key": "YOUR_API_KEY"
-      }
-    }
-  }
-}
-```
-</Tab>
-<Tab title="v3">
 ```json
 {
   "mcpServers": {
@@ -65,29 +31,11 @@ Add to `claude_desktop_config.json`:
   }
 }
 ```
-</Tab>
-</Tabs>
 
 ## Cursor
 
 Add to `.cursor/mcp.json`:
 
-<Tabs>
-<Tab title="v2">
-```json
-{
-  "mcpServers": {
-    "browser-use": {
-      "url": "https://api.browser-use.com/mcp",
-      "headers": {
-        "x-browser-use-api-key": "YOUR_API_KEY"
-      }
-    }
-  }
-}
-```
-</Tab>
-<Tab title="v3">
 ```json
 {
   "mcpServers": {
@@ -100,29 +48,11 @@ Add to `.cursor/mcp.json`:
   }
 }
 ```
-</Tab>
-</Tabs>
 
 ## Windsurf
 
 Add to `~/.codeium/windsurf/mcp_config.json`:
 
-<Tabs>
-<Tab title="v2">
-```json
-{
-  "mcpServers": {
-    "browser-use": {
-      "serverUrl": "https://api.browser-use.com/mcp",
-      "headers": {
-        "x-browser-use-api-key": "YOUR_API_KEY"
-      }
-    }
-  }
-}
-```
-</Tab>
-<Tab title="v3">
 ```json
 {
   "mcpServers": {
@@ -135,31 +65,15 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
   }
 }
 ```
-</Tab>
-</Tabs>
 
 ## Available Tools
 
-<Tabs>
-<Tab title="v2">
-| Tool | Description | Cost |
-|------|-------------|------|
-| `browser_task` | Run a full automation task | $0.01 init + per-step (default $0.006/step). See [Pricing](/cloud/pricing). |
-| `execute_skill` | Run a skill | $0.02/call |
-| `list_skills` | List available skills | Free |
-| `get_cookies` | Extract cookies for auth | Free |
-| `list_browser_profiles` | List profiles | Free |
-| `monitor_task` | Check task progress | Free |
-</Tab>
-<Tab title="v3">
 | Tool | Description |
 |------|-------------|
-| `run_session` | Create a new browser session and run a task. Supports `keep_alive` to reuse the session, `model` selection (`bu-mini`, `bu-max`, `bu-ultra`), `output_schema` for structured output, and `profile_id` for authenticated browsing. |
-| `get_session` | Poll a session for status and output. Returns status (`running`, `idle`, `stopped`, `error`), step count, cost breakdown, and a live URL to watch the browser. |
-| `send_task` | Send a follow-up task to an idle keep-alive session. Enables multi-turn interactions that reuse the same browser context. |
-| `stop_session` | Stop a running session. Use `strategy: "task"` to stop only the current task (session stays idle), or `"session"` to destroy the sandbox. |
-| `get_session_messages` | Get the agent's step-by-step messages for a session, including browser actions, reasoning, and results. |
-| `list_sessions` | List recent sessions with status and cost info. |
-| `list_browser_profiles` | List cloud browser profiles for authenticated tasks. |
-</Tab>
-</Tabs>
+| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`bu-mini`, `bu-max`), `output_schema`, and `profile_id`. |
+| `get_session` | Poll session status and output. Returns status, step count, cost breakdown, and live URL. |
+| `send_task` | Send a follow-up task to an idle keep-alive session. |
+| `stop_session` | Stop a session. `strategy: "task"` stops only the task, `"session"` destroys the sandbox. |
+| `get_session_messages` | Get the agent's messages — browser actions, reasoning, and results. |
+| `list_sessions` | List recent sessions with status and cost. |
+| `list_browser_profiles` | List browser profiles for authenticated tasks. |


### PR DESCRIPTION
Removed all v2 tabs and references. Single v3 endpoint, clean examples for Claude Code, Claude Desktop, Cursor, Windsurf. 166→72 lines.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move MCP server docs to v3 only. Removed all v2 references and tabs, added a single v3 endpoint, and simplified client examples.

- **Refactors**
  - Single endpoint: `https://api.browser-use.com/v3/mcp`
  - Simplified setup for Claude Code, Claude Desktop, Cursor, and Windsurf (no tabs)
  - Updated API key link to `cloud.browser-use.com/settings`
  - Tools section shows only v3 methods; model options now `bu-mini`, `bu-max`

<sup>Written for commit b01bcdd05003639d82d620f0450b88939333459a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

