### PR TITLE
Link streaming page to List session messages API reference

### DIFF
--- a/docs/cloud/agent/streaming.mdx
+++ b/docs/cloud/agent/streaming.mdx
@@ -61,4 +61,4 @@ while (true) {
 ```
 </CodeGroup>
 
-Each message has a `role` (`user`, `assistant`, `tool`), a `summary` for display, and a `type` (e.g. `browser_action`, `browser_action_result`). Browser action results include a `screenshot_url`. See the [API v3 Reference](/cloud/api-reference) for all fields.
+Each message has a `role` (`user`, `assistant`, `tool`), a `summary` for display, and a `type` (e.g. `browser_action`, `browser_action_result`). Browser action results include a `screenshot_url`. See [List session messages](/cloud/api-v3/get-apiv3sessionssession-idmessages) for all fields.

--- a/docs/cloud/agent/streaming.mdx
+++ b/docs/cloud/agent/streaming.mdx
@@ -61,4 +61,4 @@ while (true) {
 ```
 </CodeGroup>
 
-Each message has a `role` (`user`, `assistant`, `tool`), a `summary` for display, and a `type` (e.g. `browser_action`, `browser_action_result`). Browser action results include a `screenshot_url`. See [List session messages](/cloud/api-v3/get-apiv3sessionssession-idmessages) for all fields.
+Each message has a `role` (`user`, `assistant`, `tool`), a `summary` for display, and a `type` (e.g. `browser_action`, `browser_action_result`). Browser action results include a `screenshot_url`. See [List session messages](/cloud/api-v3/sessions/list-session-messages) for all fields.


### PR DESCRIPTION
Links to the specific `GET /sessions/{id}/messages` endpoint instead of generic API reference.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Streaming docs to link directly to the “List session messages” endpoint (`GET /sessions/{id}/messages`) and fixed the path to the correct page. This makes it faster to find the full message schema and fields.

<sup>Written for commit 90cbaf111bf21b67fd7c092f75d21fd98ff1896a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

