### PR TITLE
Add sessions.wait_for_recording() helper

### DIFF
--- a/browser-use-node/src/generated/v2/types.ts
+++ b/browser-use-node/src/generated/v2/types.ts
@@ -2467,10 +2467,11 @@ export interface components {
          *             CREATED: Task has been created but not yet started.
          *         STARTED: Task has been started and is currently running.
          *         FINISHED: Task has finished and the agent has completed the task.
+         *         FAILED: Task execution failed due to an error.
          *         STOPPED: Task execution has been manually stopped (cannot be resumed).
          * @enum {string}
          */
-        TaskStatus: "created" | "started" | "finished" | "stopped";
+        TaskStatus: "created" | "started" | "finished" | "failed" | "stopped";
         /**
          * TaskStatusView
          * @description Lightweight view optimized for polling. Use GET /tasks/{id}/status for efficient polling

--- a/browser-use-node/src/generated/v3/types.ts
+++ b/browser-use-node/src/generated/v3/types.ts
@@ -150,6 +150,70 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/profiles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Profiles
+         * @description Get paginated list of profiles.
+         *
+         *     Use the `query` parameter to search profiles by name or user_id.
+         *     This is useful when you have many profiles and need to find a specific user.
+         *
+         *     Example: If you set `user_id` to your internal user identifier when creating profiles,
+         *     you can later search for that user by passing their identifier as the `query` parameter.
+         */
+        get: operations["list_profiles_profiles_get"];
+        put?: never;
+        /**
+         * Create Profile
+         * @description Profiles allow you to preserve the state of the browser between tasks.
+         *
+         *     They are most commonly used to allow users to preserve the log-in state in the agent between tasks.
+         *     You'd normally create one profile per user and then use it for all their tasks.
+         *
+         *     You can set a `user_id` when creating a profile to associate it with a user in your system.
+         *     This allows you to later search for the profile using the GET /profiles endpoint with a query parameter.
+         */
+        post: operations["create_profile_profiles_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/profiles/{profile_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Profile
+         * @description Get profile details.
+         */
+        get: operations["get_profile_profiles__profile_id__get"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete Browser Profile
+         * @description Permanently delete a browser profile and its configuration.
+         */
+        delete: operations["delete_browser_profile_profiles__profile_id__delete"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Profile
+         * @description Update a browser profile's information.
+         */
+        patch: operations["update_profile_profiles__profile_id__patch"];
+        trace?: never;
+    };
     "/workspaces": {
         parameters: {
             query?: never;
@@ -279,7 +343,7 @@ export interface components {
          * BuModel
          * @enum {string}
          */
-        BuModel: "bu-mini" | "bu-max";
+        BuModel: "bu-mini" | "bu-max" | "bu-ultra";
         /**
          * FileInfo
          * @description A file in a session's workspace.
@@ -375,6 +439,17 @@ export interface components {
             /** Detail */
             detail?: components["schemas"]["ValidationError"][];
         };
+        /**
+         * InsufficientCreditsError
+         * @description Error response when there are insufficient credits
+         */
+        InsufficientCreditsError: {
+            /**
+             * Detail
+             * @default Insufficient credits
+             */
+            detail: string;
+        };
         /** MessageListResponse */
         MessageListResponse: {
             /** Messages */
@@ -415,6 +490,122 @@ export interface components {
              * Format: date-time
              */
             createdAt: string;
+        };
+        /**
+         * ProfileCreateRequest
+         * @description Request model for creating a new profile.
+         */
+        ProfileCreateRequest: {
+            /**
+             * Name
+             * @description Optional name for the profile
+             */
+            name?: string | null;
+            /**
+             * User ID
+             * @description Your internal user identifier for this profile. Use this to associate a profile with a user in your system.
+             */
+            userId?: string | null;
+        };
+        /**
+         * ProfileListResponse
+         * @description Response model for paginated profile list requests.
+         */
+        ProfileListResponse: {
+            /**
+             * Items
+             * @description List of profile views for the current page
+             */
+            items: components["schemas"]["ProfileView"][];
+            /**
+             * Total Items
+             * @description Total number of items in the list
+             */
+            totalItems: number;
+            /**
+             * Page Number
+             * @description Page number
+             */
+            pageNumber: number;
+            /**
+             * Page Size
+             * @description Number of items per page
+             */
+            pageSize: number;
+        };
+        /**
+         * ProfileNotFoundError
+         * @description Error response when a profile is not found
+         */
+        ProfileNotFoundError: {
+            /**
+             * Detail
+             * @default Profile not found
+             */
+            detail: string;
+        };
+        /**
+         * ProfileUpdateRequest
+         * @description Request model for updating a profile.
+         */
+        ProfileUpdateRequest: {
+            /**
+             * Name
+             * @description Optional name for the profile
+             */
+            name?: string | null;
+            /**
+             * User ID
+             * @description Your internal user identifier for this profile. Use this to associate a profile with a user in your system.
+             */
+            userId?: string | null;
+        };
+        /**
+         * ProfileView
+         * @description View model for representing a profile. A profile lets you preserve the login state between sessions.
+         *
+         *     We recommend that you create a separate profile for each user of your app.
+         *     You can assign a user_id to each profile to easily identify which user the profile belongs to.
+         */
+        ProfileView: {
+            /**
+             * ID
+             * Format: uuid
+             * @description Unique identifier for the profile
+             */
+            id: string;
+            /**
+             * User ID
+             * @description Your internal user identifier for this profile. Use this to associate a profile with a user in your system.
+             */
+            userId?: string | null;
+            /**
+             * Name
+             * @description Optional name for the profile
+             */
+            name?: string | null;
+            /**
+             * Last Used At
+             * @description Timestamp when the profile was last used
+             */
+            lastUsedAt?: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             * @description Timestamp when the profile was created
+             */
+            createdAt: string;
+            /**
+             * Updated At
+             * Format: date-time
+             * @description Timestamp when the profile was last updated
+             */
+            updatedAt: string;
+            /**
+             * Cookie Domains
+             * @description List of domain URLs that have cookies stored for this profile
+             */
+            cookieDomains?: string[] | null;
         };
         /**
          * ProxyCountryCode
@@ -464,6 +655,16 @@ export interface components {
              * @default false
              */
             enableRecording: boolean;
+            /**
+             * Skills
+             * @default true
+             */
+            skills: boolean;
+            /**
+             * Agentmail
+             * @default true
+             */
+            agentmail: boolean;
         };
         /** SessionListResponse */
         SessionListResponse: {
@@ -504,8 +705,11 @@ export interface components {
             isTaskSuccessful?: boolean | null;
             /** Liveurl */
             liveUrl?: string | null;
-            /** Recordingurl */
-            recordingUrl?: string | null;
+            /**
+             * Recordingurls
+             * @default []
+             */
+            recordingUrls: string[];
             /** Profileid */
             profileId?: string | null;
             /** Workspaceid */
@@ -548,6 +752,8 @@ export interface components {
              * @default 0
              */
             totalCostUsd: string;
+            /** Agentmailemail */
+            agentmailEmail?: string | null;
             /**
              * Createdat
              * Format: date-time
@@ -920,6 +1126,194 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["FileUploadResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_profiles_profiles_get: {
+        parameters: {
+            query?: {
+                pageSize?: number;
+                pageNumber?: number;
+                query?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProfileListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_profile_profiles_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["ProfileCreateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProfileView"];
+                };
+            };
+            /** @description Subscription required for additional profiles */
+            402: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InsufficientCreditsError"];
+                };
+            };
+            /** @description Request validation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationError"];
+                };
+            };
+        };
+    };
+    get_profile_profiles__profile_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                profile_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProfileView"];
+                };
+            };
+            /** @description Profile not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProfileNotFoundError"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_browser_profile_profiles__profile_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                profile_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_profile_profiles__profile_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                profile_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProfileUpdateRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProfileView"];
+                };
+            };
+            /** @description Profile not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProfileNotFoundError"];
                 };
             };
             /** @description Validation Error */

--- a/browser-use-node/src/v3/resources/sessions.ts
+++ b/browser-use-node/src/v3/resources/sessions.ts
@@ -94,9 +94,8 @@ export class Sessions {
     const interval = options?.interval ?? 2_000;
     const deadline = Date.now() + timeout;
     while (Date.now() < deadline) {
-      const data = await this.http.get<Record<string, unknown>>(`/sessions/${sessionId}`);
-      const urls = data.recordingUrls;
-      if (Array.isArray(urls) && urls.length > 0) return urls as string[];
+      const session = await this.get(sessionId);
+      if (session.recordingUrls?.length) return session.recordingUrls;
       const remaining = deadline - Date.now();
       if (remaining <= 0) break;
       await new Promise((r) => setTimeout(r, Math.min(interval, remaining)));

--- a/browser-use-node/src/v3/resources/sessions.ts
+++ b/browser-use-node/src/v3/resources/sessions.ts
@@ -79,4 +79,28 @@ export class Sessions {
       params as Record<string, unknown>,
     );
   }
+
+  /**
+   * Poll until recording URLs are available. Returns presigned MP4 URLs.
+   *
+   * Returns an empty array if no recording was produced (e.g. the agent
+   * answered without opening a browser, or recording was not enabled).
+   */
+  async waitForRecording(
+    sessionId: string,
+    options?: { timeout?: number; interval?: number },
+  ): Promise<string[]> {
+    const timeout = options?.timeout ?? 15_000;
+    const interval = options?.interval ?? 2_000;
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      const data = await this.http.get<Record<string, unknown>>(`/sessions/${sessionId}`);
+      const urls = data.recordingUrls;
+      if (Array.isArray(urls) && urls.length > 0) return urls as string[];
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      await new Promise((r) => setTimeout(r, Math.min(interval, remaining)));
+    }
+    return [];
+  }
 }

--- a/browser-use-python/src/browser_use_sdk/generated/v2/models.py
+++ b/browser-use-python/src/browser_use_sdk/generated/v2/models.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, List, Literal
+from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, RootModel
@@ -247,7 +247,7 @@ class EnabledSkillsLimitExceededError(BaseModel):
 
 
 class ExecuteSkillRequest(BaseModel):
-    parameters: Dict[str, Any] | None = Field(
+    parameters: dict[str, Any] | None = Field(
         None, description='Parameters to pass to the skill handler', title='Parameters'
     )
     session_id: UUID | None = Field(
@@ -415,7 +415,7 @@ class ProfileView(BaseModel):
         description='Timestamp when the profile was last updated',
         title='Updated At',
     )
-    cookie_domains: List[str] | None = Field(
+    cookie_domains: list[str] | None = Field(
         None,
         alias='cookieDomains',
         description='List of domain URLs that have cookies stored for this profile',
@@ -957,6 +957,7 @@ class TaskStatus(Enum):
     created = 'created'
     started = 'started'
     finished = 'finished'
+    failed = 'failed'
     stopped = 'stopped'
 
 
@@ -1025,7 +1026,7 @@ class TaskStepView(BaseModel):
         description='Optional URL to the screenshot taken at this step',
         title='Screenshot URL',
     )
-    actions: List[str] = Field(
+    actions: list[str] = Field(
         ...,
         description='List of stringified json actions performed by the agent in this step',
         title='Actions',
@@ -1086,16 +1087,16 @@ class TaskView(BaseModel):
         description='Naive UTC timestamp when the task completed (None if still running)',
         title='Finished At',
     )
-    metadata: Dict[str, Any] | None = Field(
+    metadata: dict[str, Any] | None = Field(
         {},
         description='Optional additional metadata associated with the task set by the user',
         title='Metadata',
     )
-    steps: List[TaskStepView] = Field(..., title='Steps')
+    steps: list[TaskStepView] = Field(..., title='Steps')
     output: str | None = Field(
         None, description='Final output/result of the task', title='Output'
     )
-    output_files: List[FileView] = Field(..., alias='outputFiles', title='Outputfiles')
+    output_files: list[FileView] = Field(..., alias='outputFiles', title='Outputfiles')
     browser_use_version: str | None = Field(
         None,
         alias='browserUseVersion',
@@ -1124,7 +1125,7 @@ class TaskView(BaseModel):
         description='Total cost of the task in USD. This is the sum of all step costs incurred during task execution.',
         title='Cost',
     )
-    suggestions: List[Dict[str, Any]] | None = Field(
+    suggestions: list[dict[str, Any]] | None = Field(
         None,
         description='List of actionable suggestions for improving task configuration based on detected issues during execution.',
         title='Suggestions',
@@ -1183,10 +1184,10 @@ class UpdateSkillRequest(BaseModel):
         description='Description of what the skill does (shows up in the public view)',
         title='Description',
     )
-    categories: List[SkillCategory] | None = Field(
+    categories: list[SkillCategory] | None = Field(
         None, description='Categories to assign to the skill', title='Categories'
     )
-    domains: List[str] | None = Field(
+    domains: list[str] | None = Field(
         None, description='Domains/websites this skill interacts with', title='Domains'
     )
     is_enabled: bool | None = Field(
@@ -1208,7 +1209,7 @@ class UploadFilePresignedUrlResponse(BaseModel):
     method: Literal['POST'] = Field(
         ..., description='The HTTP method to use for the upload.', title='Method'
     )
-    fields: Dict[str, str] = Field(
+    fields: dict[str, str] = Field(
         ...,
         description='The form fields to include in the upload request.',
         title='Fields',
@@ -1269,7 +1270,7 @@ class UploadFileRequest(BaseModel):
 
 
 class ValidationError(BaseModel):
-    loc: List[str | int] = Field(..., title='Location')
+    loc: list[str | int] = Field(..., title='Location')
     msg: str = Field(..., title='Message')
     type: str = Field(..., title='Error Type')
 
@@ -1384,7 +1385,7 @@ class BrowserSessionItemView(BaseModel):
 
 
 class BrowserSessionListResponse(BaseModel):
-    items: List[BrowserSessionItemView] = Field(
+    items: list[BrowserSessionItemView] = Field(
         ...,
         description='List of browser session views for the current page',
         title='Items',
@@ -1549,17 +1550,17 @@ class CreateTaskRequest(BaseModel):
         description='The ID of the session where the task will run.',
         title='Session ID',
     )
-    metadata: Dict[str, str] | None = Field(
+    metadata: dict[str, str] | None = Field(
         None,
         description='The metadata for the task. Up to 10 key-value pairs.',
         title='Metadata',
     )
-    secrets: Dict[str, str] | None = Field(
+    secrets: dict[str, str] | None = Field(
         None,
         description='The secrets for the task. Allowed domains are not required for secrets to be injected, but are recommended.',
         title='Secrets',
     )
-    allowed_domains: List[str] | None = Field(
+    allowed_domains: list[str] | None = Field(
         None,
         alias='allowedDomains',
         description='The allowed domains for the task.',
@@ -1592,7 +1593,7 @@ class CreateTaskRequest(BaseModel):
     thinking: bool | None = Field(
         False, description='Whether agent thinking mode is enabled.', title='Thinking'
     )
-    vision: bool | str | None = Field(
+    vision: bool | Literal['auto'] | None = Field(
         True,
         description="Whether agent vision capabilities are enabled. Set to 'auto' to let the agent decide based on the model capabilities.",
         title='Vision',
@@ -1621,7 +1622,7 @@ class CreateTaskRequest(BaseModel):
         description='The LLM model to use for judging. If not provided, uses the default judge LLM.',
         title='Judge LLM',
     )
-    skill_ids: List[str] | None = Field(
+    skill_ids: list[str] | None = Field(
         None,
         alias='skillIds',
         description="List of skill IDs to enable for this task. Use ['*'] to enable all available skills for the project.",
@@ -1630,7 +1631,7 @@ class CreateTaskRequest(BaseModel):
 
 
 class HTTPValidationError(BaseModel):
-    detail: List[ValidationError] | None = Field(None, title='Detail')
+    detail: list[ValidationError] | None = Field(None, title='Detail')
 
 
 class ParameterSchema(BaseModel):
@@ -1643,7 +1644,7 @@ class ParameterSchema(BaseModel):
 
 
 class ProfileListResponse(BaseModel):
-    items: List[ProfileView] = Field(
+    items: list[ProfileView] = Field(
         ..., description='List of profile views for the current page', title='Items'
     )
     total_items: int = Field(
@@ -1723,7 +1724,7 @@ class SessionItemView(BaseModel):
 
 
 class SessionListResponse(BaseModel):
-    items: List[SessionItemView] = Field(
+    items: list[SessionItemView] = Field(
         ..., description='List of session views for the current page', title='Items'
     )
     total_items: int = Field(
@@ -1741,7 +1742,7 @@ class SessionListResponse(BaseModel):
 
 
 class SkillExecutionListResponse(BaseModel):
-    items: List[SkillExecutionView] = Field(
+    items: list[SkillExecutionView] = Field(
         ..., description='List of executions', title='Items'
     )
     total_items: int = Field(
@@ -1773,10 +1774,10 @@ class SkillResponse(BaseModel):
         description='Description of the skill (shows up in the public view)',
         title='Description',
     )
-    categories: List[SkillCategory] = Field(
+    categories: list[SkillCategory] = Field(
         ..., description='Categories of the skill', title='Categories'
     )
-    domains: List[str] = Field(
+    domains: list[str] = Field(
         ..., description='Domains/websites this skill interacts with', title='Domains'
     )
     goal: str | None = Field(
@@ -1793,10 +1794,10 @@ class SkillResponse(BaseModel):
     status: SkillsGenerationStatus = Field(
         ..., description='Status of the skill', title='Status'
     )
-    parameters: List[ParameterSchema] = Field(
+    parameters: list[ParameterSchema] = Field(
         ..., description='Input parameters of the skill', title='Parameters'
     )
-    output_schema: Dict[str, Any] = Field(
+    output_schema: dict[str, Any] = Field(
         ...,
         alias='outputSchema',
         description='Output schema of the skill',
@@ -1904,7 +1905,7 @@ class TaskItemView(BaseModel):
         description='Naive UTC timestamp when the task completed (None if still running)',
         title='Finished At',
     )
-    metadata: Dict[str, Any] | None = Field(
+    metadata: dict[str, Any] | None = Field(
         {},
         description='Optional additional metadata associated with the task set by the user',
         title='Metadata',
@@ -1940,7 +1941,7 @@ class TaskItemView(BaseModel):
         description='Total cost of the task in USD. This is the sum of all step costs incurred during task execution.',
         title='Cost',
     )
-    suggestions: List[Dict[str, Any]] | None = Field(
+    suggestions: list[dict[str, Any]] | None = Field(
         None,
         description='List of actionable suggestions for improving task configuration based on detected issues during execution.',
         title='Suggestions',
@@ -1948,7 +1949,7 @@ class TaskItemView(BaseModel):
 
 
 class TaskListResponse(BaseModel):
-    items: List[TaskItemView] = Field(
+    items: list[TaskItemView] = Field(
         ..., description='List of task views for the current page', title='Items'
     )
     total_items: int = Field(
@@ -1978,16 +1979,16 @@ class MarketplaceSkillResponse(BaseModel):
         description='Description of the skill (shows up in the public view)',
         title='Description',
     )
-    categories: List[SkillCategory] = Field(
+    categories: list[SkillCategory] = Field(
         ..., description='Categories of the skill', title='Categories'
     )
-    domains: List[str] = Field(
+    domains: list[str] = Field(
         ..., description='Domains/websites this skill interacts with', title='Domains'
     )
-    parameters: List[ParameterSchema] = Field(
+    parameters: list[ParameterSchema] = Field(
         ..., description='Input parameters of the skill', title='Parameters'
     )
-    output_schema: Dict[str, Any] = Field(
+    output_schema: dict[str, Any] = Field(
         ...,
         alias='outputSchema',
         description='Output schema of the skill',
@@ -2071,7 +2072,7 @@ class SessionView(BaseModel):
         description='Timestamp when the session was stopped (None if still active)',
         title='Finished At',
     )
-    tasks: List[TaskItemView] = Field(
+    tasks: list[TaskItemView] = Field(
         ..., description='List of tasks associated with this session', title='Tasks'
     )
     public_share_url: str | None = Field(
@@ -2109,7 +2110,7 @@ class SessionView(BaseModel):
 
 
 class SkillListResponse(BaseModel):
-    items: List[SkillResponse] = Field(..., description='List of skills', title='Items')
+    items: list[SkillResponse] = Field(..., description='List of skills', title='Items')
     total_items: int = Field(
         ...,
         alias='totalItems',
@@ -2125,7 +2126,7 @@ class SkillListResponse(BaseModel):
 
 
 class MarketplaceSkillListResponse(BaseModel):
-    items: List[MarketplaceSkillResponse] = Field(
+    items: list[MarketplaceSkillResponse] = Field(
         ..., description='List of skills', title='Items'
     )
     total_items: int = Field(

--- a/browser-use-python/src/browser_use_sdk/generated/v3/models.py
+++ b/browser-use-python/src/browser_use_sdk/generated/v3/models.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, List
+from typing import Any
 from uuid import UUID
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, RootModel
@@ -22,6 +22,7 @@ class BuAgentSessionStatus(Enum):
 class BuModel(Enum):
     bu_mini = 'bu-mini'
     bu_max = 'bu-max'
+    bu_ultra = 'bu-ultra'
 
 
 class FileInfo(BaseModel):
@@ -34,8 +35,8 @@ class FileInfo(BaseModel):
 
 
 class FileListResponse(BaseModel):
-    files: List[FileInfo] = Field(..., title='Files')
-    folders: List[str] | None = Field(
+    files: list[FileInfo] = Field(..., title='Files')
+    folders: list[str] | None = Field(
         None,
         description='Immediate sub-folder names at this prefix level',
         title='Folders',
@@ -76,7 +77,7 @@ class FileUploadItem(BaseModel):
 
 
 class FileUploadRequest(BaseModel):
-    files: List[FileUploadItem] = Field(..., max_length=10, min_length=1, title='Files')
+    files: list[FileUploadItem] = Field(..., max_length=10, min_length=1, title='Files')
 
 
 class FileUploadResponseItem(BaseModel):
@@ -85,6 +86,10 @@ class FileUploadResponseItem(BaseModel):
     path: str = Field(
         ..., description='S3-relative path, e.g. "uploads/data.csv"', title='Path'
     )
+
+
+class InsufficientCreditsError(BaseModel):
+    detail: str | None = Field('Insufficient credits', title='Detail')
 
 
 class MessageResponse(BaseModel):
@@ -103,6 +108,86 @@ class MessageResponse(BaseModel):
         title='Summary',
     )
     created_at: AwareDatetime = Field(..., alias='createdAt', title='Createdat')
+
+
+class Name(RootModel[str]):
+    root: str = Field(
+        ..., description='Optional name for the profile', max_length=100, title='Name'
+    )
+
+
+class UserId(RootModel[str]):
+    root: str = Field(
+        ...,
+        description='Your internal user identifier for this profile. Use this to associate a profile with a user in your system.',
+        max_length=255,
+        title='User ID',
+    )
+
+
+class ProfileCreateRequest(BaseModel):
+    name: Name | None = Field(
+        None, description='Optional name for the profile', title='Name'
+    )
+    user_id: UserId | None = Field(
+        None,
+        alias='userId',
+        description='Your internal user identifier for this profile. Use this to associate a profile with a user in your system.',
+        title='User ID',
+    )
+
+
+class ProfileNotFoundError(BaseModel):
+    detail: str | None = Field('Profile not found', title='Detail')
+
+
+class ProfileUpdateRequest(BaseModel):
+    name: Name | None = Field(
+        None, description='Optional name for the profile', title='Name'
+    )
+    user_id: UserId | None = Field(
+        None,
+        alias='userId',
+        description='Your internal user identifier for this profile. Use this to associate a profile with a user in your system.',
+        title='User ID',
+    )
+
+
+class ProfileView(BaseModel):
+    id: UUID = Field(..., description='Unique identifier for the profile', title='ID')
+    user_id: str | None = Field(
+        None,
+        alias='userId',
+        description='Your internal user identifier for this profile. Use this to associate a profile with a user in your system.',
+        title='User ID',
+    )
+    name: str | None = Field(
+        None, description='Optional name for the profile', title='Name'
+    )
+    last_used_at: AwareDatetime | None = Field(
+        None,
+        alias='lastUsedAt',
+        description='Timestamp when the profile was last used',
+        title='Last Used At',
+    )
+    created_at: AwareDatetime = Field(
+        ...,
+        alias='createdAt',
+        description='Timestamp when the profile was created',
+        title='Created At',
+    )
+    updated_at: AwareDatetime = Field(
+        ...,
+        alias='updatedAt',
+        description='Timestamp when the profile was last updated',
+        title='Updated At',
+    )
+    cookie_domains: list[str] | None = Field(
+        None,
+        alias='cookieDomains',
+        description='List of domain URLs that have cookies stored for this profile',
+        title='Cookie Domains',
+    )
 
 
 class ProxyCountryCode(Enum):
@@ -375,7 +460,7 @@ class RunTaskRequest(BaseModel):
     profile_id: UUID | None = Field(None, alias='profileId', title='Profileid')
     workspace_id: UUID | None = Field(None, alias='workspaceId', title='Workspaceid')
     proxy_country_code: ProxyCountryCode | None = Field('us', alias='proxyCountryCode')
-    output_schema: Dict[str, Any] | None = Field(
+    output_schema: dict[str, Any] | None = Field(
         None, alias='outputSchema', title='Outputschema'
     )
     enable_scheduled_tasks: bool | None = Field(
@@ -384,6 +469,8 @@ class RunTaskRequest(BaseModel):
     enable_recording: bool | None = Field(
         False, alias='enableRecording', title='Enablerecording'
     )
+    skills: bool | None = Field(True, title='Skills')
+    agentmail: bool | None = Field(True, title='Agentmail')
 
 
 class SessionResponse(BaseModel):
@@ -395,7 +482,7 @@ class SessionResponse(BaseModel):
     model: BuModel
     title: str | None = Field(None, title='Title')
     output: Any = Field(None, title='Output')
-    output_schema: Dict[str, Any] | None = Field(
+    output_schema: dict[str, Any] | None = Field(
         None, alias='outputSchema', title='Outputschema'
     )
     step_count: int | None = Field(0, alias='stepCount', title='Stepcount')
@@ -406,7 +493,9 @@ class SessionResponse(BaseModel):
         None, alias='isTaskSuccessful', title='Istasksuccessful'
     )
     live_url: str | None = Field(None, alias='liveUrl', title='Liveurl')
-    recording_url: str | None = Field(None, alias='recordingUrl', title='Recordingurl')
+    recording_urls: list[str] | None = Field(
+        [], alias='recordingUrls', title='Recordingurls'
+    )
     profile_id: UUID | None = Field(None, alias='profileId', title='Profileid')
     workspace_id: UUID | None = Field(None, alias='workspaceId', title='Workspaceid')
     proxy_country_code: ProxyCountryCode | None = Field(None, alias='proxyCountryCode')
@@ -449,6 +538,9 @@ class SessionResponse(BaseModel):
         pattern='^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$',
         title='Totalcostusd',
     )
+    agentmail_email: str | None = Field(
+        None, alias='agentmailEmail', title='Agentmailemail'
+    )
     created_at: AwareDatetime = Field(..., alias='createdAt', title='Createdat')
     updated_at: AwareDatetime = Field(..., alias='updatedAt', title='Updatedat')
 
@@ -459,25 +551,25 @@ class StopStrategy(Enum):
 
 
 class ValidationError(BaseModel):
-    loc: List[str | int] = Field(..., title='Location')
+    loc: list[str | int] = Field(..., title='Location')
     msg: str = Field(..., title='Message')
     type: str = Field(..., title='Error Type')
 
 
-class Name(RootModel[str]):
+class Name2(RootModel[str]):
     root: str = Field(
         ..., description='Optional name for the workspace', max_length=100, title='Name'
     )
 
 
 class WorkspaceCreateRequest(BaseModel):
-    name: Name | None = Field(
+    name: Name2 | None = Field(
         None, description='Optional name for the workspace', title='Name'
     )
 
 
 class WorkspaceUpdateRequest(BaseModel):
-    name: Name | None = Field(
+    name: Name2 | None = Field(
         None, description='Optional name for the workspace', title='Name'
     )
 
@@ -502,20 +594,38 @@ class WorkspaceView(BaseModel):
 
 
 class FileUploadResponse(BaseModel):
-    files: List[FileUploadResponseItem] = Field(..., title='Files')
+    files: list[FileUploadResponseItem] = Field(..., title='Files')
 
 
 class HTTPValidationError(BaseModel):
-    detail: List[ValidationError] | None = Field(None, title='Detail')
+    detail: list[ValidationError] | None = Field(None, title='Detail')
 
 
 class MessageListResponse(BaseModel):
-    messages: List[MessageResponse] = Field(..., title='Messages')
+    messages: list[MessageResponse] = Field(..., title='Messages')
     has_more: bool = Field(..., alias='hasMore', title='Hasmore')
 
 
+class ProfileListResponse(BaseModel):
+    items: list[ProfileView] = Field(
+        ..., description='List of profile views for the current page', title='Items'
+    )
+    total_items: int = Field(
+        ...,
+        alias='totalItems',
+        description='Total number of items in the list',
+        title='Total Items',
+    )
+    page_number: int = Field(
+        ..., alias='pageNumber', description='Page number', title='Page Number'
+    )
+    page_size: int = Field(
+        ..., alias='pageSize', description='Number of items per page', title='Page Size'
+    )
+
+
 class SessionListResponse(BaseModel):
-    sessions: List[SessionResponse] = Field(..., title='Sessions')
+    sessions: list[SessionResponse] = Field(..., title='Sessions')
     total: int = Field(..., title='Total')
     page: int = Field(..., title='Page')
     page_size: int = Field(..., alias='pageSize', title='Pagesize')
@@ -526,7 +636,7 @@ class StopSessionRequest(BaseModel):
 
 
 class WorkspaceListResponse(BaseModel):
-    items: List[WorkspaceView] = Field(
+    items: list[WorkspaceView] = Field(
         ..., description='List of workspace views for the current page', title='Items'
     )
     total_items: int = Field(

--- a/browser-use-python/src/browser_use_sdk/v3/resources/sessions.py
+++ b/browser-use-python/src/browser_use_sdk/v3/resources/sessions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import time
 from typing import Any
 from uuid import UUID
 
@@ -164,6 +166,27 @@ class Sessions:
             )
         )
 
+    def wait_for_recording(
+        self,
+        session_id: _ID,
+        *,
+        timeout: float = 15,
+        interval: float = 2,
+    ) -> list[str]:
+        """Poll until recording URLs are available. Returns a list of presigned MP4 URLs.
+
+        Returns an empty list if no recording was produced (e.g. the agent
+        answered without opening a browser, or recording was not enabled).
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            data = self._http.request("GET", f"/sessions/{session_id}")
+            urls = data.get("recordingUrls") or []
+            if urls:
+                return urls
+            time.sleep(interval)
+        return []
+
 
 class AsyncSessions:
     def __init__(self, http: AsyncHttpClient) -> None:
@@ -311,3 +334,24 @@ class AsyncSessions:
                 },
             )
         )
+
+    async def wait_for_recording(
+        self,
+        session_id: _ID,
+        *,
+        timeout: float = 15,
+        interval: float = 2,
+    ) -> list[str]:
+        """Poll until recording URLs are available. Returns a list of presigned MP4 URLs.
+
+        Returns an empty list if no recording was produced (e.g. the agent
+        answered without opening a browser, or recording was not enabled).
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            data = await self._http.request("GET", f"/sessions/{session_id}")
+            urls = data.get("recordingUrls") or []
+            if urls:
+                return urls
+            await asyncio.sleep(interval)
+        return []

--- a/browser-use-python/src/browser_use_sdk/v3/resources/sessions.py
+++ b/browser-use-python/src/browser_use_sdk/v3/resources/sessions.py
@@ -183,7 +183,10 @@ class Sessions:
             session = self.get(session_id)
             if session.recording_urls:
                 return list(session.recording_urls)
-            time.sleep(interval)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            time.sleep(min(interval, remaining))
         return []
 
 
@@ -351,5 +354,8 @@ class AsyncSessions:
             session = await self.get(session_id)
             if session.recording_urls:
                 return list(session.recording_urls)
-            await asyncio.sleep(interval)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            await asyncio.sleep(min(interval, remaining))
         return []

--- a/browser-use-python/src/browser_use_sdk/v3/resources/sessions.py
+++ b/browser-use-python/src/browser_use_sdk/v3/resources/sessions.py
@@ -180,10 +180,9 @@ class Sessions:
         """
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            data = self._http.request("GET", f"/sessions/{session_id}")
-            urls = data.get("recordingUrls") or []
-            if urls:
-                return urls
+            session = self.get(session_id)
+            if session.recording_urls:
+                return list(session.recording_urls)
             time.sleep(interval)
         return []
 
@@ -349,9 +348,8 @@ class AsyncSessions:
         """
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            data = await self._http.request("GET", f"/sessions/{session_id}")
-            urls = data.get("recordingUrls") or []
-            if urls:
-                return urls
+            session = await self.get(session_id)
+            if session.recording_urls:
+                return list(session.recording_urls)
             await asyncio.sleep(interval)
         return []

--- a/docs/cloud/browser/live-preview.mdx
+++ b/docs/cloud/browser/live-preview.mdx
@@ -74,11 +74,10 @@ https://live.browser-use.com?wss=...&ui=false
 
 ## Recording
 
-Enable recording to get an MP4 video of the browser session. Only available when the agent actually opens a browser — tasks answered without browsing produce no recording. If you run multiple tasks in the same session (with `keep_alive`), you may get multiple recordings. Poll `sessions.get()` if `recording_urls` is empty — processing may take a few seconds for longer sessions.
+Enable recording to get an MP4 video of the browser session. Only available when the agent actually opens a browser — tasks answered without browsing produce no recording. If you run multiple tasks in the same session (with `keep_alive`), you may get multiple recordings.
 
 <CodeGroup>
 ```python Python
-import asyncio
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
@@ -87,14 +86,9 @@ result = await client.run(
     enable_recording=True,
 )
 
-# Recording may not be ready immediately — poll until available
-for _ in range(30):
-    session = await client.sessions.get(result.id)
-    if session.recording_urls:
-        break
-    await asyncio.sleep(2)
-
-for url in session.recording_urls:
+# Waits up to 15s for recording to be ready. Returns [] if no browser was opened.
+urls = await client.sessions.wait_for_recording(result.id)
+for url in urls:
     print(url)  # presigned MP4 download URL
 ```
 ```typescript TypeScript
@@ -105,14 +99,9 @@ const result = await client.run("Check how many GitHub stars browser-use has", {
   enableRecording: true,
 });
 
-// Recording may not be ready immediately — poll until available
-let session = await client.sessions.get(result.id);
-for (let i = 0; i < 30 && !session.recordingUrls?.length; i++) {
-  await new Promise((r) => setTimeout(r, 2000));
-  session = await client.sessions.get(result.id);
-}
-
-for (const url of session.recordingUrls) {
+// Waits up to 15s for recording to be ready. Returns [] if no browser was opened.
+const urls = await client.sessions.waitForRecording(result.id);
+for (const url of urls) {
   console.log(url); // presigned MP4 download URL
 }
 ```

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -411,12 +411,13 @@ Source: https://docs.browser-use.com/cloud/agent/human-in-the-loop
 ## Flow
 
 1. Create a session with `keep_alive=True` so it stays alive between tasks
-2. Run an agent task — `result.live_url` is available after the task completes
+2. Run an agent task — poll `sessions.get()` for `live_url` (~3-5 seconds)
 3. Human interacts with the live browser
 4. Send a new follow-up task
 
 <CodeGroup>
 ```python Python
+import asyncio
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
@@ -430,7 +431,13 @@ result = await client.run(
     session_id=session.id,
 )
 print(result.output)
-print(f"Live view: {result.live_url}")
+
+# Get the live URL (available while session is alive with keep_alive)
+s = await client.sessions.get(session.id)
+while not s.live_url:
+    await asyncio.sleep(1)
+    s = await client.sessions.get(session.id)
+print(f"Live view: {s.live_url}")
 
 # 3. Human opens live_url and picks a flight
 input("Press Enter after you've selected a flight in the live view...")
@@ -460,7 +467,14 @@ const searchResult = await client.run(
   { sessionId: session.id },
 );
 console.log(searchResult.output);
-console.log(`Live view: ${searchResult.liveUrl}`);
+
+// Get the live URL (available while session is alive with keepAlive)
+let s = await client.sessions.get(session.id);
+while (!s.liveUrl) {
+  await new Promise((r) => setTimeout(r, 1000));
+  s = await client.sessions.get(session.id);
+}
+console.log(`Live view: ${s.liveUrl}`);
 
 // 3. Human opens liveUrl and picks a flight
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
@@ -649,11 +663,10 @@ https://live.browser-use.com?wss=...&ui=false
 
 ## Recording
 
-Enable recording to get an MP4 video of the browser session. Only available when the agent actually opens a browser — tasks answered without browsing produce no recording. If you run multiple tasks in the same session (with `keep_alive`), you may get multiple recordings. Poll `sessions.get()` if `recording_urls` is empty — processing may take a few seconds for longer sessions.
+Enable recording to get an MP4 video of the browser session. Only available when the agent actually opens a browser — tasks answered without browsing produce no recording. If you run multiple tasks in the same session (with `keep_alive`), you may get multiple recordings.
 
 <CodeGroup>
 ```python Python
-import asyncio
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
@@ -662,14 +675,9 @@ result = await client.run(
     enable_recording=True,
 )
 
-# Recording may not be ready immediately — poll until available
-for _ in range(30):
-    session = await client.sessions.get(result.id)
-    if session.recording_urls:
-        break
-    await asyncio.sleep(2)
-
-for url in session.recording_urls:
+# Waits up to 15s for recording to be ready. Returns [] if no browser was opened.
+urls = await client.sessions.wait_for_recording(result.id)
+for url in urls:
     print(url)  # presigned MP4 download URL
 ```
 ```typescript TypeScript
@@ -680,14 +688,9 @@ const result = await client.run("Check how many GitHub stars browser-use has", {
   enableRecording: true,
 });
 
-// Recording may not be ready immediately — poll until available
-let session = await client.sessions.get(result.id);
-for (let i = 0; i < 30 && !session.recordingUrls?.length; i++) {
-  await new Promise((r) => setTimeout(r, 2000));
-  session = await client.sessions.get(result.id);
-}
-
-for (const url of session.recordingUrls) {
+// Waits up to 15s for recording to be ready. Returns [] if no browser was opened.
+const urls = await client.sessions.waitForRecording(result.id);
+for (const url of urls) {
   console.log(url); // presigned MP4 download URL
 }
 ```
@@ -1590,12 +1593,14 @@ Set `max_cost_usd` to cap spending per task. Default is $20. A typical task cost
 
 ## How do I get the live browser URL?
 
-After `client.run()` completes, `result.live_url` is available on the result. If you use `sessions.create()` directly, poll `sessions.get()` until `live_url` appears (~3-5 seconds).
+`live_url` is available while the browser is running. Use `keep_alive=True` so the session stays alive after the task — otherwise `live_url` goes to null when the task finishes.
 
 ```python
 result = await client.run("Go to example.com", keep_alive=True)
-print(result.live_url)
+print(result.live_url)  # available because session is still alive
 ```
+
+If you use `sessions.create()` directly, poll `sessions.get()` until `live_url` appears (~3-5 seconds).
 
 ## How do I authenticate on websites?
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -411,12 +411,13 @@ Source: https://docs.browser-use.com/cloud/agent/human-in-the-loop
 ## Flow
 
 1. Create a session with `keep_alive=True` so it stays alive between tasks
-2. Run an agent task — `result.live_url` is available after the task completes
+2. Run an agent task — poll `sessions.get()` for `live_url` (~3-5 seconds)
 3. Human interacts with the live browser
 4. Send a new follow-up task
 
 <CodeGroup>
 ```python Python
+import asyncio
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
@@ -430,7 +431,13 @@ result = await client.run(
     session_id=session.id,
 )
 print(result.output)
-print(f"Live view: {result.live_url}")
+
+# Get the live URL (available while session is alive with keep_alive)
+s = await client.sessions.get(session.id)
+while not s.live_url:
+    await asyncio.sleep(1)
+    s = await client.sessions.get(session.id)
+print(f"Live view: {s.live_url}")
 
 # 3. Human opens live_url and picks a flight
 input("Press Enter after you've selected a flight in the live view...")
@@ -460,7 +467,14 @@ const searchResult = await client.run(
   { sessionId: session.id },
 );
 console.log(searchResult.output);
-console.log(`Live view: ${searchResult.liveUrl}`);
+
+// Get the live URL (available while session is alive with keepAlive)
+let s = await client.sessions.get(session.id);
+while (!s.liveUrl) {
+  await new Promise((r) => setTimeout(r, 1000));
+  s = await client.sessions.get(session.id);
+}
+console.log(`Live view: ${s.liveUrl}`);
 
 // 3. Human opens liveUrl and picks a flight
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
@@ -649,11 +663,10 @@ https://live.browser-use.com?wss=...&ui=false
 
 ## Recording
 
-Enable recording to get an MP4 video of the browser session. Only available when the agent actually opens a browser — tasks answered without browsing produce no recording. If you run multiple tasks in the same session (with `keep_alive`), you may get multiple recordings. Poll `sessions.get()` if `recording_urls` is empty — processing may take a few seconds for longer sessions.
+Enable recording to get an MP4 video of the browser session. Only available when the agent actually opens a browser — tasks answered without browsing produce no recording. If you run multiple tasks in the same session (with `keep_alive`), you may get multiple recordings.
 
 <CodeGroup>
 ```python Python
-import asyncio
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
@@ -662,14 +675,9 @@ result = await client.run(
     enable_recording=True,
 )
 
-# Recording may not be ready immediately — poll until available
-for _ in range(30):
-    session = await client.sessions.get(result.id)
-    if session.recording_urls:
-        break
-    await asyncio.sleep(2)
-
-for url in session.recording_urls:
+# Waits up to 15s for recording to be ready. Returns [] if no browser was opened.
+urls = await client.sessions.wait_for_recording(result.id)
+for url in urls:
     print(url)  # presigned MP4 download URL
 ```
 ```typescript TypeScript
@@ -680,14 +688,9 @@ const result = await client.run("Check how many GitHub stars browser-use has", {
   enableRecording: true,
 });
 
-// Recording may not be ready immediately — poll until available
-let session = await client.sessions.get(result.id);
-for (let i = 0; i < 30 && !session.recordingUrls?.length; i++) {
-  await new Promise((r) => setTimeout(r, 2000));
-  session = await client.sessions.get(result.id);
-}
-
-for (const url of session.recordingUrls) {
+// Waits up to 15s for recording to be ready. Returns [] if no browser was opened.
+const urls = await client.sessions.waitForRecording(result.id);
+for (const url of urls) {
   console.log(url); // presigned MP4 download URL
 }
 ```
@@ -1590,12 +1593,14 @@ Set `max_cost_usd` to cap spending per task. Default is $20. A typical task cost
 
 ## How do I get the live browser URL?
 
-After `client.run()` completes, `result.live_url` is available on the result. If you use `sessions.create()` directly, poll `sessions.get()` until `live_url` appears (~3-5 seconds).
+`live_url` is available while the browser is running. Use `keep_alive=True` so the session stays alive after the task — otherwise `live_url` goes to null when the task finishes.
 
 ```python
 result = await client.run("Go to example.com", keep_alive=True)
-print(result.live_url)
+print(result.live_url)  # available because session is still alive
 ```
+
+If you use `sessions.create()` directly, poll `sessions.get()` until `live_url` appears (~3-5 seconds).
 
 ## How do I authenticate on websites?
 


### PR DESCRIPTION
## Summary
- Add `sessions.wait_for_recording(session_id)` to Python (sync + async) and TypeScript
- Polls `sessions.get()` up to 15s (default) for `recordingUrls` to become non-empty
- Returns empty list if no recording was produced (agent didn't open a browser, or recording not enabled)
- Reads raw JSON to bypass stale generated models (`recordingUrl` singular vs `recordingUrls` array)

## Before (8 lines)
```python
for _ in range(30):
    session = await client.sessions.get(result.id)
    if session.recording_urls:
        break
    await asyncio.sleep(2)
```

## After (1 line)
```python
urls = await client.sessions.wait_for_recording(result.id)
```

## Test plan
- [ ] Test with recording enabled — should return URLs
- [ ] Test without recording — should return empty list after 15s
- [ ] Test with task that doesn't open browser — should return empty list quickly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `sessions.wait_for_recording()` (Python, sync + async) and `sessions.waitForRecording()` (TypeScript) to poll for session recording URLs with a single call. Docs updated (live preview + LLM guides) to use the helper and clarify `liveUrl` availability.

- **New Features**
  - Polls `sessions.get()` up to 15s (2s interval; both configurable) for `recordingUrls`; returns an empty list if none.
  - Caps sleep to the remaining time so the timeout is respected.

- **Dependencies**
  - Regenerated clients from the latest OpenAPI spec: Profiles CRUD models/endpoints, `InsufficientCreditsError`, `BuModel` `bu-ultra`, `TaskStatus` `failed` (v2), `skills`/`agentmail` flags, `agentmailEmail`.
  - Session response field switched to `recordingUrls`/`recording_urls`.

<sup>Written for commit 045e696e640346afa075d0324f0acb2b7fd81f02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

