### PR TITLE
Add Chat UI link + SDK upgrade instructions to llms.txt

### DIFF
--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -8,14 +8,14 @@
 - Open Source: https://github.com/browser-use/browser-use
 - Docs: https://docs.browser-use.com
 - OpenAPI spec (v3): https://docs.browser-use.com/cloud/openapi/v3.json
+- Chat UI example: https://docs.browser-use.com/cloud/tutorials/chat-ui — Full end-to-end example with live browser, streaming, auth. Best starting point to build a prototype.
 - Stealth benchmark: https://browser-use.com/posts/stealth-benchmark
 - Agent benchmark (online Mind2Web): https://browser-use.com/posts/online-mind2web-benchmark
 - Blog: https://browser-use.com/posts
-- API v2 Reference: https://docs.browser-use.com/cloud/api-v2-overview
 
-Install:
-- Python: `pip install browser-use-sdk`
-- TypeScript: `npm install browser-use-sdk`
+Install (check if already installed and update to latest):
+- Python: `pip install --upgrade browser-use-sdk`
+- TypeScript: `npm install browser-use-sdk@latest`
 
 
 ## Get Started

--- a/docs/generate-llms-txt.sh
+++ b/docs/generate-llms-txt.sh
@@ -182,14 +182,14 @@ cat > "$CLOUD_INDEX" << 'HEADER'
 - Open Source: https://github.com/browser-use/browser-use
 - Docs: https://docs.browser-use.com
 - OpenAPI spec (v3): https://docs.browser-use.com/cloud/openapi/v3.json
+- Chat UI example: https://docs.browser-use.com/cloud/tutorials/chat-ui — Full end-to-end example with live browser, streaming, auth. Best starting point to build a prototype.
 - Stealth benchmark: https://browser-use.com/posts/stealth-benchmark
 - Agent benchmark (online Mind2Web): https://browser-use.com/posts/online-mind2web-benchmark
 - Blog: https://browser-use.com/posts
-- API v2 Reference: https://docs.browser-use.com/cloud/api-v2-overview
 
-Install:
-- Python: `pip install browser-use-sdk`
-- TypeScript: `npm install browser-use-sdk`
+Install (check if already installed and update to latest):
+- Python: `pip install --upgrade browser-use-sdk`
+- TypeScript: `npm install browser-use-sdk@latest`
 
 HEADER
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -8,14 +8,14 @@
 - Open Source: https://github.com/browser-use/browser-use
 - Docs: https://docs.browser-use.com
 - OpenAPI spec (v3): https://docs.browser-use.com/cloud/openapi/v3.json
+- Chat UI example: https://docs.browser-use.com/cloud/tutorials/chat-ui — Full end-to-end example with live browser, streaming, auth. Best starting point to build a prototype.
 - Stealth benchmark: https://browser-use.com/posts/stealth-benchmark
 - Agent benchmark (online Mind2Web): https://browser-use.com/posts/online-mind2web-benchmark
 - Blog: https://browser-use.com/posts
-- API v2 Reference: https://docs.browser-use.com/cloud/api-v2-overview
 
-Install:
-- Python: `pip install browser-use-sdk`
-- TypeScript: `npm install browser-use-sdk`
+Install (check if already installed and update to latest):
+- Python: `pip install --upgrade browser-use-sdk`
+- TypeScript: `npm install browser-use-sdk@latest`
 
 
 ## Get Started


### PR DESCRIPTION
- Chat UI example link in header — "Best starting point to build a prototype"
- Install commands now use `--upgrade` / `@latest` so agents check for latest version
- Removed stale API v2 Reference link from header

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Chat UI example link and switch install commands in `llms.txt` to `--upgrade`/`@latest` so users can start prototypes quickly and always get the latest `browser-use-sdk`. Removed the stale API v2 link and updated `docs/generate-llms-txt.sh` to keep cloud and root docs in sync.

<sup>Written for commit 875dffe9b3ebd059276e1441be414f82772bb577. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

