### PR TITLE
Add message streaming + fix minor docs issues

### DIFF
--- a/browser-use-node/src/v3/helpers.ts
+++ b/browser-use-node/src/v3/helpers.ts
@@ -3,6 +3,7 @@ import type { components } from "../generated/v3/types.js";
 import type { Sessions } from "./resources/sessions.js";
 
 type SessionResponse = components["schemas"]["SessionResponse"];
+type MessageResponse = components["schemas"]["MessageResponse"];
 
 const TERMINAL_STATUSES = new Set(["idle", "stopped", "timed_out", "error"]);
 
@@ -92,6 +93,40 @@ export class SessionRun<T = string> implements PromiseLike<SessionResult<T>> {
     throw new Error(
       `Session ${sessionId} did not complete within ${this._timeout}ms`,
     );
+  }
+
+  /**
+   * Enable `for await (const msg of client.run(...))` — yields messages as they appear.
+   * After iteration, `.result` contains the final SessionResult.
+   */
+  async *[Symbol.asyncIterator](): AsyncGenerator<MessageResponse> {
+    const sessionId = await this._ensureSessionId();
+    let cursor: string | undefined;
+    const deadline = Date.now() + this._timeout;
+
+    while (Date.now() < deadline) {
+      const resp = await this._sessions.messages(sessionId, { after: cursor, limit: 100 });
+      for (const msg of resp.messages) {
+        yield msg;
+        cursor = msg.id;
+      }
+
+      const session = await this._sessions.get(sessionId);
+      if (TERMINAL_STATUSES.has(session.status)) {
+        // Drain remaining messages
+        const final = await this._sessions.messages(sessionId, { after: cursor, limit: 100 });
+        for (const msg of final.messages) yield msg;
+        const { output, ...rest } = session;
+        this._result = { ...rest, output: this._parseOutput(output) } as SessionResult<T>;
+        return;
+      }
+
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      await new Promise((r) => setTimeout(r, Math.min(this._interval, remaining)));
+    }
+
+    throw new Error(`Session ${sessionId} did not complete within ${this._timeout}ms`);
   }
 
   private _parseOutput(output: unknown): T {

--- a/browser-use-node/src/v3/helpers.ts
+++ b/browser-use-node/src/v3/helpers.ts
@@ -113,9 +113,15 @@ export class SessionRun<T = string> implements PromiseLike<SessionResult<T>> {
 
       const session = await this._sessions.get(sessionId);
       if (TERMINAL_STATUSES.has(session.status)) {
-        // Drain remaining messages
-        const final = await this._sessions.messages(sessionId, { after: cursor, limit: 100 });
-        for (const msg of final.messages) yield msg;
+        // Drain all remaining messages (may be multiple pages)
+        while (true) {
+          const page = await this._sessions.messages(sessionId, { after: cursor, limit: 100 });
+          if (!page.messages.length) break;
+          for (const msg of page.messages) {
+            yield msg;
+            cursor = msg.id;
+          }
+        }
         const { output, ...rest } = session;
         this._result = { ...rest, output: this._parseOutput(output) } as SessionResult<T>;
         return;

--- a/browser-use-python/src/browser_use_sdk/v3/client.py
+++ b/browser-use-python/src/browser_use_sdk/v3/client.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from .._core.http import AsyncHttpClient, SyncHttpClient
 from .resources.sessions import AsyncSessions, Sessions
 from .resources.workspaces import AsyncWorkspaces, Workspaces
-from .helpers import AsyncSessionRun, SessionResult, _poll_output
+from .helpers import AsyncSessionRun, SessionResult, SessionStream, _poll_output
 from ..generated.v3.models import SessionResponse
 
 _V3_BASE_URL = "https://api.browser-use.com/api/v3"
@@ -122,6 +122,49 @@ class BrowserUse:
             **extra,
         )
         return _poll_output(self.sessions, str(data.id), resolved_schema)
+
+    def stream(
+        self,
+        task: str,
+        *,
+        schema: type[Any] | None = None,
+        output_schema: type[Any] | None = None,
+        model: str | None = None,
+        session_id: str | UUID | None = None,
+        keep_alive: bool | None = None,
+        max_cost_usd: float | None = None,
+        profile_id: str | None = None,
+        proxy_country_code: str | None = None,
+        workspace_id: str | None = None,
+        **extra: Any,
+    ) -> SessionStream[Any]:
+        """Run a task and yield messages as they happen.
+
+        Usage::
+
+            stream = client.stream("Find the top story on HN")
+            for msg in stream:
+                print(f"[{msg.role}] {msg.summary}")
+            print(stream.result.output)
+        """
+        resolved_schema = schema or output_schema
+        schema_dict: dict[str, Any] | None = None
+        if resolved_schema is not None and issubclass(resolved_schema, BaseModel):
+            schema_dict = resolved_schema.model_json_schema()
+
+        data = self.sessions.create(
+            task,
+            model=model,
+            session_id=session_id,
+            keep_alive=keep_alive,
+            max_cost_usd=max_cost_usd,
+            profile_id=profile_id,
+            proxy_country_code=proxy_country_code,
+            output_schema=schema_dict,
+            workspace_id=workspace_id,
+            **extra,
+        )
+        return SessionStream(data, self.sessions, resolved_schema)
 
     def close(self) -> None:
         """Close the underlying HTTP client."""

--- a/browser-use-python/src/browser_use_sdk/v3/helpers.py
+++ b/browser-use-python/src/browser_use_sdk/v3/helpers.py
@@ -143,10 +143,14 @@ class AsyncSessionRun(Generic[T]):
 
             session = await self._sessions.get(self.session_id)
             if session.status.value in _TERMINAL_STATUSES:
-                # Drain any remaining messages
-                resp = await self._sessions.messages(self.session_id, after=cursor, limit=100)
-                for msg in resp.messages:
-                    yield msg
+                # Drain all remaining messages (may be multiple pages)
+                while True:
+                    resp = await self._sessions.messages(self.session_id, after=cursor, limit=100)
+                    if not resp.messages:
+                        break
+                    for msg in resp.messages:
+                        yield msg
+                        cursor = str(msg.id)
                 self.result = SessionResult(session, _parse_output(session.output, self._output_schema))
                 return
 
@@ -199,9 +203,13 @@ class SessionStream(Generic[T]):
 
             session = self._sessions.get(self.session_id)
             if session.status.value in _TERMINAL_STATUSES:
-                resp = self._sessions.messages(self.session_id, after=cursor, limit=100)
-                for msg in resp.messages:
-                    yield msg
+                while True:
+                    resp = self._sessions.messages(self.session_id, after=cursor, limit=100)
+                    if not resp.messages:
+                        break
+                    for msg in resp.messages:
+                        yield msg
+                        cursor = str(msg.id)
                 self.result = SessionResult(session, _parse_output(session.output, self._output_schema))
                 return
 

--- a/browser-use-python/src/browser_use_sdk/v3/helpers.py
+++ b/browser-use-python/src/browser_use_sdk/v3/helpers.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import time
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel
 
-from ..generated.v3.models import SessionResponse
+from ..generated.v3.models import MessageResponse, SessionResponse
 from .resources.sessions import AsyncSessions, Sessions
 
 _TERMINAL_STATUSES = {"idle", "stopped", "timed_out", "error"}
@@ -119,3 +119,92 @@ class AsyncSessionRun(Generic[T]):
 
     def __await__(self):
         return self._wait_for_output().__await__()
+
+    async def __aiter__(self) -> AsyncIterator[MessageResponse]:
+        """Yield new messages as they appear, then set .result when done.
+
+        Usage::
+
+            run = client.run("Find the top story on HN")
+            async for msg in run:
+                print(f"[{msg.role}] {msg.summary}")
+            print(run.result.output)
+        """
+        data = await self._create_fn()
+        self.session_id = str(data.id)
+        cursor: str | None = None
+        deadline = time.monotonic() + self._timeout
+
+        while time.monotonic() < deadline:
+            resp = await self._sessions.messages(self.session_id, after=cursor, limit=100)
+            for msg in resp.messages:
+                yield msg
+                cursor = str(msg.id)
+
+            session = await self._sessions.get(self.session_id)
+            if session.status.value in _TERMINAL_STATUSES:
+                # Drain any remaining messages
+                resp = await self._sessions.messages(self.session_id, after=cursor, limit=100)
+                for msg in resp.messages:
+                    yield msg
+                self.result = SessionResult(session, _parse_output(session.output, self._output_schema))
+                return
+
+            await asyncio.sleep(self._interval)
+
+        raise TimeoutError(f"Session {self.session_id} did not complete within {self._timeout}s")
+
+
+class SessionStream(Generic[T]):
+    """Sync iterator that yields new messages as they appear.
+
+    Usage::
+
+        stream = client.stream("Find the top story on HN")
+        for msg in stream:
+            print(f"[{msg.role}] {msg.summary}")
+        print(stream.result.output)
+    """
+
+    def __init__(
+        self,
+        session: SessionResponse,
+        sessions: Sessions,
+        output_schema: type[T] | None = None,
+        *,
+        timeout: float = 14400,
+        interval: float = 2,
+    ) -> None:
+        self.session_id = str(session.id)
+        self._sessions = sessions
+        self._output_schema = output_schema
+        self._timeout = timeout
+        self._interval = interval
+        self.result: SessionResult[T] | None = None
+
+    @property
+    def output(self) -> T | None:
+        """Final typed output (available after iteration completes)."""
+        return self.result.output if self.result else None
+
+    def __iter__(self) -> Iterator[MessageResponse]:
+        cursor: str | None = None
+        deadline = time.monotonic() + self._timeout
+
+        while time.monotonic() < deadline:
+            resp = self._sessions.messages(self.session_id, after=cursor, limit=100)
+            for msg in resp.messages:
+                yield msg
+                cursor = str(msg.id)
+
+            session = self._sessions.get(self.session_id)
+            if session.status.value in _TERMINAL_STATUSES:
+                resp = self._sessions.messages(self.session_id, after=cursor, limit=100)
+                for msg in resp.messages:
+                    yield msg
+                self.result = SessionResult(session, _parse_output(session.output, self._output_schema))
+                return
+
+            time.sleep(self._interval)
+
+        raise TimeoutError(f"Session {self.session_id} did not complete within {self._timeout}s")

--- a/docs/cloud/agent/streaming.mdx
+++ b/docs/cloud/agent/streaming.mdx
@@ -1,6 +1,6 @@
 ---
 title: Live messages
-description: "Poll the agent's message history in real time to build custom UIs or monitor progress."
+description: "Stream the agent's messages in real time to build custom UIs or monitor progress."
 icon: message-lines
 ---
 
@@ -8,7 +8,111 @@ icon: message-lines
   Want a ready-made UI? See the [Chat UI tutorial](/cloud/tutorials/chat-ui).
 </Note>
 
-Poll `sessions.messages()` while a task runs to get the agent's reasoning, tool calls, and results. Each message has a `role` (`user`, `assistant`, `tool`), a `summary` for display, and a `type` (e.g. `browser_action`, `browser_action_result`). See [List session messages](/cloud/api-v3/sessions/list-session-messages) for all fields.
+Stream messages as the agent works — reasoning, tool calls, browser actions, and results.
+
+<CodeGroup>
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+
+run = client.run("Find the top story on Hacker News")
+async for msg in run:
+    print(f"[{msg.role}] {msg.summary}")
+
+print(run.result.output)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+
+const client = new BrowserUse();
+
+const run = client.run("Find the top story on Hacker News");
+for await (const msg of run) {
+  console.log(`[${msg.role}] ${msg.summary}`);
+}
+
+console.log(run.result.output);
+```
+</CodeGroup>
+
+## Follow-up tasks
+
+Each `run()` only streams messages from its own task — not the entire session history.
+
+<CodeGroup>
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+session = await client.sessions.create(keep_alive=True)
+
+run1 = client.run("Search flights NYC to London", session_id=session.id)
+async for msg in run1:
+    print(f"[Task 1] {msg.summary}")
+
+# Human picks a flight...
+
+run2 = client.run("Get details of the selected flight", session_id=session.id)
+async for msg in run2:
+    print(f"[Task 2] {msg.summary}")
+
+await client.sessions.stop(session.id)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+
+const client = new BrowserUse();
+const session = await client.sessions.create({ keepAlive: true });
+
+const run1 = client.run("Search flights NYC to London", { sessionId: session.id });
+for await (const msg of run1) {
+  console.log(`[Task 1] ${msg.summary}`);
+}
+
+// Human picks a flight...
+
+const run2 = client.run("Get details of the selected flight", { sessionId: session.id });
+for await (const msg of run2) {
+  console.log(`[Task 2] ${msg.summary}`);
+}
+
+await client.sessions.stop(session.id);
+```
+</CodeGroup>
+
+## Without streaming
+
+If you just need the final result:
+
+<CodeGroup>
+```python Python
+result = await client.run("Find the top story on Hacker News")
+print(result.output)
+```
+```typescript TypeScript
+const result = await client.run("Find the top story on Hacker News");
+console.log(result.output);
+```
+</CodeGroup>
+
+## Message fields
+
+Each message has:
+
+| Field | Description |
+|-------|-------------|
+| `role` | `user`, `assistant`, or `tool` |
+| `type` | `browser_action`, `browser_action_result`, `planning`, `completion`, etc. |
+| `summary` | One-liner for display (e.g. "Navigating to google.com") |
+| `data` | Full message content (JSON string) |
+| `screenshot_url` | Screenshot URL (on `browser_action_result` messages) |
+
+See [List session messages](/cloud/api-v3/sessions/list-session-messages) for all fields.
+
+## Manual polling
+
+If you need full control over the polling loop (e.g. custom interval, filtering):
 
 <CodeGroup>
 ```python Python
@@ -18,13 +122,12 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 client = AsyncBrowserUse()
 session = await client.sessions.create(task="Find the top story on Hacker News")
 
-seen = set()
+cursor = None
 while True:
-    msgs = await client.sessions.messages(session.id, limit=100)
+    msgs = await client.sessions.messages(session.id, after=cursor, limit=100)
     for m in msgs.messages:
-        if m.id not in seen:
-            seen.add(m.id)
-            print(f"[{m.role}] {m.summary}")
+        print(f"[{m.role}] {m.summary}")
+        cursor = m.id
 
     s = await client.sessions.get(session.id)
     if s.status in ("idle", "stopped", "error", "timed_out"):
@@ -41,24 +144,20 @@ const session = await client.sessions.create({
   task: "Find the top story on Hacker News",
 });
 
-const seen = new Set<string>();
+let cursor: string | undefined;
 while (true) {
-  const msgs = await client.sessions.messages(session.id, { limit: 100 });
+  const msgs = await client.sessions.messages(session.id, { after: cursor, limit: 100 });
   for (const m of msgs.messages) {
-    if (!seen.has(m.id)) {
-      seen.add(m.id);
-      console.log(`[${m.role}] ${m.summary}`);
-    }
+    console.log(`[${m.role}] ${m.summary}`);
+    cursor = m.id;
   }
 
   const s = await client.sessions.get(session.id);
   if (["idle", "stopped", "error", "timed_out"].includes(s.status)) {
+    console.log(s.output);
     break;
   }
   await new Promise((r) => setTimeout(r, 2000));
 }
-
-const result = await client.sessions.get(session.id);
-console.log(result.output);
 ```
 </CodeGroup>

--- a/docs/cloud/agent/streaming.mdx
+++ b/docs/cloud/agent/streaming.mdx
@@ -8,7 +8,7 @@ icon: message-lines
   Want a ready-made UI? See the [Chat UI tutorial](/cloud/tutorials/chat-ui).
 </Note>
 
-Poll `sessions.messages()` while a task runs to get the agent's reasoning, tool calls, and results.
+Poll `sessions.messages()` while a task runs to get the agent's reasoning, tool calls, and results. Each message has a `role` (`user`, `assistant`, `tool`), a `summary` for display, and a `type` (e.g. `browser_action`, `browser_action_result`). See [List session messages](/cloud/api-v3/sessions/list-session-messages) for all fields.
 
 <CodeGroup>
 ```python Python
@@ -17,22 +17,20 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 session = await client.sessions.create(task="Find the top story on Hacker News")
-session_id = session.id
 
 seen = set()
 while True:
-    msgs = await client.sessions.messages(session_id, limit=100)
+    msgs = await client.sessions.messages(session.id, limit=100)
     for m in msgs.messages:
-        if str(m.id) not in seen:
-            seen.add(str(m.id))
-            print(f"[{m.role}] {m.data[:200]}")
+        if m.id not in seen:
+            seen.add(m.id)
+            print(f"[{m.role}] {m.summary}")
 
-    s = await client.sessions.get(session_id)
-    if s.status.value in ("idle", "stopped", "error", "timed_out"):
+    s = await client.sessions.get(session.id)
+    if s.status in ("idle", "stopped", "error", "timed_out"):
         break
     await asyncio.sleep(2)
 
-# Final output
 print(s.output)
 ```
 ```typescript TypeScript
@@ -49,7 +47,7 @@ while (true) {
   for (const m of msgs.messages) {
     if (!seen.has(m.id)) {
       seen.add(m.id);
-      console.log(`[${m.role}] ${m.data.slice(0, 200)}`);
+      console.log(`[${m.role}] ${m.summary}`);
     }
   }
 
@@ -60,10 +58,7 @@ while (true) {
   await new Promise((r) => setTimeout(r, 2000));
 }
 
-// Final output
 const result = await client.sessions.get(session.id);
 console.log(result.output);
 ```
 </CodeGroup>
-
-Each message has a `role` (`user`, `assistant`, `tool`), a `summary` for display, and a `type` (e.g. `browser_action`, `browser_action_result`). Browser action results include a `screenshot_url`. See [List session messages](/cloud/api-v3/sessions/list-session-messages) for all fields.

--- a/docs/cloud/agent/streaming.mdx
+++ b/docs/cloud/agent/streaming.mdx
@@ -36,66 +36,6 @@ console.log(run.result.output);
 ```
 </CodeGroup>
 
-## Follow-up tasks
-
-Each `run()` only streams messages from its own task — not the entire session history.
-
-<CodeGroup>
-```python Python
-from browser_use_sdk.v3 import AsyncBrowserUse
-
-client = AsyncBrowserUse()
-session = await client.sessions.create(keep_alive=True)
-
-run1 = client.run("Search flights NYC to London", session_id=session.id)
-async for msg in run1:
-    print(f"[Task 1] {msg.summary}")
-
-# Human picks a flight...
-
-run2 = client.run("Get details of the selected flight", session_id=session.id)
-async for msg in run2:
-    print(f"[Task 2] {msg.summary}")
-
-await client.sessions.stop(session.id)
-```
-```typescript TypeScript
-import { BrowserUse } from "browser-use-sdk/v3";
-
-const client = new BrowserUse();
-const session = await client.sessions.create({ keepAlive: true });
-
-const run1 = client.run("Search flights NYC to London", { sessionId: session.id });
-for await (const msg of run1) {
-  console.log(`[Task 1] ${msg.summary}`);
-}
-
-// Human picks a flight...
-
-const run2 = client.run("Get details of the selected flight", { sessionId: session.id });
-for await (const msg of run2) {
-  console.log(`[Task 2] ${msg.summary}`);
-}
-
-await client.sessions.stop(session.id);
-```
-</CodeGroup>
-
-## Without streaming
-
-If you just need the final result:
-
-<CodeGroup>
-```python Python
-result = await client.run("Find the top story on Hacker News")
-print(result.output)
-```
-```typescript TypeScript
-const result = await client.run("Find the top story on Hacker News");
-console.log(result.output);
-```
-</CodeGroup>
-
 ## Message fields
 
 Each message has:

--- a/docs/cloud/browser/live-preview.mdx
+++ b/docs/cloud/browser/live-preview.mdx
@@ -14,7 +14,7 @@ import asyncio
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
-session = await client.sessions.create("Check how many GitHub stars browser-use has")
+session = await client.sessions.create(task="Check how many GitHub stars browser-use has")
 
 # liveUrl becomes available once the browser is ready
 while True:

--- a/docs/cloud/openapi/v3.json
+++ b/docs/cloud/openapi/v3.json
@@ -1,3623 +1,3644 @@
 {
-    "openapi": "3.1.0",
-    "info": {
-        "title": "Browser Use Public API v3",
-        "summary": "Browser Use session-based agent API (v3)",
-        "version": "3.0.0"
-    },
-    "servers": [
-        {
-            "url": "https://api.browser-use.com/api/v3",
-            "description": "Production server"
-        }
-    ],
-    "paths": {
-        "/sessions": {
-            "post": {
-                "tags": [
-                    "Sessions"
-                ],
-                "summary": "Create Session",
-                "description": "Create a session and/or dispatch a task.\n\n- Without session_id, without task: creates a new idle session (e.g. for file uploads).\n- Without session_id, with task: creates a new session and dispatches the task.\n- With session_id, with task: dispatches the task to an existing idle session.\n- With session_id, without task: 422 \u2014 task is required when targeting an existing session.\n\nIf keep_alive is false (default), the session auto-stops when the task finishes.\nIf keep_alive is true, the session stays idle after the task, ready for follow-ups.",
-                "operationId": "create_session_sessions_post",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/RunTaskRequest"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SessionResponse"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "get": {
-                "tags": [
-                    "Sessions"
-                ],
-                "summary": "List Sessions",
-                "description": "List sessions for the authenticated project.",
-                "operationId": "list_sessions_sessions_get",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "page",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "minimum": 1,
-                            "default": 1,
-                            "title": "Page"
-                        }
-                    },
-                    {
-                        "name": "page_size",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "maximum": 100,
-                            "minimum": 1,
-                            "default": 20,
-                            "title": "Page Size"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SessionListResponse"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/sessions/{session_id}": {
-            "get": {
-                "tags": [
-                    "Sessions"
-                ],
-                "summary": "Get Session",
-                "description": "Get session details. Use this to poll for task completion and output.",
-                "operationId": "get_session_sessions__session_id__get",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "session_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Session Id"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SessionResponse"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "tags": [
-                    "Sessions"
-                ],
-                "summary": "Delete Session",
-                "description": "Soft-delete a session. Stops the sandbox first if still running.",
-                "operationId": "delete_session_sessions__session_id__delete",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "session_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Session Id"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "Successful Response"
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/sessions/{session_id}/stop": {
-            "post": {
-                "tags": [
-                    "Sessions"
-                ],
-                "summary": "Stop Session",
-                "description": "Stop a session or the running task.\n\n- strategy=session (default): destroy sandbox entirely, session \u2192 stopped.\n- strategy=task: stop the running query, session stays alive (\u2192 idle).",
-                "operationId": "stop_session_sessions__session_id__stop_post",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "session_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Session Id"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/components/schemas/StopSessionRequest"
-                                    },
-                                    {
-                                        "type": "null"
-                                    }
-                                ],
-                                "title": "Body"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SessionResponse"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/sessions/{session_id}/messages": {
-            "get": {
-                "tags": [
-                    "Sessions"
-                ],
-                "summary": "List Session Messages",
-                "description": "Return messages for a session with cursor-based pagination (chronological order).",
-                "operationId": "list_session_messages_sessions__session_id__messages_get",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "session_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Session Id"
-                        }
-                    },
-                    {
-                        "name": "after",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "string",
-                                    "format": "uuid"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Cursor: return messages after this message ID",
-                            "title": "After"
-                        },
-                        "description": "Cursor: return messages after this message ID"
-                    },
-                    {
-                        "name": "before",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "string",
-                                    "format": "uuid"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "description": "Cursor: return messages before this message ID",
-                            "title": "Before"
-                        },
-                        "description": "Cursor: return messages before this message ID"
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "maximum": 100,
-                            "minimum": 1,
-                            "default": 10,
-                            "title": "Limit"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/MessageListResponse"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/sessions/{session_id}/files": {
-            "get": {
-                "tags": [
-                    "Files"
-                ],
-                "summary": "List Session Files",
-                "description": "List files in a session's workspace.\n\nReturns paginated file metadata. Pass includeUrls=true to get\npresigned download URLs (60s expiry) inline with each file.",
-                "operationId": "list_session_files_sessions__session_id__files_get",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "session_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Session Id"
-                        }
-                    },
-                    {
-                        "name": "prefix",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "default": "",
-                            "title": "Prefix"
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "maximum": 100,
-                            "minimum": 1,
-                            "default": 50,
-                            "title": "Limit"
-                        }
-                    },
-                    {
-                        "name": "cursor",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "Cursor"
-                        }
-                    },
-                    {
-                        "name": "includeUrls",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean",
-                            "default": false,
-                            "title": "Includeurls"
-                        }
-                    },
-                    {
-                        "name": "shallow",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean",
-                            "default": false,
-                            "title": "Shallow"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/FileListResponse"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/sessions/{session_id}/files/upload": {
-            "post": {
-                "tags": [
-                    "Files"
-                ],
-                "summary": "Upload Session Files",
-                "description": "Get presigned PUT URLs for uploading files to a session's workspace.\n\nFiles are placed under ``uploads/`` in the session's S3 prefix. After\nreceiving the URLs, PUT each file directly to S3 using the returned\n``uploadUrl`` with the matching ``Content-Type`` header.",
-                "operationId": "upload_session_files_sessions__session_id__files_upload_post",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "session_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Session Id"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/FileUploadRequest"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/FileUploadResponse"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/profiles": {
-            "get": {
-                "tags": [
-                    "Profiles"
-                ],
-                "summary": "List Profiles",
-                "description": "Get paginated list of profiles.\n\nUse the `query` parameter to search profiles by name or user_id.\nThis is useful when you have many profiles and need to find a specific user.\n\nExample: If you set `user_id` to your internal user identifier when creating profiles,\nyou can later search for that user by passing their identifier as the `query` parameter.",
-                "operationId": "list_profiles_profiles_get",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "pageSize",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "maximum": 100,
-                            "minimum": 1,
-                            "default": 10,
-                            "title": "Pagesize"
-                        }
-                    },
-                    {
-                        "name": "pageNumber",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "minimum": 1,
-                            "default": 1,
-                            "title": "Pagenumber"
-                        }
-                    },
-                    {
-                        "name": "query",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "string",
-                                    "maxLength": 200
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "Query"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProfileListResponse"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "tags": [
-                    "Profiles"
-                ],
-                "summary": "Create Profile",
-                "description": "Profiles allow you to preserve the state of the browser between tasks.\n\nThey are most commonly used to allow users to preserve the log-in state in the agent between tasks.\nYou'd normally create one profile per user and then use it for all their tasks.\n\nYou can set a `user_id` when creating a profile to associate it with a user in your system.\nThis allows you to later search for the profile using the GET /profiles endpoint with a query parameter.",
-                "operationId": "create_profile_profiles_post",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ProfileCreateRequest"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "201": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProfileView"
-                                }
-                            }
-                        }
-                    },
-                    "402": {
-                        "description": "Subscription required for additional profiles",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/InsufficientCreditsError"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Request validation failed",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/profiles/{profile_id}": {
-            "get": {
-                "tags": [
-                    "Profiles"
-                ],
-                "summary": "Get Profile",
-                "description": "Get profile details.",
-                "operationId": "get_profile_profiles__profile_id__get",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "profile_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Profile Id"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProfileView"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Profile not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProfileNotFoundError"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "patch": {
-                "tags": [
-                    "Profiles"
-                ],
-                "summary": "Update Profile",
-                "description": "Update a browser profile's information.",
-                "operationId": "update_profile_profiles__profile_id__patch",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "profile_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Profile Id"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/ProfileUpdateRequest"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProfileView"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Profile not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProfileNotFoundError"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "tags": [
-                    "Profiles"
-                ],
-                "summary": "Delete Browser Profile",
-                "description": "Permanently delete a browser profile and its configuration.",
-                "operationId": "delete_browser_profile_profiles__profile_id__delete",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "profile_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Profile Id"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "Successful Response"
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/billing/account": {
-            "get": {
-                "tags": [
-                    "Billing"
-                ],
-                "summary": "Get Account Billing",
-                "description": "Get authenticated account information including credit balance and account details.",
-                "operationId": "get_account_billing_billing_account_get",
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AccountView"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Project for a given API key not found!",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/AccountNotFoundError"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ]
-            }
-        },
-        "/browsers": {
-            "get": {
-                "tags": [
-                    "Browsers"
-                ],
-                "summary": "List Browser Sessions",
-                "description": "Get paginated list of browser sessions with optional status filtering.",
-                "operationId": "list_browser_sessions_browsers_get",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "pageSize",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "maximum": 100,
-                            "minimum": 1,
-                            "default": 10,
-                            "title": "Pagesize"
-                        }
-                    },
-                    {
-                        "name": "pageNumber",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "minimum": 1,
-                            "default": 1,
-                            "title": "Pagenumber"
-                        }
-                    },
-                    {
-                        "name": "filterBy",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/BrowserSessionStatus"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "Filterby"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/BrowserSessionListResponse"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "tags": [
-                    "Browsers"
-                ],
-                "summary": "Create Browser Session",
-                "description": "Create a new browser session.\n\n**Pricing:** Browser sessions are charged per hour with tiered pricing:\n- Pay As You Go users: $0.06/hour\n- Business/Scaleup subscribers: $0.03/hour (50% discount)\n\nThe full rate is charged upfront when the session starts.\nWhen you stop the session, any unused time is automatically refunded proportionally.\n\nBilling is rounded up to the minute (minimum 1 minute).\nFor example, if you stop a session after 30 minutes, you'll be refunded half the charged amount.\n\n**Session Limits:**\n- All users: Up to 4 hours per session",
-                "operationId": "create_browser_session_browsers_post",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/CreateBrowserSessionRequest"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "201": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/BrowserSessionItemView"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Session timeout limit exceeded (maximum 4 hours)",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SessionTimeoutLimitExceededError"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Profile not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProfileNotFoundError"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Request validation failed",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationError"
-                                }
-                            }
-                        }
-                    },
-                    "429": {
-                        "description": "Too many concurrent active sessions",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/TooManyConcurrentActiveSessionsError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/browsers/{session_id}": {
-            "get": {
-                "tags": [
-                    "Browsers"
-                ],
-                "summary": "Get Browser Session",
-                "description": "Get detailed browser session information including status and URLs.",
-                "operationId": "get_browser_session_browsers__session_id__get",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "session_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Session Id"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/BrowserSessionView"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Session not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SessionNotFoundError"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "patch": {
-                "tags": [
-                    "Browsers"
-                ],
-                "summary": "Update Browser Session",
-                "description": "Stop a browser session.\n\n**Refund:** When you stop a session, unused time is automatically refunded.\nIf the session ran for less than 1 hour, you'll receive a proportional refund.\nBilling is ceil to the nearest minute (minimum 1 minute).",
-                "operationId": "update_browser_session_browsers__session_id__patch",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "session_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Session Id"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/UpdateBrowserSessionRequest"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/BrowserSessionView"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Session not found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SessionNotFoundError"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Request validation failed",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/workspaces": {
-            "get": {
-                "tags": [
-                    "Workspaces"
-                ],
-                "summary": "List Workspaces",
-                "description": "Get paginated list of workspaces.",
-                "operationId": "list_workspaces_workspaces_get",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "pageSize",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "maximum": 100,
-                            "minimum": 1,
-                            "default": 10,
-                            "title": "Pagesize"
-                        }
-                    },
-                    {
-                        "name": "pageNumber",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "minimum": 1,
-                            "default": 1,
-                            "title": "Pagenumber"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkspaceListResponse"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "tags": [
-                    "Workspaces"
-                ],
-                "summary": "Create Workspace",
-                "description": "Create a new workspace for persistent shared file storage across sessions.",
-                "operationId": "create_workspace_workspaces_post",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/WorkspaceCreateRequest"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "201": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkspaceView"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/workspaces/{workspace_id}": {
-            "get": {
-                "tags": [
-                    "Workspaces"
-                ],
-                "summary": "Get Workspace",
-                "description": "Get workspace details.",
-                "operationId": "get_workspace_workspaces__workspace_id__get",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "workspace_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Workspace Id"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkspaceView"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "patch": {
-                "tags": [
-                    "Workspaces"
-                ],
-                "summary": "Update Workspace",
-                "description": "Update a workspace's name.",
-                "operationId": "update_workspace_workspaces__workspace_id__patch",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "workspace_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Workspace Id"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/WorkspaceUpdateRequest"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/WorkspaceView"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "tags": [
-                    "Workspaces"
-                ],
-                "summary": "Delete Workspace",
-                "description": "Delete a workspace and its S3 data.",
-                "operationId": "delete_workspace_workspaces__workspace_id__delete",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "workspace_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Workspace Id"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "Successful Response"
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/workspaces/{workspace_id}/files": {
-            "get": {
-                "tags": [
-                    "Workspaces"
-                ],
-                "summary": "List Workspace Files",
-                "description": "List files in a workspace's S3 prefix.",
-                "operationId": "list_workspace_files_workspaces__workspace_id__files_get",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "workspace_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Workspace Id"
-                        }
-                    },
-                    {
-                        "name": "prefix",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "default": "",
-                            "title": "Prefix"
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "maximum": 100,
-                            "minimum": 1,
-                            "default": 50,
-                            "title": "Limit"
-                        }
-                    },
-                    {
-                        "name": "cursor",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "Cursor"
-                        }
-                    },
-                    {
-                        "name": "includeUrls",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean",
-                            "default": false,
-                            "title": "Includeurls"
-                        }
-                    },
-                    {
-                        "name": "shallow",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean",
-                            "default": false,
-                            "title": "Shallow"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/FileListResponse"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "tags": [
-                    "Workspaces"
-                ],
-                "summary": "Delete Workspace File",
-                "description": "Delete a single file from a workspace.",
-                "operationId": "delete_workspace_file_workspaces__workspace_id__files_delete",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "workspace_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Workspace Id"
-                        }
-                    },
-                    {
-                        "name": "path",
-                        "in": "query",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "description": "Relative file path to delete",
-                            "title": "Path"
-                        },
-                        "description": "Relative file path to delete"
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "Successful Response"
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/workspaces/{workspace_id}/size": {
-            "get": {
-                "tags": [
-                    "Workspaces"
-                ],
-                "summary": "Get Workspace Size",
-                "description": "Get current storage usage for a workspace.",
-                "operationId": "get_workspace_size_workspaces__workspace_id__size_get",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "workspace_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Workspace Id"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {}
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/workspaces/{workspace_id}/files/upload": {
-            "post": {
-                "tags": [
-                    "Workspaces"
-                ],
-                "summary": "Upload Workspace Files",
-                "description": "Get presigned PUT URLs for uploading files to a workspace.",
-                "operationId": "upload_workspace_files_workspaces__workspace_id__files_upload_post",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "workspace_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Workspace Id"
-                        }
-                    },
-                    {
-                        "name": "prefix",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "description": "Directory prefix to upload into (e.g. \"uploads/\")",
-                            "default": "",
-                            "title": "Prefix"
-                        },
-                        "description": "Directory prefix to upload into (e.g. \"uploads/\")"
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/FileUploadRequest"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/FileUploadResponse"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "AccountNotFoundError": {
-                "properties": {
-                    "detail": {
-                        "type": "string",
-                        "title": "Detail",
-                        "default": "Account not found"
-                    }
-                },
-                "type": "object",
-                "title": "AccountNotFoundError",
-                "description": "Error response when an account is not found"
-            },
-            "AccountView": {
-                "properties": {
-                    "name": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Name",
-                        "description": "The name of the user"
-                    },
-                    "totalCreditsBalanceUsd": {
-                        "type": "number",
-                        "title": "Credits Balance USD",
-                        "description": "The total credits balance in USD"
-                    },
-                    "monthlyCreditsBalanceUsd": {
-                        "type": "number",
-                        "title": "Monthly Credits Balance USD",
-                        "description": "Monthly subscription credits balance in USD"
-                    },
-                    "additionalCreditsBalanceUsd": {
-                        "type": "number",
-                        "title": "Additional Credits Balance USD",
-                        "description": "Additional top-up credits balance in USD"
-                    },
-                    "rateLimit": {
-                        "type": "integer",
-                        "title": "Rate Limit",
-                        "description": "The rate limit for the account"
-                    },
-                    "planInfo": {
-                        "$ref": "#/components/schemas/PlanInfo",
-                        "title": "Plan Info",
-                        "description": "The plan information"
-                    },
-                    "projectId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "Project ID",
-                        "description": "The ID of the project"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "totalCreditsBalanceUsd",
-                    "monthlyCreditsBalanceUsd",
-                    "additionalCreditsBalanceUsd",
-                    "rateLimit",
-                    "planInfo",
-                    "projectId"
-                ],
-                "title": "AccountView",
-                "description": "View model for account information."
-            },
-            "BrowserSessionItemView": {
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "ID",
-                        "description": "Unique identifier for the session"
-                    },
-                    "status": {
-                        "$ref": "#/components/schemas/BrowserSessionStatus",
-                        "title": "Status",
-                        "description": "Current status of the session (active/stopped)"
-                    },
-                    "liveUrl": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Live URL",
-                        "description": "URL where the browser can be viewed live in real-time"
-                    },
-                    "cdpUrl": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "CDP URL",
-                        "description": "Chrome DevTools Protocol URL for browser automation"
-                    },
-                    "timeoutAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Timeout At",
-                        "description": "Timestamp when the session will timeout"
-                    },
-                    "startedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Started At",
-                        "description": "Timestamp when the session was created and started"
-                    },
-                    "finishedAt": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Finished At",
-                        "description": "Timestamp when the session was stopped (None if still active)"
-                    },
-                    "proxyUsedMb": {
-                        "type": "string",
-                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                        "title": "Proxy Used MB",
-                        "description": "Amount of proxy data used in MB",
-                        "default": "0"
-                    },
-                    "proxyCost": {
-                        "type": "string",
-                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                        "title": "Proxy Cost",
-                        "description": "Cost of proxy usage in USD",
-                        "default": "0"
-                    },
-                    "browserCost": {
-                        "type": "string",
-                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                        "title": "Browser Cost",
-                        "description": "Cost of browser session hosting in USD",
-                        "default": "0"
-                    },
-                    "agentSessionId": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "uuid"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Agent Session ID",
-                        "description": "ID of the agent session that created this browser (None for standalone BaaS sessions)"
-                    },
-                    "recordingUrl": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Recording URL",
-                        "description": "Presigned URL to download the session recording (available after session ends, if recording was enabled)"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "id",
-                    "status",
-                    "timeoutAt",
-                    "startedAt"
-                ],
-                "title": "BrowserSessionItemView",
-                "description": "View model for representing a browser session in list views."
-            },
-            "BrowserSessionListResponse": {
-                "properties": {
-                    "items": {
-                        "items": {
-                            "$ref": "#/components/schemas/BrowserSessionItemView"
-                        },
-                        "type": "array",
-                        "title": "Items",
-                        "description": "List of browser session views for the current page"
-                    },
-                    "totalItems": {
-                        "type": "integer",
-                        "title": "Total Items",
-                        "description": "Total number of items in the list"
-                    },
-                    "pageNumber": {
-                        "type": "integer",
-                        "title": "Page Number",
-                        "description": "Page number"
-                    },
-                    "pageSize": {
-                        "type": "integer",
-                        "title": "Page Size",
-                        "description": "Number of items per page"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "items",
-                    "totalItems",
-                    "pageNumber",
-                    "pageSize"
-                ],
-                "title": "BrowserSessionListResponse",
-                "description": "Response model for paginated browser session list requests."
-            },
-            "BrowserSessionStatus": {
-                "type": "string",
-                "enum": [
-                    "active",
-                    "stopped"
-                ],
-                "title": "BrowserSessionStatus",
-                "description": "Enumeration of possible browser session states\n\nAttributes:\n    ACTIVE: Session is currently active and running (browser is running)\n    STOPPED: Session has been stopped and is no longer active (browser is stopped)"
-            },
-            "BrowserSessionUpdateAction": {
-                "type": "string",
-                "enum": [
-                    "stop"
-                ],
-                "title": "BrowserSessionUpdateAction",
-                "description": "Available actions that can be performed on a browser session\n\nAttributes:\n    STOP: Stop the browser session (cannot be undone)"
-            },
-            "BrowserSessionView": {
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "ID",
-                        "description": "Unique identifier for the session"
-                    },
-                    "status": {
-                        "$ref": "#/components/schemas/BrowserSessionStatus",
-                        "title": "Status",
-                        "description": "Current status of the session (active/stopped)"
-                    },
-                    "liveUrl": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Live URL",
-                        "description": "URL where the browser can be viewed live in real-time"
-                    },
-                    "cdpUrl": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "CDP URL",
-                        "description": "Chrome DevTools Protocol URL for browser automation"
-                    },
-                    "timeoutAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Timeout At",
-                        "description": "Timestamp when the session will timeout"
-                    },
-                    "startedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Started At",
-                        "description": "Timestamp when the session was created and started"
-                    },
-                    "finishedAt": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Finished At",
-                        "description": "Timestamp when the session was stopped (None if still active)"
-                    },
-                    "proxyUsedMb": {
-                        "type": "string",
-                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                        "title": "Proxy Used MB",
-                        "description": "Amount of proxy data used in MB",
-                        "default": "0"
-                    },
-                    "proxyCost": {
-                        "type": "string",
-                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                        "title": "Proxy Cost",
-                        "description": "Cost of proxy usage in USD",
-                        "default": "0"
-                    },
-                    "browserCost": {
-                        "type": "string",
-                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                        "title": "Browser Cost",
-                        "description": "Cost of browser session hosting in USD",
-                        "default": "0"
-                    },
-                    "agentSessionId": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "uuid"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Agent Session ID",
-                        "description": "ID of the agent session that created this browser (None for standalone BaaS sessions)"
-                    },
-                    "recordingUrl": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Recording URL",
-                        "description": "Presigned URL to download the session recording (available after session ends, if recording was enabled)"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "id",
-                    "status",
-                    "timeoutAt",
-                    "startedAt"
-                ],
-                "title": "BrowserSessionView",
-                "description": "View model for representing a browser session."
-            },
-            "BuAgentSessionStatus": {
-                "type": "string",
-                "enum": [
-                    "created",
-                    "idle",
-                    "running",
-                    "stopped",
-                    "timed_out",
-                    "error"
-                ],
-                "title": "BuAgentSessionStatus"
-            },
-            "BuModel": {
-                "type": "string",
-                "enum": [
-                    "bu-mini",
-                    "bu-max",
-                    "bu-ultra"
-                ],
-                "title": "BuModel"
-            },
-            "CreateBrowserSessionRequest": {
-                "properties": {
-                    "profileId": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "uuid"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Profile ID",
-                        "description": "The ID of the profile to use for the session"
-                    },
-                    "proxyCountryCode": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/ProxyCountryCode"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Proxy Country Code",
-                        "description": "Country code for proxy location. Defaults to US. Set to null to disable proxy.",
-                        "default": "us"
-                    },
-                    "timeout": {
-                        "type": "integer",
-                        "title": "Timeout",
-                        "description": "The timeout for the session in minutes. All users can use up to 240 minutes (4 hours). Pay As You Go users are charged $0.06/hour, subscribers get 50% off.",
-                        "default": 60,
-                        "ge": 1,
-                        "le": 240
-                    },
-                    "browserScreenWidth": {
-                        "anyOf": [
-                            {
-                                "type": "integer",
-                                "maximum": 6144.0,
-                                "minimum": 320.0
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Browser Screen Width",
-                        "description": "Custom screen width in pixels for the browser."
-                    },
-                    "browserScreenHeight": {
-                        "anyOf": [
-                            {
-                                "type": "integer",
-                                "maximum": 3456.0,
-                                "minimum": 320.0
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Browser Screen Height",
-                        "description": "Custom screen height in pixels for the browser."
-                    },
-                    "allowResizing": {
-                        "type": "boolean",
-                        "title": "Allow Resizing",
-                        "description": "Whether to allow the browser to be resized during the session (not recommended since it reduces stealthiness).",
-                        "default": false
-                    },
-                    "customProxy": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/CustomProxy"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Custom Proxy",
-                        "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are only available on the Custom Enterprise plan."
-                    },
-                    "enableRecording": {
-                        "type": "boolean",
-                        "title": "Enable Recording",
-                        "description": "If True, enables session recording. Defaults to False.",
-                        "default": false
-                    }
-                },
-                "type": "object",
-                "title": "CreateBrowserSessionRequest",
-                "description": "Request model for creating a browser session."
-            },
-            "CustomProxy": {
-                "properties": {
-                    "host": {
-                        "type": "string",
-                        "maxLength": 255,
-                        "minLength": 1,
-                        "title": "Host",
-                        "description": "Host of the proxy."
-                    },
-                    "port": {
-                        "type": "integer",
-                        "maximum": 65535.0,
-                        "minimum": 1.0,
-                        "title": "Port",
-                        "description": "Port of the proxy."
-                    },
-                    "username": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "maxLength": 255,
-                                "minLength": 1
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Username",
-                        "description": "Username for proxy authentication."
-                    },
-                    "password": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "maxLength": 255,
-                                "minLength": 1
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Password",
-                        "description": "Password for proxy authentication."
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "host",
-                    "port"
-                ],
-                "title": "CustomProxy",
-                "description": "Request model for creating a custom proxy."
-            },
-            "FileInfo": {
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "title": "Path"
-                    },
-                    "size": {
-                        "type": "integer",
-                        "title": "Size"
-                    },
-                    "lastModified": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Lastmodified"
-                    },
-                    "url": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Url"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "path",
-                    "size",
-                    "lastModified"
-                ],
-                "title": "FileInfo",
-                "description": "A file in a session's workspace."
-            },
-            "FileListResponse": {
-                "properties": {
-                    "files": {
-                        "items": {
-                            "$ref": "#/components/schemas/FileInfo"
-                        },
-                        "type": "array",
-                        "title": "Files"
-                    },
-                    "folders": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "title": "Folders",
-                        "description": "Immediate sub-folder names at this prefix level"
-                    },
-                    "nextCursor": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Nextcursor"
-                    },
-                    "hasMore": {
-                        "type": "boolean",
-                        "title": "Hasmore",
-                        "default": false
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "files"
-                ],
-                "title": "FileListResponse",
-                "description": "Paginated file listing with optional presigned download URLs."
-            },
-            "FileUploadItem": {
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "maxLength": 255,
-                        "minLength": 1,
-                        "title": "Name",
-                        "description": "Filename, e.g. \"data.csv\""
-                    },
-                    "contentType": {
-                        "type": "string",
-                        "maxLength": 255,
-                        "title": "Contenttype",
-                        "description": "MIME type, e.g. \"text/csv\"",
-                        "default": "application/octet-stream"
-                    },
-                    "size": {
-                        "anyOf": [
-                            {
-                                "type": "integer",
-                                "minimum": 1.0
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Size",
-                        "description": "File size in bytes (required for workspace uploads)"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "name"
-                ],
-                "title": "FileUploadItem",
-                "description": "A single file to upload."
-            },
-            "FileUploadRequest": {
-                "properties": {
-                    "files": {
-                        "items": {
-                            "$ref": "#/components/schemas/FileUploadItem"
-                        },
-                        "type": "array",
-                        "maxItems": 10,
-                        "minItems": 1,
-                        "title": "Files"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "files"
-                ],
-                "title": "FileUploadRequest",
-                "description": "Request body for generating presigned upload URLs."
-            },
-            "FileUploadResponse": {
-                "properties": {
-                    "files": {
-                        "items": {
-                            "$ref": "#/components/schemas/FileUploadResponseItem"
-                        },
-                        "type": "array",
-                        "title": "Files"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "files"
-                ],
-                "title": "FileUploadResponse",
-                "description": "Presigned upload URLs for the requested files."
-            },
-            "FileUploadResponseItem": {
-                "properties": {
-                    "name": {
-                        "type": "string",
-                        "title": "Name"
-                    },
-                    "uploadUrl": {
-                        "type": "string",
-                        "title": "Uploadurl"
-                    },
-                    "path": {
-                        "type": "string",
-                        "title": "Path",
-                        "description": "S3-relative path, e.g. \"uploads/data.csv\""
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "name",
-                    "uploadUrl",
-                    "path"
-                ],
-                "title": "FileUploadResponseItem",
-                "description": "Presigned upload URL for a single file."
-            },
-            "HTTPValidationError": {
-                "properties": {
-                    "detail": {
-                        "items": {
-                            "$ref": "#/components/schemas/ValidationError"
-                        },
-                        "type": "array",
-                        "title": "Detail"
-                    }
-                },
-                "type": "object",
-                "title": "HTTPValidationError"
-            },
-            "InsufficientCreditsError": {
-                "properties": {
-                    "detail": {
-                        "type": "string",
-                        "title": "Detail",
-                        "default": "Insufficient credits"
-                    }
-                },
-                "type": "object",
-                "title": "InsufficientCreditsError",
-                "description": "Error response when there are insufficient credits"
-            },
-            "MessageListResponse": {
-                "properties": {
-                    "messages": {
-                        "items": {
-                            "$ref": "#/components/schemas/MessageResponse"
-                        },
-                        "type": "array",
-                        "title": "Messages"
-                    },
-                    "hasMore": {
-                        "type": "boolean",
-                        "title": "Hasmore"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "messages",
-                    "hasMore"
-                ],
-                "title": "MessageListResponse"
-            },
-            "MessageResponse": {
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "Id"
-                    },
-                    "sessionId": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "Sessionid"
-                    },
-                    "role": {
-                        "type": "string",
-                        "title": "Role"
-                    },
-                    "data": {
-                        "type": "string",
-                        "title": "Data"
-                    },
-                    "type": {
-                        "type": "string",
-                        "title": "Type",
-                        "description": "Coarse category: user_message, assistant_message, browser_action, file_operation, code_execution, integration, planning, completion, browser_action_result, browser_action_error, etc.",
-                        "default": ""
-                    },
-                    "summary": {
-                        "type": "string",
-                        "title": "Summary",
-                        "description": "One-liner human-readable description of the message (e.g. \"Navigating to google.com\", \"Clicking element #5\").",
-                        "default": ""
-                    },
-                    "screenshotUrl": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Screenshoturl"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Createdat"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "id",
-                    "sessionId",
-                    "role",
-                    "data",
-                    "createdAt"
-                ],
-                "title": "MessageResponse"
-            },
-            "PlanInfo": {
-                "properties": {
-                    "planName": {
-                        "type": "string",
-                        "title": "Plan Name",
-                        "description": "The name of the plan"
-                    },
-                    "subscriptionStatus": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Subscription Status",
-                        "description": "The status of the subscription"
-                    },
-                    "subscriptionId": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Subscription ID",
-                        "description": "The ID of the subscription"
-                    },
-                    "subscriptionCurrentPeriodEnd": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Subscription Current Period End",
-                        "description": "The end of the current period"
-                    },
-                    "subscriptionCanceledAt": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Subscription Canceled At",
-                        "description": "The date the subscription was canceled"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "planName",
-                    "subscriptionStatus",
-                    "subscriptionId",
-                    "subscriptionCurrentPeriodEnd",
-                    "subscriptionCanceledAt"
-                ],
-                "title": "PlanInfo",
-                "description": "View model for plan information"
-            },
-            "ProfileCreateRequest": {
-                "properties": {
-                    "name": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "maxLength": 100
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Name",
-                        "description": "Optional name for the profile"
-                    },
-                    "userId": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "maxLength": 255
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "User ID",
-                        "description": "Your internal user identifier for this profile. Use this to associate a profile with a user in your system."
-                    }
-                },
-                "type": "object",
-                "title": "ProfileCreateRequest",
-                "description": "Request model for creating a new profile."
-            },
-            "ProfileListResponse": {
-                "properties": {
-                    "items": {
-                        "items": {
-                            "$ref": "#/components/schemas/ProfileView"
-                        },
-                        "type": "array",
-                        "title": "Items",
-                        "description": "List of profile views for the current page"
-                    },
-                    "totalItems": {
-                        "type": "integer",
-                        "title": "Total Items",
-                        "description": "Total number of items in the list"
-                    },
-                    "pageNumber": {
-                        "type": "integer",
-                        "title": "Page Number",
-                        "description": "Page number"
-                    },
-                    "pageSize": {
-                        "type": "integer",
-                        "title": "Page Size",
-                        "description": "Number of items per page"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "items",
-                    "totalItems",
-                    "pageNumber",
-                    "pageSize"
-                ],
-                "title": "ProfileListResponse",
-                "description": "Response model for paginated profile list requests."
-            },
-            "ProfileNotFoundError": {
-                "properties": {
-                    "detail": {
-                        "type": "string",
-                        "title": "Detail",
-                        "default": "Profile not found"
-                    }
-                },
-                "type": "object",
-                "title": "ProfileNotFoundError",
-                "description": "Error response when a profile is not found"
-            },
-            "ProfileUpdateRequest": {
-                "properties": {
-                    "name": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "maxLength": 100
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Name",
-                        "description": "Optional name for the profile"
-                    },
-                    "userId": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "maxLength": 255
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "User ID",
-                        "description": "Your internal user identifier for this profile. Use this to associate a profile with a user in your system."
-                    }
-                },
-                "type": "object",
-                "title": "ProfileUpdateRequest",
-                "description": "Request model for updating a profile."
-            },
-            "ProfileView": {
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "ID",
-                        "description": "Unique identifier for the profile"
-                    },
-                    "userId": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "User ID",
-                        "description": "Your internal user identifier for this profile. Use this to associate a profile with a user in your system."
-                    },
-                    "name": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Name",
-                        "description": "Optional name for the profile"
-                    },
-                    "lastUsedAt": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Last Used At",
-                        "description": "Timestamp when the profile was last used"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Created At",
-                        "description": "Timestamp when the profile was created"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Updated At",
-                        "description": "Timestamp when the profile was last updated"
-                    },
-                    "cookieDomains": {
-                        "anyOf": [
-                            {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Cookie Domains",
-                        "description": "List of domain URLs that have cookies stored for this profile"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "id",
-                    "createdAt",
-                    "updatedAt"
-                ],
-                "title": "ProfileView",
-                "description": "View model for representing a profile. A profile lets you preserve the login state between sessions.\n\nWe recommend that you create a separate profile for each user of your app.\nYou can assign a user_id to each profile to easily identify which user the profile belongs to."
-            },
-            "ProxyCountryCode": {
-                "type": "string",
-                "enum": [
-                    "ad",
-                    "ae",
-                    "af",
-                    "ag",
-                    "ai",
-                    "al",
-                    "am",
-                    "an",
-                    "ao",
-                    "aq",
-                    "ar",
-                    "as",
-                    "at",
-                    "au",
-                    "aw",
-                    "az",
-                    "ba",
-                    "bb",
-                    "bd",
-                    "be",
-                    "bf",
-                    "bg",
-                    "bh",
-                    "bi",
-                    "bj",
-                    "bl",
-                    "bm",
-                    "bn",
-                    "bo",
-                    "bq",
-                    "br",
-                    "bs",
-                    "bt",
-                    "bv",
-                    "bw",
-                    "by",
-                    "bz",
-                    "ca",
-                    "cc",
-                    "cd",
-                    "cf",
-                    "cg",
-                    "ch",
-                    "ck",
-                    "cl",
-                    "cm",
-                    "co",
-                    "cr",
-                    "cs",
-                    "cu",
-                    "cv",
-                    "cw",
-                    "cx",
-                    "cy",
-                    "cz",
-                    "de",
-                    "dj",
-                    "dk",
-                    "dm",
-                    "do",
-                    "dz",
-                    "ec",
-                    "ee",
-                    "eg",
-                    "eh",
-                    "er",
-                    "es",
-                    "et",
-                    "fi",
-                    "fj",
-                    "fk",
-                    "fm",
-                    "fo",
-                    "fr",
-                    "ga",
-                    "gd",
-                    "ge",
-                    "gf",
-                    "gg",
-                    "gh",
-                    "gi",
-                    "gl",
-                    "gm",
-                    "gn",
-                    "gp",
-                    "gq",
-                    "gr",
-                    "gs",
-                    "gt",
-                    "gu",
-                    "gw",
-                    "gy",
-                    "hk",
-                    "hm",
-                    "hn",
-                    "hr",
-                    "ht",
-                    "hu",
-                    "id",
-                    "ie",
-                    "il",
-                    "im",
-                    "in",
-                    "iq",
-                    "ir",
-                    "is",
-                    "it",
-                    "je",
-                    "jm",
-                    "jo",
-                    "jp",
-                    "ke",
-                    "kg",
-                    "kh",
-                    "ki",
-                    "km",
-                    "kn",
-                    "kp",
-                    "kr",
-                    "kw",
-                    "ky",
-                    "kz",
-                    "la",
-                    "lb",
-                    "lc",
-                    "li",
-                    "lk",
-                    "lr",
-                    "ls",
-                    "lt",
-                    "lu",
-                    "lv",
-                    "ly",
-                    "ma",
-                    "mc",
-                    "md",
-                    "me",
-                    "mf",
-                    "mg",
-                    "mh",
-                    "mk",
-                    "ml",
-                    "mm",
-                    "mn",
-                    "mo",
-                    "mp",
-                    "mq",
-                    "mr",
-                    "ms",
-                    "mt",
-                    "mu",
-                    "mv",
-                    "mw",
-                    "mx",
-                    "my",
-                    "mz",
-                    "na",
-                    "nc",
-                    "ne",
-                    "nf",
-                    "ng",
-                    "ni",
-                    "nl",
-                    "no",
-                    "np",
-                    "nr",
-                    "nu",
-                    "nz",
-                    "om",
-                    "pa",
-                    "pe",
-                    "pf",
-                    "pg",
-                    "ph",
-                    "pk",
-                    "pl",
-                    "pm",
-                    "pn",
-                    "pr",
-                    "ps",
-                    "pt",
-                    "pw",
-                    "py",
-                    "qa",
-                    "re",
-                    "ro",
-                    "rs",
-                    "ru",
-                    "rw",
-                    "sa",
-                    "sb",
-                    "sc",
-                    "sd",
-                    "se",
-                    "sg",
-                    "sh",
-                    "si",
-                    "sj",
-                    "sk",
-                    "sl",
-                    "sm",
-                    "sn",
-                    "so",
-                    "sr",
-                    "ss",
-                    "st",
-                    "sv",
-                    "sx",
-                    "sy",
-                    "sz",
-                    "tc",
-                    "td",
-                    "tf",
-                    "tg",
-                    "th",
-                    "tj",
-                    "tk",
-                    "tl",
-                    "tm",
-                    "tn",
-                    "to",
-                    "tr",
-                    "tt",
-                    "tv",
-                    "tw",
-                    "tz",
-                    "ua",
-                    "ug",
-                    "uk",
-                    "us",
-                    "uy",
-                    "uz",
-                    "va",
-                    "vc",
-                    "ve",
-                    "vg",
-                    "vi",
-                    "vn",
-                    "vu",
-                    "wf",
-                    "ws",
-                    "xk",
-                    "ye",
-                    "yt",
-                    "za",
-                    "zm",
-                    "zw"
-                ],
-                "title": "ProxyCountryCode"
-            },
-            "RunTaskRequest": {
-                "properties": {
-                    "task": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Task"
-                    },
-                    "model": {
-                        "$ref": "#/components/schemas/BuModel",
-                        "default": "bu-mini"
-                    },
-                    "sessionId": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "uuid"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Sessionid"
-                    },
-                    "keepAlive": {
-                        "type": "boolean",
-                        "title": "Keepalive",
-                        "default": false
-                    },
-                    "maxCostUsd": {
-                        "anyOf": [
-                            {
-                                "type": "number"
-                            },
-                            {
-                                "type": "string",
-                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Maxcostusd"
-                    },
-                    "profileId": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "uuid"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Profileid"
-                    },
-                    "workspaceId": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "uuid"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Workspaceid"
-                    },
-                    "proxyCountryCode": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/ProxyCountryCode"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "default": "us"
-                    },
-                    "outputSchema": {
-                        "anyOf": [
-                            {
-                                "additionalProperties": true,
-                                "type": "object"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Outputschema"
-                    },
-                    "enableScheduledTasks": {
-                        "type": "boolean",
-                        "title": "Enablescheduledtasks",
-                        "default": false
-                    },
-                    "enableRecording": {
-                        "type": "boolean",
-                        "title": "Enablerecording",
-                        "default": false
-                    },
-                    "skills": {
-                        "type": "boolean",
-                        "title": "Skills",
-                        "default": true
-                    },
-                    "agentmail": {
-                        "type": "boolean",
-                        "title": "Agentmail",
-                        "default": true
-                    }
-                },
-                "type": "object",
-                "title": "RunTaskRequest",
-                "description": "Unified request for creating a session or dispatching a task.\n\n- Without session_id + without task: creates a new idle session (for file uploads, etc.)\n- Without session_id + with task: creates a new session and dispatches the task\n- With session_id + with task: dispatches the task to an existing idle session\n- With session_id + without task: 422 (task required when dispatching to existing session)"
-            },
-            "SessionListResponse": {
-                "properties": {
-                    "sessions": {
-                        "items": {
-                            "$ref": "#/components/schemas/SessionResponse"
-                        },
-                        "type": "array",
-                        "title": "Sessions"
-                    },
-                    "total": {
-                        "type": "integer",
-                        "title": "Total"
-                    },
-                    "page": {
-                        "type": "integer",
-                        "title": "Page"
-                    },
-                    "pageSize": {
-                        "type": "integer",
-                        "title": "Pagesize"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "sessions",
-                    "total",
-                    "page",
-                    "pageSize"
-                ],
-                "title": "SessionListResponse"
-            },
-            "SessionNotFoundError": {
-                "properties": {
-                    "detail": {
-                        "type": "string",
-                        "title": "Detail",
-                        "default": "Session not found"
-                    }
-                },
-                "type": "object",
-                "title": "SessionNotFoundError",
-                "description": "Error response when a session is not found"
-            },
-            "SessionResponse": {
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "Id"
-                    },
-                    "status": {
-                        "$ref": "#/components/schemas/BuAgentSessionStatus"
-                    },
-                    "model": {
-                        "$ref": "#/components/schemas/BuModel"
-                    },
-                    "title": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Title"
-                    },
-                    "output": {
-                        "anyOf": [
-                            {},
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Output"
-                    },
-                    "outputSchema": {
-                        "anyOf": [
-                            {
-                                "additionalProperties": true,
-                                "type": "object"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Outputschema"
-                    },
-                    "stepCount": {
-                        "type": "integer",
-                        "title": "Stepcount",
-                        "default": 0
-                    },
-                    "lastStepSummary": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Laststepsummary"
-                    },
-                    "isTaskSuccessful": {
-                        "anyOf": [
-                            {
-                                "type": "boolean"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Istasksuccessful"
-                    },
-                    "liveUrl": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Liveurl"
-                    },
-                    "recordingUrls": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "title": "Recordingurls",
-                        "default": []
-                    },
-                    "profileId": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "uuid"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Profileid"
-                    },
-                    "workspaceId": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "uuid"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Workspaceid"
-                    },
-                    "proxyCountryCode": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/ProxyCountryCode"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ]
-                    },
-                    "maxCostUsd": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Maxcostusd"
-                    },
-                    "totalInputTokens": {
-                        "type": "integer",
-                        "title": "Totalinputtokens",
-                        "default": 0
-                    },
-                    "totalOutputTokens": {
-                        "type": "integer",
-                        "title": "Totaloutputtokens",
-                        "default": 0
-                    },
-                    "proxyUsedMb": {
-                        "type": "string",
-                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                        "title": "Proxyusedmb",
-                        "default": "0"
-                    },
-                    "llmCostUsd": {
-                        "type": "string",
-                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                        "title": "Llmcostusd",
-                        "default": "0"
-                    },
-                    "proxyCostUsd": {
-                        "type": "string",
-                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                        "title": "Proxycostusd",
-                        "default": "0"
-                    },
-                    "browserCostUsd": {
-                        "type": "string",
-                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                        "title": "Browsercostusd",
-                        "default": "0"
-                    },
-                    "totalCostUsd": {
-                        "type": "string",
-                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-                        "title": "Totalcostusd",
-                        "default": "0"
-                    },
-                    "screenshotUrl": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Screenshoturl"
-                    },
-                    "agentmailEmail": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Agentmailemail"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Createdat"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Updatedat"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "id",
-                    "status",
-                    "model",
-                    "createdAt",
-                    "updatedAt"
-                ],
-                "title": "SessionResponse"
-            },
-            "SessionTimeoutLimitExceededError": {
-                "properties": {
-                    "detail": {
-                        "type": "string",
-                        "title": "Detail",
-                        "default": "Maximum session timeout is 4 hours (240 minutes)."
-                    }
-                },
-                "type": "object",
-                "title": "SessionTimeoutLimitExceededError",
-                "description": "Error response when session timeout exceeds the maximum allowed limit"
-            },
-            "StopSessionRequest": {
-                "properties": {
-                    "strategy": {
-                        "$ref": "#/components/schemas/StopStrategy",
-                        "default": "session"
-                    }
-                },
-                "type": "object",
-                "title": "StopSessionRequest"
-            },
-            "StopStrategy": {
-                "type": "string",
-                "enum": [
-                    "task",
-                    "session"
-                ],
-                "title": "StopStrategy"
-            },
-            "TooManyConcurrentActiveSessionsError": {
-                "properties": {
-                    "detail": {
-                        "type": "string",
-                        "title": "Detail",
-                        "default": "Too many concurrent active sessions. Please wait for one to finish, kill one, or upgrade your plan."
-                    }
-                },
-                "type": "object",
-                "title": "TooManyConcurrentActiveSessionsError",
-                "description": "Error response when user has too many concurrent active sessions"
-            },
-            "UpdateBrowserSessionRequest": {
-                "properties": {
-                    "action": {
-                        "$ref": "#/components/schemas/BrowserSessionUpdateAction",
-                        "title": "Action",
-                        "description": "The action to perform on the session"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "action"
-                ],
-                "title": "UpdateBrowserSessionRequest",
-                "description": "Request model for updating browser session state."
-            },
-            "ValidationError": {
-                "properties": {
-                    "loc": {
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "integer"
-                                }
-                            ]
-                        },
-                        "type": "array",
-                        "title": "Location"
-                    },
-                    "msg": {
-                        "type": "string",
-                        "title": "Message"
-                    },
-                    "type": {
-                        "type": "string",
-                        "title": "Error Type"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "loc",
-                    "msg",
-                    "type"
-                ],
-                "title": "ValidationError"
-            },
-            "WorkspaceCreateRequest": {
-                "properties": {
-                    "name": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "maxLength": 100
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Name",
-                        "description": "Optional name for the workspace"
-                    }
-                },
-                "type": "object",
-                "title": "WorkspaceCreateRequest",
-                "description": "Request model for creating a new workspace."
-            },
-            "WorkspaceListResponse": {
-                "properties": {
-                    "items": {
-                        "items": {
-                            "$ref": "#/components/schemas/WorkspaceView"
-                        },
-                        "type": "array",
-                        "title": "Items",
-                        "description": "List of workspace views for the current page"
-                    },
-                    "totalItems": {
-                        "type": "integer",
-                        "title": "Total Items",
-                        "description": "Total number of items in the list"
-                    },
-                    "pageNumber": {
-                        "type": "integer",
-                        "title": "Page Number",
-                        "description": "Page number"
-                    },
-                    "pageSize": {
-                        "type": "integer",
-                        "title": "Page Size",
-                        "description": "Number of items per page"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "items",
-                    "totalItems",
-                    "pageNumber",
-                    "pageSize"
-                ],
-                "title": "WorkspaceListResponse",
-                "description": "Response model for paginated workspace list requests."
-            },
-            "WorkspaceUpdateRequest": {
-                "properties": {
-                    "name": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "maxLength": 100
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Name",
-                        "description": "Optional name for the workspace"
-                    }
-                },
-                "type": "object",
-                "title": "WorkspaceUpdateRequest",
-                "description": "Request model for updating a workspace."
-            },
-            "WorkspaceView": {
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "ID",
-                        "description": "Unique identifier for the workspace"
-                    },
-                    "name": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Name",
-                        "description": "Optional name for the workspace"
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Created At",
-                        "description": "Timestamp when the workspace was created"
-                    },
-                    "updatedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Updated At",
-                        "description": "Timestamp when the workspace was last updated"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "id",
-                    "createdAt",
-                    "updatedAt"
-                ],
-                "title": "WorkspaceView",
-                "description": "View model for a workspace \u2014 persistent shared storage across sessions."
-            }
-        },
-        "securitySchemes": {
-            "APIKeyHeader": {
-                "type": "apiKey",
-                "in": "header",
-                "name": "X-Browser-Use-API-Key"
-            }
-        }
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Browser Use Public API v3",
+    "summary": "Browser Use session-based agent API (v3)",
+    "version": "3.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://api.browser-use.com/api/v3",
+      "description": "Production server"
     }
+  ],
+  "paths": {
+    "/sessions": {
+      "post": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "Create Session",
+        "description": "Create a session and/or dispatch a task.\n\n- Without session_id, without task: creates a new idle session (e.g. for file uploads).\n- Without session_id, with task: creates a new session and dispatches the task.\n- With session_id, with task: dispatches the task to an existing idle session.\n- With session_id, without task: 422 \u2014 task is required when targeting an existing session.\n\nIf keep_alive is false (default), the session auto-stops when the task finishes.\nIf keep_alive is true, the session stays idle after the task, ready for follow-ups.",
+        "operationId": "create_session_sessions_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RunTaskRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "List Sessions",
+        "description": "List sessions for the authenticated project.",
+        "operationId": "list_sessions_sessions_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Page Size"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{session_id}": {
+      "get": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "Get Session",
+        "description": "Get session details. Use this to poll for task completion and output.",
+        "operationId": "get_session_sessions__session_id__get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "Delete Session",
+        "description": "Soft-delete a session. Stops the sandbox first if still running.",
+        "operationId": "delete_session_sessions__session_id__delete",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{session_id}/stop": {
+      "post": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "Stop Session",
+        "description": "Stop a session or the running task.\n\n- strategy=session (default): destroy sandbox entirely, session \u2192 stopped.\n- strategy=task: stop the running query, session stays alive (\u2192 idle).",
+        "operationId": "stop_session_sessions__session_id__stop_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/StopSessionRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Body"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{session_id}/messages": {
+      "get": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "List Session Messages",
+        "description": "Return messages for a session with cursor-based pagination (chronological order).",
+        "operationId": "list_session_messages_sessions__session_id__messages_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Cursor: return messages after this message ID",
+              "title": "After"
+            },
+            "description": "Cursor: return messages after this message ID"
+          },
+          {
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Cursor: return messages before this message ID",
+              "title": "Before"
+            },
+            "description": "Cursor: return messages before this message ID"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{session_id}/files": {
+      "get": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "List Session Files",
+        "description": "List files in a session's workspace.\n\nReturns paginated file metadata. Pass includeUrls=true to get\npresigned download URLs (60s expiry) inline with each file.",
+        "operationId": "list_session_files_sessions__session_id__files_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "prefix",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "",
+              "title": "Prefix"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "name": "includeUrls",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Includeurls"
+            }
+          },
+          {
+            "name": "shallow",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Shallow"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{session_id}/files/upload": {
+      "post": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Upload Session Files",
+        "description": "Get presigned PUT URLs for uploading files to a session's workspace.\n\nFiles are placed under ``uploads/`` in the session's S3 prefix. After\nreceiving the URLs, PUT each file directly to S3 using the returned\n``uploadUrl`` with the matching ``Content-Type`` header.",
+        "operationId": "upload_session_files_sessions__session_id__files_upload_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileUploadRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileUploadResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/profiles": {
+      "get": {
+        "tags": [
+          "Profiles"
+        ],
+        "summary": "List Profiles",
+        "description": "Get paginated list of profiles.\n\nUse the `query` parameter to search profiles by name or user_id.\nThis is useful when you have many profiles and need to find a specific user.\n\nExample: If you set `user_id` to your internal user identifier when creating profiles,\nyou can later search for that user by passing their identifier as the `query` parameter.",
+        "operationId": "list_profiles_profiles_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10,
+              "title": "Pagesize"
+            }
+          },
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Pagenumber"
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 200
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Query"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Profiles"
+        ],
+        "summary": "Create Profile",
+        "description": "Profiles allow you to preserve the state of the browser between tasks.\n\nThey are most commonly used to allow users to preserve the log-in state in the agent between tasks.\nYou'd normally create one profile per user and then use it for all their tasks.\n\nYou can set a `user_id` when creating a profile to associate it with a user in your system.\nThis allows you to later search for the profile using the GET /profiles endpoint with a query parameter.",
+        "operationId": "create_profile_profiles_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProfileCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileView"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Subscription required for additional profiles",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsufficientCreditsError"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Request validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/profiles/{profile_id}": {
+      "get": {
+        "tags": [
+          "Profiles"
+        ],
+        "summary": "Get Profile",
+        "description": "Get profile details.",
+        "operationId": "get_profile_profiles__profile_id__get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "profile_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Profile Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileView"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Profile not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileNotFoundError"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Profiles"
+        ],
+        "summary": "Update Profile",
+        "description": "Update a browser profile's information.",
+        "operationId": "update_profile_profiles__profile_id__patch",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "profile_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Profile Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProfileUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileView"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Profile not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileNotFoundError"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Profiles"
+        ],
+        "summary": "Delete Browser Profile",
+        "description": "Permanently delete a browser profile and its configuration.",
+        "operationId": "delete_browser_profile_profiles__profile_id__delete",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "profile_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Profile Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/billing/account": {
+      "get": {
+        "tags": [
+          "Billing"
+        ],
+        "summary": "Get Account Billing",
+        "description": "Get authenticated account information including credit balance and account details.",
+        "operationId": "get_account_billing_billing_account_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountView"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Project for a given API key not found!",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountNotFoundError"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ]
+      }
+    },
+    "/browsers": {
+      "get": {
+        "tags": [
+          "Browsers"
+        ],
+        "summary": "List Browser Sessions",
+        "description": "Get paginated list of browser sessions with optional status filtering.",
+        "operationId": "list_browser_sessions_browsers_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10,
+              "title": "Pagesize"
+            }
+          },
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Pagenumber"
+            }
+          },
+          {
+            "name": "filterBy",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/BrowserSessionStatus"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Filterby"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrowserSessionListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Browsers"
+        ],
+        "summary": "Create Browser Session",
+        "description": "Create a new browser session.\n\n**Pricing:** Browser sessions are charged per hour with tiered pricing:\n- Pay As You Go users: $0.06/hour\n- Business/Scaleup subscribers: $0.03/hour (50% discount)\n\nThe full rate is charged upfront when the session starts.\nWhen you stop the session, any unused time is automatically refunded proportionally.\n\nBilling is rounded up to the minute (minimum 1 minute).\nFor example, if you stop a session after 30 minutes, you'll be refunded half the charged amount.\n\n**Session Limits:**\n- All users: Up to 4 hours per session",
+        "operationId": "create_browser_session_browsers_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateBrowserSessionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrowserSessionItemView"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Session timeout limit exceeded (maximum 4 hours)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionTimeoutLimitExceededError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Profile not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileNotFoundError"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Request validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many concurrent active sessions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TooManyConcurrentActiveSessionsError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/browsers/{session_id}": {
+      "get": {
+        "tags": [
+          "Browsers"
+        ],
+        "summary": "Get Browser Session",
+        "description": "Get detailed browser session information including status and URLs.",
+        "operationId": "get_browser_session_browsers__session_id__get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrowserSessionView"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionNotFoundError"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Browsers"
+        ],
+        "summary": "Update Browser Session",
+        "description": "Stop a browser session.\n\n**Refund:** When you stop a session, unused time is automatically refunded.\nIf the session ran for less than 1 hour, you'll receive a proportional refund.\nBilling is ceil to the nearest minute (minimum 1 minute).",
+        "operationId": "update_browser_session_browsers__session_id__patch",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBrowserSessionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrowserSessionView"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionNotFoundError"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Request validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workspaces": {
+      "get": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "List Workspaces",
+        "description": "Get paginated list of workspaces.",
+        "operationId": "list_workspaces_workspaces_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10,
+              "title": "Pagesize"
+            }
+          },
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Pagenumber"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Create Workspace",
+        "description": "Create a new workspace for persistent shared file storage across sessions.",
+        "operationId": "create_workspace_workspaces_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceView"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workspaces/{workspace_id}": {
+      "get": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Get Workspace",
+        "description": "Get workspace details.",
+        "operationId": "get_workspace_workspaces__workspace_id__get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceView"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Update Workspace",
+        "description": "Update a workspace's name.",
+        "operationId": "update_workspace_workspaces__workspace_id__patch",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceView"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Delete Workspace",
+        "description": "Delete a workspace and its S3 data.",
+        "operationId": "delete_workspace_workspaces__workspace_id__delete",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workspaces/{workspace_id}/files": {
+      "get": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "List Workspace Files",
+        "description": "List files in a workspace's S3 prefix.",
+        "operationId": "list_workspace_files_workspaces__workspace_id__files_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          },
+          {
+            "name": "prefix",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "",
+              "title": "Prefix"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "name": "includeUrls",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Includeurls"
+            }
+          },
+          {
+            "name": "shallow",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Shallow"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Delete Workspace File",
+        "description": "Delete a single file from a workspace.",
+        "operationId": "delete_workspace_file_workspaces__workspace_id__files_delete",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Relative file path to delete",
+              "title": "Path"
+            },
+            "description": "Relative file path to delete"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workspaces/{workspace_id}/size": {
+      "get": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Get Workspace Size",
+        "description": "Get current storage usage for a workspace.",
+        "operationId": "get_workspace_size_workspaces__workspace_id__size_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workspaces/{workspace_id}/files/upload": {
+      "post": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Upload Workspace Files",
+        "description": "Get presigned PUT URLs for uploading files to a workspace.",
+        "operationId": "upload_workspace_files_workspaces__workspace_id__files_upload_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Workspace Id"
+            }
+          },
+          {
+            "name": "prefix",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Directory prefix to upload into (e.g. \"uploads/\")",
+              "default": "",
+              "title": "Prefix"
+            },
+            "description": "Directory prefix to upload into (e.g. \"uploads/\")"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileUploadRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileUploadResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AccountNotFoundError": {
+        "properties": {
+          "detail": {
+            "type": "string",
+            "title": "Detail",
+            "default": "Account not found"
+          }
+        },
+        "type": "object",
+        "title": "AccountNotFoundError",
+        "description": "Error response when an account is not found"
+      },
+      "AccountView": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "The name of the user"
+          },
+          "totalCreditsBalanceUsd": {
+            "type": "number",
+            "title": "Credits Balance USD",
+            "description": "The total credits balance in USD"
+          },
+          "monthlyCreditsBalanceUsd": {
+            "type": "number",
+            "title": "Monthly Credits Balance USD",
+            "description": "Monthly subscription credits balance in USD"
+          },
+          "additionalCreditsBalanceUsd": {
+            "type": "number",
+            "title": "Additional Credits Balance USD",
+            "description": "Additional top-up credits balance in USD"
+          },
+          "rateLimit": {
+            "type": "integer",
+            "title": "Rate Limit",
+            "description": "The rate limit for the account"
+          },
+          "planInfo": {
+            "$ref": "#/components/schemas/PlanInfo",
+            "title": "Plan Info",
+            "description": "The plan information"
+          },
+          "projectId": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Project ID",
+            "description": "The ID of the project"
+          }
+        },
+        "type": "object",
+        "required": [
+          "totalCreditsBalanceUsd",
+          "monthlyCreditsBalanceUsd",
+          "additionalCreditsBalanceUsd",
+          "rateLimit",
+          "planInfo",
+          "projectId"
+        ],
+        "title": "AccountView",
+        "description": "View model for account information."
+      },
+      "BrowserSessionItemView": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "ID",
+            "description": "Unique identifier for the session"
+          },
+          "status": {
+            "$ref": "#/components/schemas/BrowserSessionStatus",
+            "title": "Status",
+            "description": "Current status of the session (active/stopped)"
+          },
+          "liveUrl": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Live URL",
+            "description": "URL where the browser can be viewed live in real-time"
+          },
+          "cdpUrl": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "CDP URL",
+            "description": "Chrome DevTools Protocol URL for browser automation"
+          },
+          "timeoutAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timeout At",
+            "description": "Timestamp when the session will timeout"
+          },
+          "startedAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Started At",
+            "description": "Timestamp when the session was created and started"
+          },
+          "finishedAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At",
+            "description": "Timestamp when the session was stopped (None if still active)"
+          },
+          "proxyUsedMb": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Proxy Used MB",
+            "description": "Amount of proxy data used in MB",
+            "default": "0"
+          },
+          "proxyCost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Proxy Cost",
+            "description": "Cost of proxy usage in USD",
+            "default": "0"
+          },
+          "browserCost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Browser Cost",
+            "description": "Cost of browser session hosting in USD",
+            "default": "0"
+          },
+          "agentSessionId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Session ID",
+            "description": "ID of the agent session that created this browser (None for standalone BaaS sessions)"
+          },
+          "recordingUrl": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recording URL",
+            "description": "Presigned URL to download the session recording (available after session ends, if recording was enabled)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "status",
+          "timeoutAt",
+          "startedAt"
+        ],
+        "title": "BrowserSessionItemView",
+        "description": "View model for representing a browser session in list views."
+      },
+      "BrowserSessionListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/BrowserSessionItemView"
+            },
+            "type": "array",
+            "title": "Items",
+            "description": "List of browser session views for the current page"
+          },
+          "totalItems": {
+            "type": "integer",
+            "title": "Total Items",
+            "description": "Total number of items in the list"
+          },
+          "pageNumber": {
+            "type": "integer",
+            "title": "Page Number",
+            "description": "Page number"
+          },
+          "pageSize": {
+            "type": "integer",
+            "title": "Page Size",
+            "description": "Number of items per page"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "totalItems",
+          "pageNumber",
+          "pageSize"
+        ],
+        "title": "BrowserSessionListResponse",
+        "description": "Response model for paginated browser session list requests."
+      },
+      "BrowserSessionStatus": {
+        "type": "string",
+        "enum": [
+          "active",
+          "stopped"
+        ],
+        "title": "BrowserSessionStatus",
+        "description": "Enumeration of possible browser session states\n\nAttributes:\n    ACTIVE: Session is currently active and running (browser is running)\n    STOPPED: Session has been stopped and is no longer active (browser is stopped)"
+      },
+      "BrowserSessionUpdateAction": {
+        "type": "string",
+        "enum": [
+          "stop"
+        ],
+        "title": "BrowserSessionUpdateAction",
+        "description": "Available actions that can be performed on a browser session\n\nAttributes:\n    STOP: Stop the browser session (cannot be undone)"
+      },
+      "BrowserSessionView": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "ID",
+            "description": "Unique identifier for the session"
+          },
+          "status": {
+            "$ref": "#/components/schemas/BrowserSessionStatus",
+            "title": "Status",
+            "description": "Current status of the session (active/stopped)"
+          },
+          "liveUrl": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Live URL",
+            "description": "URL where the browser can be viewed live in real-time"
+          },
+          "cdpUrl": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "CDP URL",
+            "description": "Chrome DevTools Protocol URL for browser automation"
+          },
+          "timeoutAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Timeout At",
+            "description": "Timestamp when the session will timeout"
+          },
+          "startedAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Started At",
+            "description": "Timestamp when the session was created and started"
+          },
+          "finishedAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At",
+            "description": "Timestamp when the session was stopped (None if still active)"
+          },
+          "proxyUsedMb": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Proxy Used MB",
+            "description": "Amount of proxy data used in MB",
+            "default": "0"
+          },
+          "proxyCost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Proxy Cost",
+            "description": "Cost of proxy usage in USD",
+            "default": "0"
+          },
+          "browserCost": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Browser Cost",
+            "description": "Cost of browser session hosting in USD",
+            "default": "0"
+          },
+          "agentSessionId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Session ID",
+            "description": "ID of the agent session that created this browser (None for standalone BaaS sessions)"
+          },
+          "recordingUrl": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Recording URL",
+            "description": "Presigned URL to download the session recording (available after session ends, if recording was enabled)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "status",
+          "timeoutAt",
+          "startedAt"
+        ],
+        "title": "BrowserSessionView",
+        "description": "View model for representing a browser session."
+      },
+      "BuAgentSessionStatus": {
+        "type": "string",
+        "enum": [
+          "created",
+          "idle",
+          "running",
+          "stopped",
+          "timed_out",
+          "error"
+        ],
+        "title": "BuAgentSessionStatus"
+      },
+      "BuModel": {
+        "type": "string",
+        "enum": [
+          "bu-mini",
+          "bu-max",
+          "bu-ultra"
+        ],
+        "title": "BuModel"
+      },
+      "CreateBrowserSessionRequest": {
+        "properties": {
+          "profileId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Profile ID",
+            "description": "The ID of the profile to use for the session"
+          },
+          "proxyCountryCode": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProxyCountryCode"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Proxy Country Code",
+            "description": "Country code for proxy location. Defaults to US. Set to null to disable proxy.",
+            "default": "us"
+          },
+          "timeout": {
+            "type": "integer",
+            "title": "Timeout",
+            "description": "The timeout for the session in minutes. All users can use up to 240 minutes (4 hours). Pay As You Go users are charged $0.06/hour, subscribers get 50% off.",
+            "default": 60,
+            "ge": 1,
+            "le": 240
+          },
+          "browserScreenWidth": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 6144.0,
+                "minimum": 320.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Browser Screen Width",
+            "description": "Custom screen width in pixels for the browser."
+          },
+          "browserScreenHeight": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 3456.0,
+                "minimum": 320.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Browser Screen Height",
+            "description": "Custom screen height in pixels for the browser."
+          },
+          "allowResizing": {
+            "type": "boolean",
+            "title": "Allow Resizing",
+            "description": "Whether to allow the browser to be resized during the session (not recommended since it reduces stealthiness).",
+            "default": false
+          },
+          "customProxy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CustomProxy"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Custom Proxy",
+            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are only available on the Custom Enterprise plan."
+          },
+          "enableRecording": {
+            "type": "boolean",
+            "title": "Enable Recording",
+            "description": "If True, enables session recording. Defaults to False.",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "CreateBrowserSessionRequest",
+        "description": "Request model for creating a browser session."
+      },
+      "CustomProxy": {
+        "properties": {
+          "host": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Host",
+            "description": "Host of the proxy."
+          },
+          "port": {
+            "type": "integer",
+            "maximum": 65535.0,
+            "minimum": 1.0,
+            "title": "Port",
+            "description": "Port of the proxy."
+          },
+          "username": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Username",
+            "description": "Username for proxy authentication."
+          },
+          "password": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Password",
+            "description": "Password for proxy authentication."
+          }
+        },
+        "type": "object",
+        "required": [
+          "host",
+          "port"
+        ],
+        "title": "CustomProxy",
+        "description": "Request model for creating a custom proxy."
+      },
+      "FileInfo": {
+        "properties": {
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "size": {
+            "type": "integer",
+            "title": "Size"
+          },
+          "lastModified": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Lastmodified"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url"
+          }
+        },
+        "type": "object",
+        "required": [
+          "path",
+          "size",
+          "lastModified"
+        ],
+        "title": "FileInfo",
+        "description": "A file in a session's workspace."
+      },
+      "FileListResponse": {
+        "properties": {
+          "files": {
+            "items": {
+              "$ref": "#/components/schemas/FileInfo"
+            },
+            "type": "array",
+            "title": "Files"
+          },
+          "folders": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Folders",
+            "description": "Immediate sub-folder names at this prefix level"
+          },
+          "nextCursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Nextcursor"
+          },
+          "hasMore": {
+            "type": "boolean",
+            "title": "Hasmore",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "files"
+        ],
+        "title": "FileListResponse",
+        "description": "Paginated file listing with optional presigned download URLs."
+      },
+      "FileUploadItem": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name",
+            "description": "Filename, e.g. \"data.csv\""
+          },
+          "contentType": {
+            "type": "string",
+            "maxLength": 255,
+            "title": "Contenttype",
+            "description": "MIME type, e.g. \"text/csv\"",
+            "default": "application/octet-stream"
+          },
+          "size": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size",
+            "description": "File size in bytes (required for workspace uploads)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "FileUploadItem",
+        "description": "A single file to upload."
+      },
+      "FileUploadRequest": {
+        "properties": {
+          "files": {
+            "items": {
+              "$ref": "#/components/schemas/FileUploadItem"
+            },
+            "type": "array",
+            "maxItems": 10,
+            "minItems": 1,
+            "title": "Files"
+          }
+        },
+        "type": "object",
+        "required": [
+          "files"
+        ],
+        "title": "FileUploadRequest",
+        "description": "Request body for generating presigned upload URLs."
+      },
+      "FileUploadResponse": {
+        "properties": {
+          "files": {
+            "items": {
+              "$ref": "#/components/schemas/FileUploadResponseItem"
+            },
+            "type": "array",
+            "title": "Files"
+          }
+        },
+        "type": "object",
+        "required": [
+          "files"
+        ],
+        "title": "FileUploadResponse",
+        "description": "Presigned upload URLs for the requested files."
+      },
+      "FileUploadResponseItem": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "uploadUrl": {
+            "type": "string",
+            "title": "Uploadurl"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path",
+            "description": "S3-relative path, e.g. \"uploads/data.csv\""
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "uploadUrl",
+          "path"
+        ],
+        "title": "FileUploadResponseItem",
+        "description": "Presigned upload URL for a single file."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "InsufficientCreditsError": {
+        "properties": {
+          "detail": {
+            "type": "string",
+            "title": "Detail",
+            "default": "Insufficient credits"
+          }
+        },
+        "type": "object",
+        "title": "InsufficientCreditsError",
+        "description": "Error response when there are insufficient credits"
+      },
+      "MessageListResponse": {
+        "properties": {
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/MessageResponse"
+            },
+            "type": "array",
+            "title": "Messages"
+          },
+          "hasMore": {
+            "type": "boolean",
+            "title": "Hasmore"
+          }
+        },
+        "type": "object",
+        "required": [
+          "messages",
+          "hasMore"
+        ],
+        "title": "MessageListResponse"
+      },
+      "MessageResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "sessionId": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Sessionid"
+          },
+          "role": {
+            "type": "string",
+            "title": "Role"
+          },
+          "data": {
+            "type": "string",
+            "title": "Data"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "description": "Coarse category: user_message, assistant_message, browser_action, file_operation, code_execution, integration, planning, completion, browser_action_result, browser_action_error, etc.",
+            "default": ""
+          },
+          "summary": {
+            "type": "string",
+            "title": "Summary",
+            "description": "One-liner human-readable description of the message (e.g. \"Navigating to google.com\", \"Clicking element #5\").",
+            "default": ""
+          },
+          "screenshotUrl": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Screenshoturl"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Createdat"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "sessionId",
+          "role",
+          "data",
+          "createdAt"
+        ],
+        "title": "MessageResponse"
+      },
+      "PlanInfo": {
+        "properties": {
+          "planName": {
+            "type": "string",
+            "title": "Plan Name",
+            "description": "The name of the plan"
+          },
+          "subscriptionStatus": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subscription Status",
+            "description": "The status of the subscription"
+          },
+          "subscriptionId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subscription ID",
+            "description": "The ID of the subscription"
+          },
+          "subscriptionCurrentPeriodEnd": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subscription Current Period End",
+            "description": "The end of the current period"
+          },
+          "subscriptionCanceledAt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subscription Canceled At",
+            "description": "The date the subscription was canceled"
+          }
+        },
+        "type": "object",
+        "required": [
+          "planName",
+          "subscriptionStatus",
+          "subscriptionId",
+          "subscriptionCurrentPeriodEnd",
+          "subscriptionCanceledAt"
+        ],
+        "title": "PlanInfo",
+        "description": "View model for plan information"
+      },
+      "ProfileCreateRequest": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 100
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "Optional name for the profile"
+          },
+          "userId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User ID",
+            "description": "Your internal user identifier for this profile. Use this to associate a profile with a user in your system."
+          }
+        },
+        "type": "object",
+        "title": "ProfileCreateRequest",
+        "description": "Request model for creating a new profile."
+      },
+      "ProfileListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ProfileView"
+            },
+            "type": "array",
+            "title": "Items",
+            "description": "List of profile views for the current page"
+          },
+          "totalItems": {
+            "type": "integer",
+            "title": "Total Items",
+            "description": "Total number of items in the list"
+          },
+          "pageNumber": {
+            "type": "integer",
+            "title": "Page Number",
+            "description": "Page number"
+          },
+          "pageSize": {
+            "type": "integer",
+            "title": "Page Size",
+            "description": "Number of items per page"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "totalItems",
+          "pageNumber",
+          "pageSize"
+        ],
+        "title": "ProfileListResponse",
+        "description": "Response model for paginated profile list requests."
+      },
+      "ProfileNotFoundError": {
+        "properties": {
+          "detail": {
+            "type": "string",
+            "title": "Detail",
+            "default": "Profile not found"
+          }
+        },
+        "type": "object",
+        "title": "ProfileNotFoundError",
+        "description": "Error response when a profile is not found"
+      },
+      "ProfileUpdateRequest": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 100
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "Optional name for the profile"
+          },
+          "userId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User ID",
+            "description": "Your internal user identifier for this profile. Use this to associate a profile with a user in your system."
+          }
+        },
+        "type": "object",
+        "title": "ProfileUpdateRequest",
+        "description": "Request model for updating a profile."
+      },
+      "ProfileView": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "ID",
+            "description": "Unique identifier for the profile"
+          },
+          "userId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User ID",
+            "description": "Your internal user identifier for this profile. Use this to associate a profile with a user in your system."
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "Optional name for the profile"
+          },
+          "lastUsedAt": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Used At",
+            "description": "Timestamp when the profile was last used"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "Timestamp when the profile was created"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At",
+            "description": "Timestamp when the profile was last updated"
+          },
+          "cookieDomains": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cookie Domains",
+            "description": "List of domain URLs that have cookies stored for this profile"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "createdAt",
+          "updatedAt"
+        ],
+        "title": "ProfileView",
+        "description": "View model for representing a profile. A profile lets you preserve the login state between sessions.\n\nWe recommend that you create a separate profile for each user of your app.\nYou can assign a user_id to each profile to easily identify which user the profile belongs to."
+      },
+      "ProxyCountryCode": {
+        "type": "string",
+        "enum": [
+          "ad",
+          "ae",
+          "af",
+          "ag",
+          "ai",
+          "al",
+          "am",
+          "an",
+          "ao",
+          "aq",
+          "ar",
+          "as",
+          "at",
+          "au",
+          "aw",
+          "az",
+          "ba",
+          "bb",
+          "bd",
+          "be",
+          "bf",
+          "bg",
+          "bh",
+          "bi",
+          "bj",
+          "bl",
+          "bm",
+          "bn",
+          "bo",
+          "bq",
+          "br",
+          "bs",
+          "bt",
+          "bv",
+          "bw",
+          "by",
+          "bz",
+          "ca",
+          "cc",
+          "cd",
+          "cf",
+          "cg",
+          "ch",
+          "ck",
+          "cl",
+          "cm",
+          "co",
+          "cr",
+          "cs",
+          "cu",
+          "cv",
+          "cw",
+          "cx",
+          "cy",
+          "cz",
+          "de",
+          "dj",
+          "dk",
+          "dm",
+          "do",
+          "dz",
+          "ec",
+          "ee",
+          "eg",
+          "eh",
+          "er",
+          "es",
+          "et",
+          "fi",
+          "fj",
+          "fk",
+          "fm",
+          "fo",
+          "fr",
+          "ga",
+          "gd",
+          "ge",
+          "gf",
+          "gg",
+          "gh",
+          "gi",
+          "gl",
+          "gm",
+          "gn",
+          "gp",
+          "gq",
+          "gr",
+          "gs",
+          "gt",
+          "gu",
+          "gw",
+          "gy",
+          "hk",
+          "hm",
+          "hn",
+          "hr",
+          "ht",
+          "hu",
+          "id",
+          "ie",
+          "il",
+          "im",
+          "in",
+          "iq",
+          "ir",
+          "is",
+          "it",
+          "je",
+          "jm",
+          "jo",
+          "jp",
+          "ke",
+          "kg",
+          "kh",
+          "ki",
+          "km",
+          "kn",
+          "kp",
+          "kr",
+          "kw",
+          "ky",
+          "kz",
+          "la",
+          "lb",
+          "lc",
+          "li",
+          "lk",
+          "lr",
+          "ls",
+          "lt",
+          "lu",
+          "lv",
+          "ly",
+          "ma",
+          "mc",
+          "md",
+          "me",
+          "mf",
+          "mg",
+          "mh",
+          "mk",
+          "ml",
+          "mm",
+          "mn",
+          "mo",
+          "mp",
+          "mq",
+          "mr",
+          "ms",
+          "mt",
+          "mu",
+          "mv",
+          "mw",
+          "mx",
+          "my",
+          "mz",
+          "na",
+          "nc",
+          "ne",
+          "nf",
+          "ng",
+          "ni",
+          "nl",
+          "no",
+          "np",
+          "nr",
+          "nu",
+          "nz",
+          "om",
+          "pa",
+          "pe",
+          "pf",
+          "pg",
+          "ph",
+          "pk",
+          "pl",
+          "pm",
+          "pn",
+          "pr",
+          "ps",
+          "pt",
+          "pw",
+          "py",
+          "qa",
+          "re",
+          "ro",
+          "rs",
+          "ru",
+          "rw",
+          "sa",
+          "sb",
+          "sc",
+          "sd",
+          "se",
+          "sg",
+          "sh",
+          "si",
+          "sj",
+          "sk",
+          "sl",
+          "sm",
+          "sn",
+          "so",
+          "sr",
+          "ss",
+          "st",
+          "sv",
+          "sx",
+          "sy",
+          "sz",
+          "tc",
+          "td",
+          "tf",
+          "tg",
+          "th",
+          "tj",
+          "tk",
+          "tl",
+          "tm",
+          "tn",
+          "to",
+          "tr",
+          "tt",
+          "tv",
+          "tw",
+          "tz",
+          "ua",
+          "ug",
+          "uk",
+          "us",
+          "uy",
+          "uz",
+          "va",
+          "vc",
+          "ve",
+          "vg",
+          "vi",
+          "vn",
+          "vu",
+          "wf",
+          "ws",
+          "xk",
+          "ye",
+          "yt",
+          "za",
+          "zm",
+          "zw"
+        ],
+        "title": "ProxyCountryCode"
+      },
+      "RunTaskRequest": {
+        "properties": {
+          "task": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task"
+          },
+          "model": {
+            "$ref": "#/components/schemas/BuModel",
+            "default": "bu-mini"
+          },
+          "sessionId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sessionid"
+          },
+          "keepAlive": {
+            "type": "boolean",
+            "title": "Keepalive",
+            "default": false
+          },
+          "maxCostUsd": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Maxcostusd"
+          },
+          "profileId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Profileid"
+          },
+          "workspaceId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workspaceid"
+          },
+          "proxyCountryCode": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProxyCountryCode"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "us"
+          },
+          "outputSchema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Outputschema"
+          },
+          "enableScheduledTasks": {
+            "type": "boolean",
+            "title": "Enablescheduledtasks",
+            "default": false
+          },
+          "enableRecording": {
+            "type": "boolean",
+            "title": "Enablerecording",
+            "default": false
+          },
+          "skills": {
+            "type": "boolean",
+            "title": "Skills",
+            "default": true
+          },
+          "agentmail": {
+            "type": "boolean",
+            "title": "Agentmail",
+            "default": true
+          }
+        },
+        "type": "object",
+        "title": "RunTaskRequest",
+        "description": "Unified request for creating a session or dispatching a task.\n\n- Without session_id + without task: creates a new idle session (for file uploads, etc.)\n- Without session_id + with task: creates a new session and dispatches the task\n- With session_id + with task: dispatches the task to an existing idle session\n- With session_id + without task: 422 (task required when dispatching to existing session)"
+      },
+      "SessionListResponse": {
+        "properties": {
+          "sessions": {
+            "items": {
+              "$ref": "#/components/schemas/SessionResponse"
+            },
+            "type": "array",
+            "title": "Sessions"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page"
+          },
+          "pageSize": {
+            "type": "integer",
+            "title": "Pagesize"
+          }
+        },
+        "type": "object",
+        "required": [
+          "sessions",
+          "total",
+          "page",
+          "pageSize"
+        ],
+        "title": "SessionListResponse"
+      },
+      "SessionNotFoundError": {
+        "properties": {
+          "detail": {
+            "type": "string",
+            "title": "Detail",
+            "default": "Session not found"
+          }
+        },
+        "type": "object",
+        "title": "SessionNotFoundError",
+        "description": "Error response when a session is not found"
+      },
+      "SessionResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "status": {
+            "$ref": "#/components/schemas/BuAgentSessionStatus"
+          },
+          "model": {
+            "$ref": "#/components/schemas/BuModel"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "output": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output"
+          },
+          "outputSchema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Outputschema"
+          },
+          "stepCount": {
+            "type": "integer",
+            "title": "Stepcount",
+            "default": 0
+          },
+          "lastStepSummary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Laststepsummary"
+          },
+          "isTaskSuccessful": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Istasksuccessful"
+          },
+          "liveUrl": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Liveurl"
+          },
+          "recordingUrls": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Recordingurls",
+            "default": []
+          },
+          "profileId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Profileid"
+          },
+          "workspaceId": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workspaceid"
+          },
+          "proxyCountryCode": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProxyCountryCode"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "maxCostUsd": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Maxcostusd"
+          },
+          "totalInputTokens": {
+            "type": "integer",
+            "title": "Totalinputtokens",
+            "default": 0
+          },
+          "totalOutputTokens": {
+            "type": "integer",
+            "title": "Totaloutputtokens",
+            "default": 0
+          },
+          "proxyUsedMb": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Proxyusedmb",
+            "default": "0"
+          },
+          "llmCostUsd": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Llmcostusd",
+            "default": "0"
+          },
+          "proxyCostUsd": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Proxycostusd",
+            "default": "0"
+          },
+          "browserCostUsd": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Browsercostusd",
+            "default": "0"
+          },
+          "totalCostUsd": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "title": "Totalcostusd",
+            "default": "0"
+          },
+          "screenshotUrl": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Screenshoturl"
+          },
+          "agentmailEmail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agentmailemail"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Createdat"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updatedat"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "status",
+          "model",
+          "createdAt",
+          "updatedAt"
+        ],
+        "title": "SessionResponse"
+      },
+      "SessionTimeoutLimitExceededError": {
+        "properties": {
+          "detail": {
+            "type": "string",
+            "title": "Detail",
+            "default": "Maximum session timeout is 4 hours (240 minutes)."
+          }
+        },
+        "type": "object",
+        "title": "SessionTimeoutLimitExceededError",
+        "description": "Error response when session timeout exceeds the maximum allowed limit"
+      },
+      "StopSessionRequest": {
+        "properties": {
+          "strategy": {
+            "$ref": "#/components/schemas/StopStrategy",
+            "default": "session"
+          }
+        },
+        "type": "object",
+        "title": "StopSessionRequest"
+      },
+      "StopStrategy": {
+        "type": "string",
+        "enum": [
+          "task",
+          "session"
+        ],
+        "title": "StopStrategy"
+      },
+      "TooManyConcurrentActiveSessionsError": {
+        "properties": {
+          "detail": {
+            "type": "string",
+            "title": "Detail",
+            "default": "Too many concurrent active sessions. Please wait for one to finish, kill one, or upgrade your plan."
+          }
+        },
+        "type": "object",
+        "title": "TooManyConcurrentActiveSessionsError",
+        "description": "Error response when user has too many concurrent active sessions"
+      },
+      "UpdateBrowserSessionRequest": {
+        "properties": {
+          "action": {
+            "$ref": "#/components/schemas/BrowserSessionUpdateAction",
+            "title": "Action",
+            "description": "The action to perform on the session"
+          }
+        },
+        "type": "object",
+        "required": [
+          "action"
+        ],
+        "title": "UpdateBrowserSessionRequest",
+        "description": "Request model for updating browser session state."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      },
+      "WorkspaceCreateRequest": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 100
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "Optional name for the workspace"
+          }
+        },
+        "type": "object",
+        "title": "WorkspaceCreateRequest",
+        "description": "Request model for creating a new workspace."
+      },
+      "WorkspaceListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceView"
+            },
+            "type": "array",
+            "title": "Items",
+            "description": "List of workspace views for the current page"
+          },
+          "totalItems": {
+            "type": "integer",
+            "title": "Total Items",
+            "description": "Total number of items in the list"
+          },
+          "pageNumber": {
+            "type": "integer",
+            "title": "Page Number",
+            "description": "Page number"
+          },
+          "pageSize": {
+            "type": "integer",
+            "title": "Page Size",
+            "description": "Number of items per page"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "totalItems",
+          "pageNumber",
+          "pageSize"
+        ],
+        "title": "WorkspaceListResponse",
+        "description": "Response model for paginated workspace list requests."
+      },
+      "WorkspaceUpdateRequest": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 100
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "Optional name for the workspace"
+          }
+        },
+        "type": "object",
+        "title": "WorkspaceUpdateRequest",
+        "description": "Request model for updating a workspace."
+      },
+      "WorkspaceView": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "ID",
+            "description": "Unique identifier for the workspace"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "Optional name for the workspace"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "Timestamp when the workspace was created"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At",
+            "description": "Timestamp when the workspace was last updated"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "createdAt",
+          "updatedAt"
+        ],
+        "title": "WorkspaceView",
+        "description": "View model for a workspace \u2014 persistent shared storage across sessions."
+      }
+    },
+    "securitySchemes": {
+      "APIKeyHeader": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Browser-Use-API-Key"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Sessions"
+    },
+    {
+      "name": "Browsers"
+    },
+    {
+      "name": "Profiles"
+    },
+    {
+      "name": "Workspaces",
+      "description": "File handling across sessions. Upload and download files, give the agent persistent memory."
+    },
+    {
+      "name": "Files"
+    },
+    {
+      "name": "Billing"
+    }
+  ]
 }

--- a/docs/cloud/openapi/v3.json
+++ b/docs/cloud/openapi/v3.json
@@ -1,3644 +1,3643 @@
 {
-  "openapi": "3.1.0",
-  "info": {
-    "title": "Browser Use Public API v3",
-    "summary": "Browser Use session-based agent API (v3)",
-    "version": "3.0.0"
-  },
-  "servers": [
-    {
-      "url": "https://api.browser-use.com/api/v3",
-      "description": "Production server"
-    }
-  ],
-  "paths": {
-    "/sessions": {
-      "post": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "Create Session",
-        "description": "Create a session and/or dispatch a task.\n\n- Without session_id, without task: creates a new idle session (e.g. for file uploads).\n- Without session_id, with task: creates a new session and dispatches the task.\n- With session_id, with task: dispatches the task to an existing idle session.\n- With session_id, without task: 422 \u2014 task is required when targeting an existing session.\n\nIf keep_alive is false (default), the session auto-stops when the task finishes.\nIf keep_alive is true, the session stays idle after the task, ready for follow-ups.",
-        "operationId": "create_session_sessions_post",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RunTaskRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "List Sessions",
-        "description": "List sessions for the authenticated project.",
-        "operationId": "list_sessions_sessions_get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1,
-              "title": "Page"
-            }
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 20,
-              "title": "Page Size"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionListResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Browser Use Public API v3",
+        "summary": "Browser Use session-based agent API (v3)",
+        "version": "3.0.0"
     },
-    "/sessions/{session_id}": {
-      "get": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "Get Session",
-        "description": "Get session details. Use this to poll for task completion and output.",
-        "operationId": "get_session_sessions__session_id__get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Session Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
+    "servers": [
+        {
+            "url": "https://api.browser-use.com/api/v3",
+            "description": "Production server"
         }
-      },
-      "delete": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "Delete Session",
-        "description": "Soft-delete a session. Stops the sandbox first if still running.",
-        "operationId": "delete_session_sessions__session_id__delete",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Session Id"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/sessions/{session_id}/stop": {
-      "post": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "Stop Session",
-        "description": "Stop a session or the running task.\n\n- strategy=session (default): destroy sandbox entirely, session \u2192 stopped.\n- strategy=task: stop the running query, session stays alive (\u2192 idle).",
-        "operationId": "stop_session_sessions__session_id__stop_post",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Session Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/StopSessionRequest"
-                  },
-                  {
-                    "type": "null"
-                  }
+    ],
+    "paths": {
+        "/sessions": {
+            "post": {
+                "tags": [
+                    "Sessions"
                 ],
-                "title": "Body"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/sessions/{session_id}/messages": {
-      "get": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "List Session Messages",
-        "description": "Return messages for a session with cursor-based pagination (chronological order).",
-        "operationId": "list_session_messages_sessions__session_id__messages_get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Session Id"
-            }
-          },
-          {
-            "name": "after",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "uuid"
+                "summary": "Create Session",
+                "description": "Create a session and/or dispatch a task.\n\n- Without session_id, without task: creates a new idle session (e.g. for file uploads).\n- Without session_id, with task: creates a new session and dispatches the task.\n- With session_id, with task: dispatches the task to an existing idle session.\n- With session_id, without task: 422 \u2014 task is required when targeting an existing session.\n\nIf keep_alive is false (default), the session auto-stops when the task finishes.\nIf keep_alive is true, the session stays idle after the task, ready for follow-ups.",
+                "operationId": "create_session_sessions_post",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RunTaskRequest"
+                            }
+                        }
+                    }
                 },
-                {
-                  "type": "null"
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SessionResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              ],
-              "description": "Cursor: return messages after this message ID",
-              "title": "After"
             },
-            "description": "Cursor: return messages after this message ID"
-          },
-          {
-            "name": "before",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "uuid"
+            "get": {
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "List Sessions",
+                "description": "List sessions for the authenticated project.",
+                "operationId": "list_sessions_sessions_get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 1,
+                            "title": "Page"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1,
+                            "default": 20,
+                            "title": "Page Size"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SessionListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/sessions/{session_id}": {
+            "get": {
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "Get Session",
+                "description": "Get session details. Use this to poll for task completion and output.",
+                "operationId": "get_session_sessions__session_id__get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SessionResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "Delete Session",
+                "description": "Soft-delete a session. Stops the sandbox first if still running.",
+                "operationId": "delete_session_sessions__session_id__delete",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful Response"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/sessions/{session_id}/stop": {
+            "post": {
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "Stop Session",
+                "description": "Stop a session or the running task.\n\n- strategy=session (default): destroy sandbox entirely, session \u2192 stopped.\n- strategy=task: stop the running query, session stays alive (\u2192 idle).",
+                "operationId": "stop_session_sessions__session_id__stop_post",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/components/schemas/StopSessionRequest"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "title": "Body"
+                            }
+                        }
+                    }
                 },
-                {
-                  "type": "null"
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SessionResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              ],
-              "description": "Cursor: return messages before this message ID",
-              "title": "Before"
-            },
-            "description": "Cursor: return messages before this message ID"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 10,
-              "title": "Limit"
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MessageListResponse"
+        },
+        "/sessions/{session_id}/messages": {
+            "get": {
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "List Session Messages",
+                "description": "Return messages for a session with cursor-based pagination (chronological order).",
+                "operationId": "list_session_messages_sessions__session_id__messages_get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    },
+                    {
+                        "name": "after",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "format": "uuid"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Cursor: return messages after this message ID",
+                            "title": "After"
+                        },
+                        "description": "Cursor: return messages after this message ID"
+                    },
+                    {
+                        "name": "before",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "format": "uuid"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Cursor: return messages before this message ID",
+                            "title": "Before"
+                        },
+                        "description": "Cursor: return messages before this message ID"
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1,
+                            "default": 10,
+                            "title": "Limit"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MessageListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              }
             }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+        },
+        "/sessions/{session_id}/files": {
+            "get": {
+                "tags": [
+                    "Files"
+                ],
+                "summary": "List Session Files",
+                "description": "List files in a session's workspace.\n\nReturns paginated file metadata. Pass includeUrls=true to get\npresigned download URLs (60s expiry) inline with each file.",
+                "operationId": "list_session_files_sessions__session_id__files_get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    },
+                    {
+                        "name": "prefix",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "",
+                            "title": "Prefix"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1,
+                            "default": 50,
+                            "title": "Limit"
+                        }
+                    },
+                    {
+                        "name": "cursor",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Cursor"
+                        }
+                    },
+                    {
+                        "name": "includeUrls",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false,
+                            "title": "Includeurls"
+                        }
+                    },
+                    {
+                        "name": "shallow",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false,
+                            "title": "Shallow"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FileListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              }
             }
-          }
-        }
-      }
-    },
-    "/sessions/{session_id}/files": {
-      "get": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "List Session Files",
-        "description": "List files in a session's workspace.\n\nReturns paginated file metadata. Pass includeUrls=true to get\npresigned download URLs (60s expiry) inline with each file.",
-        "operationId": "list_session_files_sessions__session_id__files_get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Session Id"
-            }
-          },
-          {
-            "name": "prefix",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "",
-              "title": "Prefix"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 50,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "cursor",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
+        },
+        "/sessions/{session_id}/files/upload": {
+            "post": {
+                "tags": [
+                    "Files"
+                ],
+                "summary": "Upload Session Files",
+                "description": "Get presigned PUT URLs for uploading files to a session's workspace.\n\nFiles are placed under ``uploads/`` in the session's S3 prefix. After\nreceiving the URLs, PUT each file directly to S3 using the returned\n``uploadUrl`` with the matching ``Content-Type`` header.",
+                "operationId": "upload_session_files_sessions__session_id__files_upload_post",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FileUploadRequest"
+                            }
+                        }
+                    }
                 },
-                {
-                  "type": "null"
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FileUploadResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              ],
-              "title": "Cursor"
             }
-          },
-          {
-            "name": "includeUrls",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Includeurls"
-            }
-          },
-          {
-            "name": "shallow",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Shallow"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FileListResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/sessions/{session_id}/files/upload": {
-      "post": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Upload Session Files",
-        "description": "Get presigned PUT URLs for uploading files to a session's workspace.\n\nFiles are placed under ``uploads/`` in the session's S3 prefix. After\nreceiving the URLs, PUT each file directly to S3 using the returned\n``uploadUrl`` with the matching ``Content-Type`` header.",
-        "operationId": "upload_session_files_sessions__session_id__files_upload_post",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Session Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FileUploadRequest"
-              }
-            }
-          }
         },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FileUploadResponse"
+        "/profiles": {
+            "get": {
+                "tags": [
+                    "Profiles"
+                ],
+                "summary": "List Profiles",
+                "description": "Get paginated list of profiles.\n\nUse the `query` parameter to search profiles by name or user_id.\nThis is useful when you have many profiles and need to find a specific user.\n\nExample: If you set `user_id` to your internal user identifier when creating profiles,\nyou can later search for that user by passing their identifier as the `query` parameter.",
+                "operationId": "list_profiles_profiles_get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1,
+                            "default": 10,
+                            "title": "Pagesize"
+                        }
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 1,
+                            "title": "Pagenumber"
+                        }
+                    },
+                    {
+                        "name": "query",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "maxLength": 200
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Query"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProfileListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/profiles": {
-      "get": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "List Profiles",
-        "description": "Get paginated list of profiles.\n\nUse the `query` parameter to search profiles by name or user_id.\nThis is useful when you have many profiles and need to find a specific user.\n\nExample: If you set `user_id` to your internal user identifier when creating profiles,\nyou can later search for that user by passing their identifier as the `query` parameter.",
-        "operationId": "list_profiles_profiles_get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "pageSize",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 10,
-              "title": "Pagesize"
-            }
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1,
-              "title": "Pagenumber"
-            }
-          },
-          {
-            "name": "query",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "maxLength": 200
+            },
+            "post": {
+                "tags": [
+                    "Profiles"
+                ],
+                "summary": "Create Profile",
+                "description": "Profiles allow you to preserve the state of the browser between tasks.\n\nThey are most commonly used to allow users to preserve the log-in state in the agent between tasks.\nYou'd normally create one profile per user and then use it for all their tasks.\n\nYou can set a `user_id` when creating a profile to associate it with a user in your system.\nThis allows you to later search for the profile using the GET /profiles endpoint with a query parameter.",
+                "operationId": "create_profile_profiles_post",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProfileCreateRequest"
+                            }
+                        }
+                    }
                 },
-                {
-                  "type": "null"
+                "responses": {
+                    "201": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProfileView"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Subscription required for additional profiles",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InsufficientCreditsError"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Request validation failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              ],
-              "title": "Query"
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileListResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "Create Profile",
-        "description": "Profiles allow you to preserve the state of the browser between tasks.\n\nThey are most commonly used to allow users to preserve the log-in state in the agent between tasks.\nYou'd normally create one profile per user and then use it for all their tasks.\n\nYou can set a `user_id` when creating a profile to associate it with a user in your system.\nThis allows you to later search for the profile using the GET /profiles endpoint with a query parameter.",
-        "operationId": "create_profile_profiles_post",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ProfileCreateRequest"
-              }
-            }
-          }
         },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileView"
+        "/profiles/{profile_id}": {
+            "get": {
+                "tags": [
+                    "Profiles"
+                ],
+                "summary": "Get Profile",
+                "description": "Get profile details.",
+                "operationId": "get_profile_profiles__profile_id__get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "profile_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Profile Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProfileView"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Profile not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProfileNotFoundError"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              }
-            }
-          },
-          "402": {
-            "description": "Subscription required for additional profiles",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InsufficientCreditsError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Request validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/profiles/{profile_id}": {
-      "get": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "Get Profile",
-        "description": "Get profile details.",
-        "operationId": "get_profile_profiles__profile_id__get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "profile_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Profile Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileView"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Profile not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileNotFoundError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "Update Profile",
-        "description": "Update a browser profile's information.",
-        "operationId": "update_profile_profiles__profile_id__patch",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "profile_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Profile Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ProfileUpdateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileView"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Profile not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileNotFoundError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "Delete Browser Profile",
-        "description": "Permanently delete a browser profile and its configuration.",
-        "operationId": "delete_browser_profile_profiles__profile_id__delete",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "profile_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Profile Id"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/billing/account": {
-      "get": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "Get Account Billing",
-        "description": "Get authenticated account information including credit balance and account details.",
-        "operationId": "get_account_billing_billing_account_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AccountView"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Project for a given API key not found!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AccountNotFoundError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/browsers": {
-      "get": {
-        "tags": [
-          "Browsers"
-        ],
-        "summary": "List Browser Sessions",
-        "description": "Get paginated list of browser sessions with optional status filtering.",
-        "operationId": "list_browser_sessions_browsers_get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "pageSize",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 10,
-              "title": "Pagesize"
-            }
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1,
-              "title": "Pagenumber"
-            }
-          },
-          {
-            "name": "filterBy",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/BrowserSessionStatus"
+            },
+            "patch": {
+                "tags": [
+                    "Profiles"
+                ],
+                "summary": "Update Profile",
+                "description": "Update a browser profile's information.",
+                "operationId": "update_profile_profiles__profile_id__patch",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "profile_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Profile Id"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProfileUpdateRequest"
+                            }
+                        }
+                    }
                 },
-                {
-                  "type": "null"
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProfileView"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Profile not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProfileNotFoundError"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              ],
-              "title": "Filterby"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BrowserSessionListResponse"
+            },
+            "delete": {
+                "tags": [
+                    "Profiles"
+                ],
+                "summary": "Delete Browser Profile",
+                "description": "Permanently delete a browser profile and its configuration.",
+                "operationId": "delete_browser_profile_profiles__profile_id__delete",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "profile_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Profile Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful Response"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              }
             }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Browsers"
-        ],
-        "summary": "Create Browser Session",
-        "description": "Create a new browser session.\n\n**Pricing:** Browser sessions are charged per hour with tiered pricing:\n- Pay As You Go users: $0.06/hour\n- Business/Scaleup subscribers: $0.03/hour (50% discount)\n\nThe full rate is charged upfront when the session starts.\nWhen you stop the session, any unused time is automatically refunded proportionally.\n\nBilling is rounded up to the minute (minimum 1 minute).\nFor example, if you stop a session after 30 minutes, you'll be refunded half the charged amount.\n\n**Session Limits:**\n- All users: Up to 4 hours per session",
-        "operationId": "create_browser_session_browsers_post",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateBrowserSessionRequest"
-              }
-            }
-          }
         },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BrowserSessionItemView"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Session timeout limit exceeded (maximum 4 hours)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionTimeoutLimitExceededError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Profile not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileNotFoundError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Request validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Too many concurrent active sessions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TooManyConcurrentActiveSessionsError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/browsers/{session_id}": {
-      "get": {
-        "tags": [
-          "Browsers"
-        ],
-        "summary": "Get Browser Session",
-        "description": "Get detailed browser session information including status and URLs.",
-        "operationId": "get_browser_session_browsers__session_id__get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Session Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BrowserSessionView"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Session not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionNotFoundError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "Browsers"
-        ],
-        "summary": "Update Browser Session",
-        "description": "Stop a browser session.\n\n**Refund:** When you stop a session, unused time is automatically refunded.\nIf the session ran for less than 1 hour, you'll receive a proportional refund.\nBilling is ceil to the nearest minute (minimum 1 minute).",
-        "operationId": "update_browser_session_browsers__session_id__patch",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Session Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateBrowserSessionRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BrowserSessionView"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Session not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionNotFoundError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Request validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/workspaces": {
-      "get": {
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "List Workspaces",
-        "description": "Get paginated list of workspaces.",
-        "operationId": "list_workspaces_workspaces_get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "pageSize",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 10,
-              "title": "Pagesize"
-            }
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1,
-              "title": "Pagenumber"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkspaceListResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Create Workspace",
-        "description": "Create a new workspace for persistent shared file storage across sessions.",
-        "operationId": "create_workspace_workspaces_post",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorkspaceCreateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkspaceView"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/workspaces/{workspace_id}": {
-      "get": {
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Get Workspace",
-        "description": "Get workspace details.",
-        "operationId": "get_workspace_workspaces__workspace_id__get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkspaceView"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Update Workspace",
-        "description": "Update a workspace's name.",
-        "operationId": "update_workspace_workspaces__workspace_id__patch",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorkspaceUpdateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkspaceView"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Delete Workspace",
-        "description": "Delete a workspace and its S3 data.",
-        "operationId": "delete_workspace_workspaces__workspace_id__delete",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/workspaces/{workspace_id}/files": {
-      "get": {
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "List Workspace Files",
-        "description": "List files in a workspace's S3 prefix.",
-        "operationId": "list_workspace_files_workspaces__workspace_id__files_get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          },
-          {
-            "name": "prefix",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "",
-              "title": "Prefix"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 50,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "cursor",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
+        "/billing/account": {
+            "get": {
+                "tags": [
+                    "Billing"
+                ],
+                "summary": "Get Account Billing",
+                "description": "Get authenticated account information including credit balance and account details.",
+                "operationId": "get_account_billing_billing_account_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AccountView"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Project for a given API key not found!",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AccountNotFoundError"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 },
-                {
-                  "type": "null"
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ]
+            }
+        },
+        "/browsers": {
+            "get": {
+                "tags": [
+                    "Browsers"
+                ],
+                "summary": "List Browser Sessions",
+                "description": "Get paginated list of browser sessions with optional status filtering.",
+                "operationId": "list_browser_sessions_browsers_get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1,
+                            "default": 10,
+                            "title": "Pagesize"
+                        }
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 1,
+                            "title": "Pagenumber"
+                        }
+                    },
+                    {
+                        "name": "filterBy",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/BrowserSessionStatus"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Filterby"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BrowserSessionListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              ],
-              "title": "Cursor"
-            }
-          },
-          {
-            "name": "includeUrls",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Includeurls"
-            }
-          },
-          {
-            "name": "shallow",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Shallow"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FileListResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Delete Workspace File",
-        "description": "Delete a single file from a workspace.",
-        "operationId": "delete_workspace_file_workspaces__workspace_id__files_delete",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          },
-          {
-            "name": "path",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Relative file path to delete",
-              "title": "Path"
             },
-            "description": "Relative file path to delete"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/workspaces/{workspace_id}/size": {
-      "get": {
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Get Workspace Size",
-        "description": "Get current storage usage for a workspace.",
-        "operationId": "get_workspace_size_workspaces__workspace_id__size_get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/workspaces/{workspace_id}/files/upload": {
-      "post": {
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Upload Workspace Files",
-        "description": "Get presigned PUT URLs for uploading files to a workspace.",
-        "operationId": "upload_workspace_files_workspaces__workspace_id__files_upload_post",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          },
-          {
-            "name": "prefix",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "description": "Directory prefix to upload into (e.g. \"uploads/\")",
-              "default": "",
-              "title": "Prefix"
-            },
-            "description": "Directory prefix to upload into (e.g. \"uploads/\")"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FileUploadRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FileUploadResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "AccountNotFoundError": {
-        "properties": {
-          "detail": {
-            "type": "string",
-            "title": "Detail",
-            "default": "Account not found"
-          }
-        },
-        "type": "object",
-        "title": "AccountNotFoundError",
-        "description": "Error response when an account is not found"
-      },
-      "AccountView": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name",
-            "description": "The name of the user"
-          },
-          "totalCreditsBalanceUsd": {
-            "type": "number",
-            "title": "Credits Balance USD",
-            "description": "The total credits balance in USD"
-          },
-          "monthlyCreditsBalanceUsd": {
-            "type": "number",
-            "title": "Monthly Credits Balance USD",
-            "description": "Monthly subscription credits balance in USD"
-          },
-          "additionalCreditsBalanceUsd": {
-            "type": "number",
-            "title": "Additional Credits Balance USD",
-            "description": "Additional top-up credits balance in USD"
-          },
-          "rateLimit": {
-            "type": "integer",
-            "title": "Rate Limit",
-            "description": "The rate limit for the account"
-          },
-          "planInfo": {
-            "$ref": "#/components/schemas/PlanInfo",
-            "title": "Plan Info",
-            "description": "The plan information"
-          },
-          "projectId": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Project ID",
-            "description": "The ID of the project"
-          }
-        },
-        "type": "object",
-        "required": [
-          "totalCreditsBalanceUsd",
-          "monthlyCreditsBalanceUsd",
-          "additionalCreditsBalanceUsd",
-          "rateLimit",
-          "planInfo",
-          "projectId"
-        ],
-        "title": "AccountView",
-        "description": "View model for account information."
-      },
-      "BrowserSessionItemView": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "ID",
-            "description": "Unique identifier for the session"
-          },
-          "status": {
-            "$ref": "#/components/schemas/BrowserSessionStatus",
-            "title": "Status",
-            "description": "Current status of the session (active/stopped)"
-          },
-          "liveUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Live URL",
-            "description": "URL where the browser can be viewed live in real-time"
-          },
-          "cdpUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "CDP URL",
-            "description": "Chrome DevTools Protocol URL for browser automation"
-          },
-          "timeoutAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Timeout At",
-            "description": "Timestamp when the session will timeout"
-          },
-          "startedAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Started At",
-            "description": "Timestamp when the session was created and started"
-          },
-          "finishedAt": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Finished At",
-            "description": "Timestamp when the session was stopped (None if still active)"
-          },
-          "proxyUsedMb": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Proxy Used MB",
-            "description": "Amount of proxy data used in MB",
-            "default": "0"
-          },
-          "proxyCost": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Proxy Cost",
-            "description": "Cost of proxy usage in USD",
-            "default": "0"
-          },
-          "browserCost": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Browser Cost",
-            "description": "Cost of browser session hosting in USD",
-            "default": "0"
-          },
-          "agentSessionId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Agent Session ID",
-            "description": "ID of the agent session that created this browser (None for standalone BaaS sessions)"
-          },
-          "recordingUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Recording URL",
-            "description": "Presigned URL to download the session recording (available after session ends, if recording was enabled)"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "status",
-          "timeoutAt",
-          "startedAt"
-        ],
-        "title": "BrowserSessionItemView",
-        "description": "View model for representing a browser session in list views."
-      },
-      "BrowserSessionListResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/BrowserSessionItemView"
-            },
-            "type": "array",
-            "title": "Items",
-            "description": "List of browser session views for the current page"
-          },
-          "totalItems": {
-            "type": "integer",
-            "title": "Total Items",
-            "description": "Total number of items in the list"
-          },
-          "pageNumber": {
-            "type": "integer",
-            "title": "Page Number",
-            "description": "Page number"
-          },
-          "pageSize": {
-            "type": "integer",
-            "title": "Page Size",
-            "description": "Number of items per page"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items",
-          "totalItems",
-          "pageNumber",
-          "pageSize"
-        ],
-        "title": "BrowserSessionListResponse",
-        "description": "Response model for paginated browser session list requests."
-      },
-      "BrowserSessionStatus": {
-        "type": "string",
-        "enum": [
-          "active",
-          "stopped"
-        ],
-        "title": "BrowserSessionStatus",
-        "description": "Enumeration of possible browser session states\n\nAttributes:\n    ACTIVE: Session is currently active and running (browser is running)\n    STOPPED: Session has been stopped and is no longer active (browser is stopped)"
-      },
-      "BrowserSessionUpdateAction": {
-        "type": "string",
-        "enum": [
-          "stop"
-        ],
-        "title": "BrowserSessionUpdateAction",
-        "description": "Available actions that can be performed on a browser session\n\nAttributes:\n    STOP: Stop the browser session (cannot be undone)"
-      },
-      "BrowserSessionView": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "ID",
-            "description": "Unique identifier for the session"
-          },
-          "status": {
-            "$ref": "#/components/schemas/BrowserSessionStatus",
-            "title": "Status",
-            "description": "Current status of the session (active/stopped)"
-          },
-          "liveUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Live URL",
-            "description": "URL where the browser can be viewed live in real-time"
-          },
-          "cdpUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "CDP URL",
-            "description": "Chrome DevTools Protocol URL for browser automation"
-          },
-          "timeoutAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Timeout At",
-            "description": "Timestamp when the session will timeout"
-          },
-          "startedAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Started At",
-            "description": "Timestamp when the session was created and started"
-          },
-          "finishedAt": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Finished At",
-            "description": "Timestamp when the session was stopped (None if still active)"
-          },
-          "proxyUsedMb": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Proxy Used MB",
-            "description": "Amount of proxy data used in MB",
-            "default": "0"
-          },
-          "proxyCost": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Proxy Cost",
-            "description": "Cost of proxy usage in USD",
-            "default": "0"
-          },
-          "browserCost": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Browser Cost",
-            "description": "Cost of browser session hosting in USD",
-            "default": "0"
-          },
-          "agentSessionId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Agent Session ID",
-            "description": "ID of the agent session that created this browser (None for standalone BaaS sessions)"
-          },
-          "recordingUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Recording URL",
-            "description": "Presigned URL to download the session recording (available after session ends, if recording was enabled)"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "status",
-          "timeoutAt",
-          "startedAt"
-        ],
-        "title": "BrowserSessionView",
-        "description": "View model for representing a browser session."
-      },
-      "BuAgentSessionStatus": {
-        "type": "string",
-        "enum": [
-          "created",
-          "idle",
-          "running",
-          "stopped",
-          "timed_out",
-          "error"
-        ],
-        "title": "BuAgentSessionStatus"
-      },
-      "BuModel": {
-        "type": "string",
-        "enum": [
-          "bu-mini",
-          "bu-max",
-          "bu-ultra"
-        ],
-        "title": "BuModel"
-      },
-      "CreateBrowserSessionRequest": {
-        "properties": {
-          "profileId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Profile ID",
-            "description": "The ID of the profile to use for the session"
-          },
-          "proxyCountryCode": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ProxyCountryCode"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Proxy Country Code",
-            "description": "Country code for proxy location. Defaults to US. Set to null to disable proxy.",
-            "default": "us"
-          },
-          "timeout": {
-            "type": "integer",
-            "title": "Timeout",
-            "description": "The timeout for the session in minutes. All users can use up to 240 minutes (4 hours). Pay As You Go users are charged $0.06/hour, subscribers get 50% off.",
-            "default": 60,
-            "ge": 1,
-            "le": 240
-          },
-          "browserScreenWidth": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "maximum": 6144.0,
-                "minimum": 320.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Browser Screen Width",
-            "description": "Custom screen width in pixels for the browser."
-          },
-          "browserScreenHeight": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "maximum": 3456.0,
-                "minimum": 320.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Browser Screen Height",
-            "description": "Custom screen height in pixels for the browser."
-          },
-          "allowResizing": {
-            "type": "boolean",
-            "title": "Allow Resizing",
-            "description": "Whether to allow the browser to be resized during the session (not recommended since it reduces stealthiness).",
-            "default": false
-          },
-          "customProxy": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/CustomProxy"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Custom Proxy",
-            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are only available on the Custom Enterprise plan."
-          },
-          "enableRecording": {
-            "type": "boolean",
-            "title": "Enable Recording",
-            "description": "If True, enables session recording. Defaults to False.",
-            "default": false
-          }
-        },
-        "type": "object",
-        "title": "CreateBrowserSessionRequest",
-        "description": "Request model for creating a browser session."
-      },
-      "CustomProxy": {
-        "properties": {
-          "host": {
-            "type": "string",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Host",
-            "description": "Host of the proxy."
-          },
-          "port": {
-            "type": "integer",
-            "maximum": 65535.0,
-            "minimum": 1.0,
-            "title": "Port",
-            "description": "Port of the proxy."
-          },
-          "username": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Username",
-            "description": "Username for proxy authentication."
-          },
-          "password": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Password",
-            "description": "Password for proxy authentication."
-          }
-        },
-        "type": "object",
-        "required": [
-          "host",
-          "port"
-        ],
-        "title": "CustomProxy",
-        "description": "Request model for creating a custom proxy."
-      },
-      "FileInfo": {
-        "properties": {
-          "path": {
-            "type": "string",
-            "title": "Path"
-          },
-          "size": {
-            "type": "integer",
-            "title": "Size"
-          },
-          "lastModified": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Lastmodified"
-          },
-          "url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Url"
-          }
-        },
-        "type": "object",
-        "required": [
-          "path",
-          "size",
-          "lastModified"
-        ],
-        "title": "FileInfo",
-        "description": "A file in a session's workspace."
-      },
-      "FileListResponse": {
-        "properties": {
-          "files": {
-            "items": {
-              "$ref": "#/components/schemas/FileInfo"
-            },
-            "type": "array",
-            "title": "Files"
-          },
-          "folders": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Folders",
-            "description": "Immediate sub-folder names at this prefix level"
-          },
-          "nextCursor": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Nextcursor"
-          },
-          "hasMore": {
-            "type": "boolean",
-            "title": "Hasmore",
-            "default": false
-          }
-        },
-        "type": "object",
-        "required": [
-          "files"
-        ],
-        "title": "FileListResponse",
-        "description": "Paginated file listing with optional presigned download URLs."
-      },
-      "FileUploadItem": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Name",
-            "description": "Filename, e.g. \"data.csv\""
-          },
-          "contentType": {
-            "type": "string",
-            "maxLength": 255,
-            "title": "Contenttype",
-            "description": "MIME type, e.g. \"text/csv\"",
-            "default": "application/octet-stream"
-          },
-          "size": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "minimum": 1.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size",
-            "description": "File size in bytes (required for workspace uploads)"
-          }
-        },
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "title": "FileUploadItem",
-        "description": "A single file to upload."
-      },
-      "FileUploadRequest": {
-        "properties": {
-          "files": {
-            "items": {
-              "$ref": "#/components/schemas/FileUploadItem"
-            },
-            "type": "array",
-            "maxItems": 10,
-            "minItems": 1,
-            "title": "Files"
-          }
-        },
-        "type": "object",
-        "required": [
-          "files"
-        ],
-        "title": "FileUploadRequest",
-        "description": "Request body for generating presigned upload URLs."
-      },
-      "FileUploadResponse": {
-        "properties": {
-          "files": {
-            "items": {
-              "$ref": "#/components/schemas/FileUploadResponseItem"
-            },
-            "type": "array",
-            "title": "Files"
-          }
-        },
-        "type": "object",
-        "required": [
-          "files"
-        ],
-        "title": "FileUploadResponse",
-        "description": "Presigned upload URLs for the requested files."
-      },
-      "FileUploadResponseItem": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "uploadUrl": {
-            "type": "string",
-            "title": "Uploadurl"
-          },
-          "path": {
-            "type": "string",
-            "title": "Path",
-            "description": "S3-relative path, e.g. \"uploads/data.csv\""
-          }
-        },
-        "type": "object",
-        "required": [
-          "name",
-          "uploadUrl",
-          "path"
-        ],
-        "title": "FileUploadResponseItem",
-        "description": "Presigned upload URL for a single file."
-      },
-      "HTTPValidationError": {
-        "properties": {
-          "detail": {
-            "items": {
-              "$ref": "#/components/schemas/ValidationError"
-            },
-            "type": "array",
-            "title": "Detail"
-          }
-        },
-        "type": "object",
-        "title": "HTTPValidationError"
-      },
-      "InsufficientCreditsError": {
-        "properties": {
-          "detail": {
-            "type": "string",
-            "title": "Detail",
-            "default": "Insufficient credits"
-          }
-        },
-        "type": "object",
-        "title": "InsufficientCreditsError",
-        "description": "Error response when there are insufficient credits"
-      },
-      "MessageListResponse": {
-        "properties": {
-          "messages": {
-            "items": {
-              "$ref": "#/components/schemas/MessageResponse"
-            },
-            "type": "array",
-            "title": "Messages"
-          },
-          "hasMore": {
-            "type": "boolean",
-            "title": "Hasmore"
-          }
-        },
-        "type": "object",
-        "required": [
-          "messages",
-          "hasMore"
-        ],
-        "title": "MessageListResponse"
-      },
-      "MessageResponse": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Id"
-          },
-          "sessionId": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Sessionid"
-          },
-          "role": {
-            "type": "string",
-            "title": "Role"
-          },
-          "data": {
-            "type": "string",
-            "title": "Data"
-          },
-          "type": {
-            "type": "string",
-            "title": "Type",
-            "description": "Coarse category: user_message, assistant_message, browser_action, file_operation, code_execution, integration, planning, completion, browser_action_result, browser_action_error, etc.",
-            "default": ""
-          },
-          "summary": {
-            "type": "string",
-            "title": "Summary",
-            "description": "One-liner human-readable description of the message (e.g. \"Navigating to google.com\", \"Clicking element #5\").",
-            "default": ""
-          },
-          "screenshotUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Screenshoturl"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Createdat"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "sessionId",
-          "role",
-          "data",
-          "createdAt"
-        ],
-        "title": "MessageResponse"
-      },
-      "PlanInfo": {
-        "properties": {
-          "planName": {
-            "type": "string",
-            "title": "Plan Name",
-            "description": "The name of the plan"
-          },
-          "subscriptionStatus": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Subscription Status",
-            "description": "The status of the subscription"
-          },
-          "subscriptionId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Subscription ID",
-            "description": "The ID of the subscription"
-          },
-          "subscriptionCurrentPeriodEnd": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Subscription Current Period End",
-            "description": "The end of the current period"
-          },
-          "subscriptionCanceledAt": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Subscription Canceled At",
-            "description": "The date the subscription was canceled"
-          }
-        },
-        "type": "object",
-        "required": [
-          "planName",
-          "subscriptionStatus",
-          "subscriptionId",
-          "subscriptionCurrentPeriodEnd",
-          "subscriptionCanceledAt"
-        ],
-        "title": "PlanInfo",
-        "description": "View model for plan information"
-      },
-      "ProfileCreateRequest": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 100
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name",
-            "description": "Optional name for the profile"
-          },
-          "userId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User ID",
-            "description": "Your internal user identifier for this profile. Use this to associate a profile with a user in your system."
-          }
-        },
-        "type": "object",
-        "title": "ProfileCreateRequest",
-        "description": "Request model for creating a new profile."
-      },
-      "ProfileListResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/ProfileView"
-            },
-            "type": "array",
-            "title": "Items",
-            "description": "List of profile views for the current page"
-          },
-          "totalItems": {
-            "type": "integer",
-            "title": "Total Items",
-            "description": "Total number of items in the list"
-          },
-          "pageNumber": {
-            "type": "integer",
-            "title": "Page Number",
-            "description": "Page number"
-          },
-          "pageSize": {
-            "type": "integer",
-            "title": "Page Size",
-            "description": "Number of items per page"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items",
-          "totalItems",
-          "pageNumber",
-          "pageSize"
-        ],
-        "title": "ProfileListResponse",
-        "description": "Response model for paginated profile list requests."
-      },
-      "ProfileNotFoundError": {
-        "properties": {
-          "detail": {
-            "type": "string",
-            "title": "Detail",
-            "default": "Profile not found"
-          }
-        },
-        "type": "object",
-        "title": "ProfileNotFoundError",
-        "description": "Error response when a profile is not found"
-      },
-      "ProfileUpdateRequest": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 100
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name",
-            "description": "Optional name for the profile"
-          },
-          "userId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User ID",
-            "description": "Your internal user identifier for this profile. Use this to associate a profile with a user in your system."
-          }
-        },
-        "type": "object",
-        "title": "ProfileUpdateRequest",
-        "description": "Request model for updating a profile."
-      },
-      "ProfileView": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "ID",
-            "description": "Unique identifier for the profile"
-          },
-          "userId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User ID",
-            "description": "Your internal user identifier for this profile. Use this to associate a profile with a user in your system."
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name",
-            "description": "Optional name for the profile"
-          },
-          "lastUsedAt": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Used At",
-            "description": "Timestamp when the profile was last used"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At",
-            "description": "Timestamp when the profile was created"
-          },
-          "updatedAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At",
-            "description": "Timestamp when the profile was last updated"
-          },
-          "cookieDomains": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
+            "post": {
+                "tags": [
+                    "Browsers"
+                ],
+                "summary": "Create Browser Session",
+                "description": "Create a new browser session.\n\n**Pricing:** Browser sessions are charged per hour with tiered pricing:\n- Pay As You Go users: $0.06/hour\n- Business/Scaleup subscribers: $0.03/hour (50% discount)\n\nThe full rate is charged upfront when the session starts.\nWhen you stop the session, any unused time is automatically refunded proportionally.\n\nBilling is rounded up to the minute (minimum 1 minute).\nFor example, if you stop a session after 30 minutes, you'll be refunded half the charged amount.\n\n**Session Limits:**\n- All users: Up to 4 hours per session",
+                "operationId": "create_browser_session_browsers_post",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateBrowserSessionRequest"
+                            }
+                        }
+                    }
                 },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cookie Domains",
-            "description": "List of domain URLs that have cookies stored for this profile"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "createdAt",
-          "updatedAt"
-        ],
-        "title": "ProfileView",
-        "description": "View model for representing a profile. A profile lets you preserve the login state between sessions.\n\nWe recommend that you create a separate profile for each user of your app.\nYou can assign a user_id to each profile to easily identify which user the profile belongs to."
-      },
-      "ProxyCountryCode": {
-        "type": "string",
-        "enum": [
-          "ad",
-          "ae",
-          "af",
-          "ag",
-          "ai",
-          "al",
-          "am",
-          "an",
-          "ao",
-          "aq",
-          "ar",
-          "as",
-          "at",
-          "au",
-          "aw",
-          "az",
-          "ba",
-          "bb",
-          "bd",
-          "be",
-          "bf",
-          "bg",
-          "bh",
-          "bi",
-          "bj",
-          "bl",
-          "bm",
-          "bn",
-          "bo",
-          "bq",
-          "br",
-          "bs",
-          "bt",
-          "bv",
-          "bw",
-          "by",
-          "bz",
-          "ca",
-          "cc",
-          "cd",
-          "cf",
-          "cg",
-          "ch",
-          "ck",
-          "cl",
-          "cm",
-          "co",
-          "cr",
-          "cs",
-          "cu",
-          "cv",
-          "cw",
-          "cx",
-          "cy",
-          "cz",
-          "de",
-          "dj",
-          "dk",
-          "dm",
-          "do",
-          "dz",
-          "ec",
-          "ee",
-          "eg",
-          "eh",
-          "er",
-          "es",
-          "et",
-          "fi",
-          "fj",
-          "fk",
-          "fm",
-          "fo",
-          "fr",
-          "ga",
-          "gd",
-          "ge",
-          "gf",
-          "gg",
-          "gh",
-          "gi",
-          "gl",
-          "gm",
-          "gn",
-          "gp",
-          "gq",
-          "gr",
-          "gs",
-          "gt",
-          "gu",
-          "gw",
-          "gy",
-          "hk",
-          "hm",
-          "hn",
-          "hr",
-          "ht",
-          "hu",
-          "id",
-          "ie",
-          "il",
-          "im",
-          "in",
-          "iq",
-          "ir",
-          "is",
-          "it",
-          "je",
-          "jm",
-          "jo",
-          "jp",
-          "ke",
-          "kg",
-          "kh",
-          "ki",
-          "km",
-          "kn",
-          "kp",
-          "kr",
-          "kw",
-          "ky",
-          "kz",
-          "la",
-          "lb",
-          "lc",
-          "li",
-          "lk",
-          "lr",
-          "ls",
-          "lt",
-          "lu",
-          "lv",
-          "ly",
-          "ma",
-          "mc",
-          "md",
-          "me",
-          "mf",
-          "mg",
-          "mh",
-          "mk",
-          "ml",
-          "mm",
-          "mn",
-          "mo",
-          "mp",
-          "mq",
-          "mr",
-          "ms",
-          "mt",
-          "mu",
-          "mv",
-          "mw",
-          "mx",
-          "my",
-          "mz",
-          "na",
-          "nc",
-          "ne",
-          "nf",
-          "ng",
-          "ni",
-          "nl",
-          "no",
-          "np",
-          "nr",
-          "nu",
-          "nz",
-          "om",
-          "pa",
-          "pe",
-          "pf",
-          "pg",
-          "ph",
-          "pk",
-          "pl",
-          "pm",
-          "pn",
-          "pr",
-          "ps",
-          "pt",
-          "pw",
-          "py",
-          "qa",
-          "re",
-          "ro",
-          "rs",
-          "ru",
-          "rw",
-          "sa",
-          "sb",
-          "sc",
-          "sd",
-          "se",
-          "sg",
-          "sh",
-          "si",
-          "sj",
-          "sk",
-          "sl",
-          "sm",
-          "sn",
-          "so",
-          "sr",
-          "ss",
-          "st",
-          "sv",
-          "sx",
-          "sy",
-          "sz",
-          "tc",
-          "td",
-          "tf",
-          "tg",
-          "th",
-          "tj",
-          "tk",
-          "tl",
-          "tm",
-          "tn",
-          "to",
-          "tr",
-          "tt",
-          "tv",
-          "tw",
-          "tz",
-          "ua",
-          "ug",
-          "uk",
-          "us",
-          "uy",
-          "uz",
-          "va",
-          "vc",
-          "ve",
-          "vg",
-          "vi",
-          "vn",
-          "vu",
-          "wf",
-          "ws",
-          "xk",
-          "ye",
-          "yt",
-          "za",
-          "zm",
-          "zw"
-        ],
-        "title": "ProxyCountryCode"
-      },
-      "RunTaskRequest": {
-        "properties": {
-          "task": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Task"
-          },
-          "model": {
-            "$ref": "#/components/schemas/BuModel",
-            "default": "bu-mini"
-          },
-          "sessionId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sessionid"
-          },
-          "keepAlive": {
-            "type": "boolean",
-            "title": "Keepalive",
-            "default": false
-          },
-          "maxCostUsd": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Maxcostusd"
-          },
-          "profileId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Profileid"
-          },
-          "workspaceId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Workspaceid"
-          },
-          "proxyCountryCode": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ProxyCountryCode"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": "us"
-          },
-          "outputSchema": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Outputschema"
-          },
-          "enableScheduledTasks": {
-            "type": "boolean",
-            "title": "Enablescheduledtasks",
-            "default": false
-          },
-          "enableRecording": {
-            "type": "boolean",
-            "title": "Enablerecording",
-            "default": false
-          },
-          "skills": {
-            "type": "boolean",
-            "title": "Skills",
-            "default": true
-          },
-          "agentmail": {
-            "type": "boolean",
-            "title": "Agentmail",
-            "default": true
-          }
-        },
-        "type": "object",
-        "title": "RunTaskRequest",
-        "description": "Unified request for creating a session or dispatching a task.\n\n- Without session_id + without task: creates a new idle session (for file uploads, etc.)\n- Without session_id + with task: creates a new session and dispatches the task\n- With session_id + with task: dispatches the task to an existing idle session\n- With session_id + without task: 422 (task required when dispatching to existing session)"
-      },
-      "SessionListResponse": {
-        "properties": {
-          "sessions": {
-            "items": {
-              "$ref": "#/components/schemas/SessionResponse"
-            },
-            "type": "array",
-            "title": "Sessions"
-          },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          },
-          "page": {
-            "type": "integer",
-            "title": "Page"
-          },
-          "pageSize": {
-            "type": "integer",
-            "title": "Pagesize"
-          }
-        },
-        "type": "object",
-        "required": [
-          "sessions",
-          "total",
-          "page",
-          "pageSize"
-        ],
-        "title": "SessionListResponse"
-      },
-      "SessionNotFoundError": {
-        "properties": {
-          "detail": {
-            "type": "string",
-            "title": "Detail",
-            "default": "Session not found"
-          }
-        },
-        "type": "object",
-        "title": "SessionNotFoundError",
-        "description": "Error response when a session is not found"
-      },
-      "SessionResponse": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Id"
-          },
-          "status": {
-            "$ref": "#/components/schemas/BuAgentSessionStatus"
-          },
-          "model": {
-            "$ref": "#/components/schemas/BuModel"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "output": {
-            "anyOf": [
-              {},
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Output"
-          },
-          "outputSchema": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Outputschema"
-          },
-          "stepCount": {
-            "type": "integer",
-            "title": "Stepcount",
-            "default": 0
-          },
-          "lastStepSummary": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Laststepsummary"
-          },
-          "isTaskSuccessful": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Istasksuccessful"
-          },
-          "liveUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Liveurl"
-          },
-          "recordingUrls": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Recordingurls",
-            "default": []
-          },
-          "profileId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Profileid"
-          },
-          "workspaceId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Workspaceid"
-          },
-          "proxyCountryCode": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ProxyCountryCode"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "maxCostUsd": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Maxcostusd"
-          },
-          "totalInputTokens": {
-            "type": "integer",
-            "title": "Totalinputtokens",
-            "default": 0
-          },
-          "totalOutputTokens": {
-            "type": "integer",
-            "title": "Totaloutputtokens",
-            "default": 0
-          },
-          "proxyUsedMb": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Proxyusedmb",
-            "default": "0"
-          },
-          "llmCostUsd": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Llmcostusd",
-            "default": "0"
-          },
-          "proxyCostUsd": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Proxycostusd",
-            "default": "0"
-          },
-          "browserCostUsd": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Browsercostusd",
-            "default": "0"
-          },
-          "totalCostUsd": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Totalcostusd",
-            "default": "0"
-          },
-          "screenshotUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Screenshoturl"
-          },
-          "agentmailEmail": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Agentmailemail"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Createdat"
-          },
-          "updatedAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updatedat"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "status",
-          "model",
-          "createdAt",
-          "updatedAt"
-        ],
-        "title": "SessionResponse"
-      },
-      "SessionTimeoutLimitExceededError": {
-        "properties": {
-          "detail": {
-            "type": "string",
-            "title": "Detail",
-            "default": "Maximum session timeout is 4 hours (240 minutes)."
-          }
-        },
-        "type": "object",
-        "title": "SessionTimeoutLimitExceededError",
-        "description": "Error response when session timeout exceeds the maximum allowed limit"
-      },
-      "StopSessionRequest": {
-        "properties": {
-          "strategy": {
-            "$ref": "#/components/schemas/StopStrategy",
-            "default": "session"
-          }
-        },
-        "type": "object",
-        "title": "StopSessionRequest"
-      },
-      "StopStrategy": {
-        "type": "string",
-        "enum": [
-          "task",
-          "session"
-        ],
-        "title": "StopStrategy"
-      },
-      "TooManyConcurrentActiveSessionsError": {
-        "properties": {
-          "detail": {
-            "type": "string",
-            "title": "Detail",
-            "default": "Too many concurrent active sessions. Please wait for one to finish, kill one, or upgrade your plan."
-          }
-        },
-        "type": "object",
-        "title": "TooManyConcurrentActiveSessionsError",
-        "description": "Error response when user has too many concurrent active sessions"
-      },
-      "UpdateBrowserSessionRequest": {
-        "properties": {
-          "action": {
-            "$ref": "#/components/schemas/BrowserSessionUpdateAction",
-            "title": "Action",
-            "description": "The action to perform on the session"
-          }
-        },
-        "type": "object",
-        "required": [
-          "action"
-        ],
-        "title": "UpdateBrowserSessionRequest",
-        "description": "Request model for updating browser session state."
-      },
-      "ValidationError": {
-        "properties": {
-          "loc": {
-            "items": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "integer"
+                "responses": {
+                    "201": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BrowserSessionItemView"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Session timeout limit exceeded (maximum 4 hours)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SessionTimeoutLimitExceededError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Profile not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProfileNotFoundError"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Request validation failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "Too many concurrent active sessions",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TooManyConcurrentActiveSessionsError"
+                                }
+                            }
+                        }
+                    }
                 }
-              ]
+            }
+        },
+        "/browsers/{session_id}": {
+            "get": {
+                "tags": [
+                    "Browsers"
+                ],
+                "summary": "Get Browser Session",
+                "description": "Get detailed browser session information including status and URLs.",
+                "operationId": "get_browser_session_browsers__session_id__get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BrowserSessionView"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Session not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SessionNotFoundError"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
             },
-            "type": "array",
-            "title": "Location"
-          },
-          "msg": {
-            "type": "string",
-            "title": "Message"
-          },
-          "type": {
-            "type": "string",
-            "title": "Error Type"
-          }
+            "patch": {
+                "tags": [
+                    "Browsers"
+                ],
+                "summary": "Update Browser Session",
+                "description": "Stop a browser session.\n\n**Refund:** When you stop a session, unused time is automatically refunded.\nIf the session ran for less than 1 hour, you'll receive a proportional refund.\nBilling is ceil to the nearest minute (minimum 1 minute).",
+                "operationId": "update_browser_session_browsers__session_id__patch",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateBrowserSessionRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BrowserSessionView"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Session not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SessionNotFoundError"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Request validation failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         },
-        "type": "object",
-        "required": [
-          "loc",
-          "msg",
-          "type"
-        ],
-        "title": "ValidationError"
-      },
-      "WorkspaceCreateRequest": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 100
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name",
-            "description": "Optional name for the workspace"
-          }
-        },
-        "type": "object",
-        "title": "WorkspaceCreateRequest",
-        "description": "Request model for creating a new workspace."
-      },
-      "WorkspaceListResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/WorkspaceView"
+        "/workspaces": {
+            "get": {
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "List Workspaces",
+                "description": "Get paginated list of workspaces.",
+                "operationId": "list_workspaces_workspaces_get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1,
+                            "default": 10,
+                            "title": "Pagesize"
+                        }
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 1,
+                            "title": "Pagenumber"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/WorkspaceListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
             },
-            "type": "array",
-            "title": "Items",
-            "description": "List of workspace views for the current page"
-          },
-          "totalItems": {
-            "type": "integer",
-            "title": "Total Items",
-            "description": "Total number of items in the list"
-          },
-          "pageNumber": {
-            "type": "integer",
-            "title": "Page Number",
-            "description": "Page number"
-          },
-          "pageSize": {
-            "type": "integer",
-            "title": "Page Size",
-            "description": "Number of items per page"
-          }
+            "post": {
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "Create Workspace",
+                "description": "Create a new workspace for persistent shared file storage across sessions.",
+                "operationId": "create_workspace_workspaces_post",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/WorkspaceCreateRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/WorkspaceView"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         },
-        "type": "object",
-        "required": [
-          "items",
-          "totalItems",
-          "pageNumber",
-          "pageSize"
-        ],
-        "title": "WorkspaceListResponse",
-        "description": "Response model for paginated workspace list requests."
-      },
-      "WorkspaceUpdateRequest": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
+        "/workspaces/{workspace_id}": {
+            "get": {
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "Get Workspace",
+                "description": "Get workspace details.",
+                "operationId": "get_workspace_workspaces__workspace_id__get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "workspace_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Workspace Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/WorkspaceView"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "Update Workspace",
+                "description": "Update a workspace's name.",
+                "operationId": "update_workspace_workspaces__workspace_id__patch",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "workspace_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Workspace Id"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/WorkspaceUpdateRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/WorkspaceView"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "Delete Workspace",
+                "description": "Delete a workspace and its S3 data.",
+                "operationId": "delete_workspace_workspaces__workspace_id__delete",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "workspace_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Workspace Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful Response"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{workspace_id}/files": {
+            "get": {
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "List Workspace Files",
+                "description": "List files in a workspace's S3 prefix.",
+                "operationId": "list_workspace_files_workspaces__workspace_id__files_get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "workspace_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Workspace Id"
+                        }
+                    },
+                    {
+                        "name": "prefix",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "",
+                            "title": "Prefix"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1,
+                            "default": 50,
+                            "title": "Limit"
+                        }
+                    },
+                    {
+                        "name": "cursor",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Cursor"
+                        }
+                    },
+                    {
+                        "name": "includeUrls",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false,
+                            "title": "Includeurls"
+                        }
+                    },
+                    {
+                        "name": "shallow",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false,
+                            "title": "Shallow"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FileListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "Delete Workspace File",
+                "description": "Delete a single file from a workspace.",
+                "operationId": "delete_workspace_file_workspaces__workspace_id__files_delete",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "workspace_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Workspace Id"
+                        }
+                    },
+                    {
+                        "name": "path",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "description": "Relative file path to delete",
+                            "title": "Path"
+                        },
+                        "description": "Relative file path to delete"
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful Response"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{workspace_id}/size": {
+            "get": {
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "Get Workspace Size",
+                "description": "Get current storage usage for a workspace.",
+                "operationId": "get_workspace_size_workspaces__workspace_id__size_get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "workspace_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Workspace Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{workspace_id}/files/upload": {
+            "post": {
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "Upload Workspace Files",
+                "description": "Get presigned PUT URLs for uploading files to a workspace.",
+                "operationId": "upload_workspace_files_workspaces__workspace_id__files_upload_post",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "workspace_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Workspace Id"
+                        }
+                    },
+                    {
+                        "name": "prefix",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "description": "Directory prefix to upload into (e.g. \"uploads/\")",
+                            "default": "",
+                            "title": "Prefix"
+                        },
+                        "description": "Directory prefix to upload into (e.g. \"uploads/\")"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FileUploadRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FileUploadResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "AccountNotFoundError": {
+                "properties": {
+                    "detail": {
+                        "type": "string",
+                        "title": "Detail",
+                        "default": "Account not found"
+                    }
+                },
+                "type": "object",
+                "title": "AccountNotFoundError",
+                "description": "Error response when an account is not found"
+            },
+            "AccountView": {
+                "properties": {
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name",
+                        "description": "The name of the user"
+                    },
+                    "totalCreditsBalanceUsd": {
+                        "type": "number",
+                        "title": "Credits Balance USD",
+                        "description": "The total credits balance in USD"
+                    },
+                    "monthlyCreditsBalanceUsd": {
+                        "type": "number",
+                        "title": "Monthly Credits Balance USD",
+                        "description": "Monthly subscription credits balance in USD"
+                    },
+                    "additionalCreditsBalanceUsd": {
+                        "type": "number",
+                        "title": "Additional Credits Balance USD",
+                        "description": "Additional top-up credits balance in USD"
+                    },
+                    "rateLimit": {
+                        "type": "integer",
+                        "title": "Rate Limit",
+                        "description": "The rate limit for the account"
+                    },
+                    "planInfo": {
+                        "$ref": "#/components/schemas/PlanInfo",
+                        "title": "Plan Info",
+                        "description": "The plan information"
+                    },
+                    "projectId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Project ID",
+                        "description": "The ID of the project"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "totalCreditsBalanceUsd",
+                    "monthlyCreditsBalanceUsd",
+                    "additionalCreditsBalanceUsd",
+                    "rateLimit",
+                    "planInfo",
+                    "projectId"
+                ],
+                "title": "AccountView",
+                "description": "View model for account information."
+            },
+            "BrowserSessionItemView": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "ID",
+                        "description": "Unique identifier for the session"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/BrowserSessionStatus",
+                        "title": "Status",
+                        "description": "Current status of the session (active/stopped)"
+                    },
+                    "liveUrl": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Live URL",
+                        "description": "URL where the browser can be viewed live in real-time"
+                    },
+                    "cdpUrl": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "CDP URL",
+                        "description": "Chrome DevTools Protocol URL for browser automation"
+                    },
+                    "timeoutAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Timeout At",
+                        "description": "Timestamp when the session will timeout"
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Started At",
+                        "description": "Timestamp when the session was created and started"
+                    },
+                    "finishedAt": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Finished At",
+                        "description": "Timestamp when the session was stopped (None if still active)"
+                    },
+                    "proxyUsedMb": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Proxy Used MB",
+                        "description": "Amount of proxy data used in MB",
+                        "default": "0"
+                    },
+                    "proxyCost": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Proxy Cost",
+                        "description": "Cost of proxy usage in USD",
+                        "default": "0"
+                    },
+                    "browserCost": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Browser Cost",
+                        "description": "Cost of browser session hosting in USD",
+                        "default": "0"
+                    },
+                    "agentSessionId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Agent Session ID",
+                        "description": "ID of the agent session that created this browser (None for standalone BaaS sessions)"
+                    },
+                    "recordingUrl": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Recording URL",
+                        "description": "Presigned URL to download the session recording (available after session ends, if recording was enabled)"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "status",
+                    "timeoutAt",
+                    "startedAt"
+                ],
+                "title": "BrowserSessionItemView",
+                "description": "View model for representing a browser session in list views."
+            },
+            "BrowserSessionListResponse": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "$ref": "#/components/schemas/BrowserSessionItemView"
+                        },
+                        "type": "array",
+                        "title": "Items",
+                        "description": "List of browser session views for the current page"
+                    },
+                    "totalItems": {
+                        "type": "integer",
+                        "title": "Total Items",
+                        "description": "Total number of items in the list"
+                    },
+                    "pageNumber": {
+                        "type": "integer",
+                        "title": "Page Number",
+                        "description": "Page number"
+                    },
+                    "pageSize": {
+                        "type": "integer",
+                        "title": "Page Size",
+                        "description": "Number of items per page"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "items",
+                    "totalItems",
+                    "pageNumber",
+                    "pageSize"
+                ],
+                "title": "BrowserSessionListResponse",
+                "description": "Response model for paginated browser session list requests."
+            },
+            "BrowserSessionStatus": {
                 "type": "string",
-                "maxLength": 100
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name",
-            "description": "Optional name for the workspace"
-          }
+                "enum": [
+                    "active",
+                    "stopped"
+                ],
+                "title": "BrowserSessionStatus",
+                "description": "Enumeration of possible browser session states\n\nAttributes:\n    ACTIVE: Session is currently active and running (browser is running)\n    STOPPED: Session has been stopped and is no longer active (browser is stopped)"
+            },
+            "BrowserSessionUpdateAction": {
+                "type": "string",
+                "enum": [
+                    "stop"
+                ],
+                "title": "BrowserSessionUpdateAction",
+                "description": "Available actions that can be performed on a browser session\n\nAttributes:\n    STOP: Stop the browser session (cannot be undone)"
+            },
+            "BrowserSessionView": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "ID",
+                        "description": "Unique identifier for the session"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/BrowserSessionStatus",
+                        "title": "Status",
+                        "description": "Current status of the session (active/stopped)"
+                    },
+                    "liveUrl": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Live URL",
+                        "description": "URL where the browser can be viewed live in real-time"
+                    },
+                    "cdpUrl": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "CDP URL",
+                        "description": "Chrome DevTools Protocol URL for browser automation"
+                    },
+                    "timeoutAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Timeout At",
+                        "description": "Timestamp when the session will timeout"
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Started At",
+                        "description": "Timestamp when the session was created and started"
+                    },
+                    "finishedAt": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Finished At",
+                        "description": "Timestamp when the session was stopped (None if still active)"
+                    },
+                    "proxyUsedMb": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Proxy Used MB",
+                        "description": "Amount of proxy data used in MB",
+                        "default": "0"
+                    },
+                    "proxyCost": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Proxy Cost",
+                        "description": "Cost of proxy usage in USD",
+                        "default": "0"
+                    },
+                    "browserCost": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Browser Cost",
+                        "description": "Cost of browser session hosting in USD",
+                        "default": "0"
+                    },
+                    "agentSessionId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Agent Session ID",
+                        "description": "ID of the agent session that created this browser (None for standalone BaaS sessions)"
+                    },
+                    "recordingUrl": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Recording URL",
+                        "description": "Presigned URL to download the session recording (available after session ends, if recording was enabled)"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "status",
+                    "timeoutAt",
+                    "startedAt"
+                ],
+                "title": "BrowserSessionView",
+                "description": "View model for representing a browser session."
+            },
+            "BuAgentSessionStatus": {
+                "type": "string",
+                "enum": [
+                    "created",
+                    "idle",
+                    "running",
+                    "stopped",
+                    "timed_out",
+                    "error"
+                ],
+                "title": "BuAgentSessionStatus"
+            },
+            "BuModel": {
+                "type": "string",
+                "enum": [
+                    "bu-mini",
+                    "bu-max",
+                    "bu-ultra"
+                ],
+                "title": "BuModel"
+            },
+            "CreateBrowserSessionRequest": {
+                "properties": {
+                    "profileId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Profile ID",
+                        "description": "The ID of the profile to use for the session"
+                    },
+                    "proxyCountryCode": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ProxyCountryCode"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Proxy Country Code",
+                        "description": "Country code for proxy location. Defaults to US. Set to null to disable proxy.",
+                        "default": "us"
+                    },
+                    "timeout": {
+                        "type": "integer",
+                        "title": "Timeout",
+                        "description": "The timeout for the session in minutes. All users can use up to 240 minutes (4 hours). Pay As You Go users are charged $0.06/hour, subscribers get 50% off.",
+                        "default": 60,
+                        "ge": 1,
+                        "le": 240
+                    },
+                    "browserScreenWidth": {
+                        "anyOf": [
+                            {
+                                "type": "integer",
+                                "maximum": 6144.0,
+                                "minimum": 320.0
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Browser Screen Width",
+                        "description": "Custom screen width in pixels for the browser."
+                    },
+                    "browserScreenHeight": {
+                        "anyOf": [
+                            {
+                                "type": "integer",
+                                "maximum": 3456.0,
+                                "minimum": 320.0
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Browser Screen Height",
+                        "description": "Custom screen height in pixels for the browser."
+                    },
+                    "allowResizing": {
+                        "type": "boolean",
+                        "title": "Allow Resizing",
+                        "description": "Whether to allow the browser to be resized during the session (not recommended since it reduces stealthiness).",
+                        "default": false
+                    },
+                    "customProxy": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/CustomProxy"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Custom Proxy",
+                        "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are only available on the Custom Enterprise plan."
+                    },
+                    "enableRecording": {
+                        "type": "boolean",
+                        "title": "Enable Recording",
+                        "description": "If True, enables session recording. Defaults to False.",
+                        "default": false
+                    }
+                },
+                "type": "object",
+                "title": "CreateBrowserSessionRequest",
+                "description": "Request model for creating a browser session."
+            },
+            "CustomProxy": {
+                "properties": {
+                    "host": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "minLength": 1,
+                        "title": "Host",
+                        "description": "Host of the proxy."
+                    },
+                    "port": {
+                        "type": "integer",
+                        "maximum": 65535.0,
+                        "minimum": 1.0,
+                        "title": "Port",
+                        "description": "Port of the proxy."
+                    },
+                    "username": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 255,
+                                "minLength": 1
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Username",
+                        "description": "Username for proxy authentication."
+                    },
+                    "password": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 255,
+                                "minLength": 1
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Password",
+                        "description": "Password for proxy authentication."
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "host",
+                    "port"
+                ],
+                "title": "CustomProxy",
+                "description": "Request model for creating a custom proxy."
+            },
+            "FileInfo": {
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "title": "Path"
+                    },
+                    "size": {
+                        "type": "integer",
+                        "title": "Size"
+                    },
+                    "lastModified": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Lastmodified"
+                    },
+                    "url": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Url"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "path",
+                    "size",
+                    "lastModified"
+                ],
+                "title": "FileInfo",
+                "description": "A file in a session's workspace."
+            },
+            "FileListResponse": {
+                "properties": {
+                    "files": {
+                        "items": {
+                            "$ref": "#/components/schemas/FileInfo"
+                        },
+                        "type": "array",
+                        "title": "Files"
+                    },
+                    "folders": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Folders",
+                        "description": "Immediate sub-folder names at this prefix level"
+                    },
+                    "nextCursor": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Nextcursor"
+                    },
+                    "hasMore": {
+                        "type": "boolean",
+                        "title": "Hasmore",
+                        "default": false
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "files"
+                ],
+                "title": "FileListResponse",
+                "description": "Paginated file listing with optional presigned download URLs."
+            },
+            "FileUploadItem": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "minLength": 1,
+                        "title": "Name",
+                        "description": "Filename, e.g. \"data.csv\""
+                    },
+                    "contentType": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "title": "Contenttype",
+                        "description": "MIME type, e.g. \"text/csv\"",
+                        "default": "application/octet-stream"
+                    },
+                    "size": {
+                        "anyOf": [
+                            {
+                                "type": "integer",
+                                "minimum": 1.0
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Size",
+                        "description": "File size in bytes (required for workspace uploads)"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "title": "FileUploadItem",
+                "description": "A single file to upload."
+            },
+            "FileUploadRequest": {
+                "properties": {
+                    "files": {
+                        "items": {
+                            "$ref": "#/components/schemas/FileUploadItem"
+                        },
+                        "type": "array",
+                        "maxItems": 10,
+                        "minItems": 1,
+                        "title": "Files"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "files"
+                ],
+                "title": "FileUploadRequest",
+                "description": "Request body for generating presigned upload URLs."
+            },
+            "FileUploadResponse": {
+                "properties": {
+                    "files": {
+                        "items": {
+                            "$ref": "#/components/schemas/FileUploadResponseItem"
+                        },
+                        "type": "array",
+                        "title": "Files"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "files"
+                ],
+                "title": "FileUploadResponse",
+                "description": "Presigned upload URLs for the requested files."
+            },
+            "FileUploadResponseItem": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "title": "Name"
+                    },
+                    "uploadUrl": {
+                        "type": "string",
+                        "title": "Uploadurl"
+                    },
+                    "path": {
+                        "type": "string",
+                        "title": "Path",
+                        "description": "S3-relative path, e.g. \"uploads/data.csv\""
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "name",
+                    "uploadUrl",
+                    "path"
+                ],
+                "title": "FileUploadResponseItem",
+                "description": "Presigned upload URL for a single file."
+            },
+            "HTTPValidationError": {
+                "properties": {
+                    "detail": {
+                        "items": {
+                            "$ref": "#/components/schemas/ValidationError"
+                        },
+                        "type": "array",
+                        "title": "Detail"
+                    }
+                },
+                "type": "object",
+                "title": "HTTPValidationError"
+            },
+            "InsufficientCreditsError": {
+                "properties": {
+                    "detail": {
+                        "type": "string",
+                        "title": "Detail",
+                        "default": "Insufficient credits"
+                    }
+                },
+                "type": "object",
+                "title": "InsufficientCreditsError",
+                "description": "Error response when there are insufficient credits"
+            },
+            "MessageListResponse": {
+                "properties": {
+                    "messages": {
+                        "items": {
+                            "$ref": "#/components/schemas/MessageResponse"
+                        },
+                        "type": "array",
+                        "title": "Messages"
+                    },
+                    "hasMore": {
+                        "type": "boolean",
+                        "title": "Hasmore"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "messages",
+                    "hasMore"
+                ],
+                "title": "MessageListResponse"
+            },
+            "MessageResponse": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "sessionId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Sessionid"
+                    },
+                    "role": {
+                        "type": "string",
+                        "title": "Role"
+                    },
+                    "data": {
+                        "type": "string",
+                        "title": "Data"
+                    },
+                    "type": {
+                        "type": "string",
+                        "title": "Type",
+                        "description": "Coarse category: user_message, assistant_message, browser_action, file_operation, code_execution, integration, planning, completion, browser_action_result, browser_action_error, etc.",
+                        "default": ""
+                    },
+                    "summary": {
+                        "type": "string",
+                        "title": "Summary",
+                        "description": "One-liner human-readable description of the message (e.g. \"Navigating to google.com\", \"Clicking element #5\").",
+                        "default": ""
+                    },
+                    "screenshotUrl": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Screenshoturl"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Createdat"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "sessionId",
+                    "role",
+                    "data",
+                    "createdAt"
+                ],
+                "title": "MessageResponse"
+            },
+            "PlanInfo": {
+                "properties": {
+                    "planName": {
+                        "type": "string",
+                        "title": "Plan Name",
+                        "description": "The name of the plan"
+                    },
+                    "subscriptionStatus": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Subscription Status",
+                        "description": "The status of the subscription"
+                    },
+                    "subscriptionId": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Subscription ID",
+                        "description": "The ID of the subscription"
+                    },
+                    "subscriptionCurrentPeriodEnd": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Subscription Current Period End",
+                        "description": "The end of the current period"
+                    },
+                    "subscriptionCanceledAt": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Subscription Canceled At",
+                        "description": "The date the subscription was canceled"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "planName",
+                    "subscriptionStatus",
+                    "subscriptionId",
+                    "subscriptionCurrentPeriodEnd",
+                    "subscriptionCanceledAt"
+                ],
+                "title": "PlanInfo",
+                "description": "View model for plan information"
+            },
+            "ProfileCreateRequest": {
+                "properties": {
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 100
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name",
+                        "description": "Optional name for the profile"
+                    },
+                    "userId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 255
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "User ID",
+                        "description": "Your internal user identifier for this profile. Use this to associate a profile with a user in your system."
+                    }
+                },
+                "type": "object",
+                "title": "ProfileCreateRequest",
+                "description": "Request model for creating a new profile."
+            },
+            "ProfileListResponse": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "$ref": "#/components/schemas/ProfileView"
+                        },
+                        "type": "array",
+                        "title": "Items",
+                        "description": "List of profile views for the current page"
+                    },
+                    "totalItems": {
+                        "type": "integer",
+                        "title": "Total Items",
+                        "description": "Total number of items in the list"
+                    },
+                    "pageNumber": {
+                        "type": "integer",
+                        "title": "Page Number",
+                        "description": "Page number"
+                    },
+                    "pageSize": {
+                        "type": "integer",
+                        "title": "Page Size",
+                        "description": "Number of items per page"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "items",
+                    "totalItems",
+                    "pageNumber",
+                    "pageSize"
+                ],
+                "title": "ProfileListResponse",
+                "description": "Response model for paginated profile list requests."
+            },
+            "ProfileNotFoundError": {
+                "properties": {
+                    "detail": {
+                        "type": "string",
+                        "title": "Detail",
+                        "default": "Profile not found"
+                    }
+                },
+                "type": "object",
+                "title": "ProfileNotFoundError",
+                "description": "Error response when a profile is not found"
+            },
+            "ProfileUpdateRequest": {
+                "properties": {
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 100
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name",
+                        "description": "Optional name for the profile"
+                    },
+                    "userId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 255
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "User ID",
+                        "description": "Your internal user identifier for this profile. Use this to associate a profile with a user in your system."
+                    }
+                },
+                "type": "object",
+                "title": "ProfileUpdateRequest",
+                "description": "Request model for updating a profile."
+            },
+            "ProfileView": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "ID",
+                        "description": "Unique identifier for the profile"
+                    },
+                    "userId": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "User ID",
+                        "description": "Your internal user identifier for this profile. Use this to associate a profile with a user in your system."
+                    },
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name",
+                        "description": "Optional name for the profile"
+                    },
+                    "lastUsedAt": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Last Used At",
+                        "description": "Timestamp when the profile was last used"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Created At",
+                        "description": "Timestamp when the profile was created"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Updated At",
+                        "description": "Timestamp when the profile was last updated"
+                    },
+                    "cookieDomains": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cookie Domains",
+                        "description": "List of domain URLs that have cookies stored for this profile"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "createdAt",
+                    "updatedAt"
+                ],
+                "title": "ProfileView",
+                "description": "View model for representing a profile. A profile lets you preserve the login state between sessions.\n\nWe recommend that you create a separate profile for each user of your app.\nYou can assign a user_id to each profile to easily identify which user the profile belongs to."
+            },
+            "ProxyCountryCode": {
+                "type": "string",
+                "enum": [
+                    "ad",
+                    "ae",
+                    "af",
+                    "ag",
+                    "ai",
+                    "al",
+                    "am",
+                    "an",
+                    "ao",
+                    "aq",
+                    "ar",
+                    "as",
+                    "at",
+                    "au",
+                    "aw",
+                    "az",
+                    "ba",
+                    "bb",
+                    "bd",
+                    "be",
+                    "bf",
+                    "bg",
+                    "bh",
+                    "bi",
+                    "bj",
+                    "bl",
+                    "bm",
+                    "bn",
+                    "bo",
+                    "bq",
+                    "br",
+                    "bs",
+                    "bt",
+                    "bv",
+                    "bw",
+                    "by",
+                    "bz",
+                    "ca",
+                    "cc",
+                    "cd",
+                    "cf",
+                    "cg",
+                    "ch",
+                    "ck",
+                    "cl",
+                    "cm",
+                    "co",
+                    "cr",
+                    "cs",
+                    "cu",
+                    "cv",
+                    "cw",
+                    "cx",
+                    "cy",
+                    "cz",
+                    "de",
+                    "dj",
+                    "dk",
+                    "dm",
+                    "do",
+                    "dz",
+                    "ec",
+                    "ee",
+                    "eg",
+                    "eh",
+                    "er",
+                    "es",
+                    "et",
+                    "fi",
+                    "fj",
+                    "fk",
+                    "fm",
+                    "fo",
+                    "fr",
+                    "ga",
+                    "gd",
+                    "ge",
+                    "gf",
+                    "gg",
+                    "gh",
+                    "gi",
+                    "gl",
+                    "gm",
+                    "gn",
+                    "gp",
+                    "gq",
+                    "gr",
+                    "gs",
+                    "gt",
+                    "gu",
+                    "gw",
+                    "gy",
+                    "hk",
+                    "hm",
+                    "hn",
+                    "hr",
+                    "ht",
+                    "hu",
+                    "id",
+                    "ie",
+                    "il",
+                    "im",
+                    "in",
+                    "iq",
+                    "ir",
+                    "is",
+                    "it",
+                    "je",
+                    "jm",
+                    "jo",
+                    "jp",
+                    "ke",
+                    "kg",
+                    "kh",
+                    "ki",
+                    "km",
+                    "kn",
+                    "kp",
+                    "kr",
+                    "kw",
+                    "ky",
+                    "kz",
+                    "la",
+                    "lb",
+                    "lc",
+                    "li",
+                    "lk",
+                    "lr",
+                    "ls",
+                    "lt",
+                    "lu",
+                    "lv",
+                    "ly",
+                    "ma",
+                    "mc",
+                    "md",
+                    "me",
+                    "mf",
+                    "mg",
+                    "mh",
+                    "mk",
+                    "ml",
+                    "mm",
+                    "mn",
+                    "mo",
+                    "mp",
+                    "mq",
+                    "mr",
+                    "ms",
+                    "mt",
+                    "mu",
+                    "mv",
+                    "mw",
+                    "mx",
+                    "my",
+                    "mz",
+                    "na",
+                    "nc",
+                    "ne",
+                    "nf",
+                    "ng",
+                    "ni",
+                    "nl",
+                    "no",
+                    "np",
+                    "nr",
+                    "nu",
+                    "nz",
+                    "om",
+                    "pa",
+                    "pe",
+                    "pf",
+                    "pg",
+                    "ph",
+                    "pk",
+                    "pl",
+                    "pm",
+                    "pn",
+                    "pr",
+                    "ps",
+                    "pt",
+                    "pw",
+                    "py",
+                    "qa",
+                    "re",
+                    "ro",
+                    "rs",
+                    "ru",
+                    "rw",
+                    "sa",
+                    "sb",
+                    "sc",
+                    "sd",
+                    "se",
+                    "sg",
+                    "sh",
+                    "si",
+                    "sj",
+                    "sk",
+                    "sl",
+                    "sm",
+                    "sn",
+                    "so",
+                    "sr",
+                    "ss",
+                    "st",
+                    "sv",
+                    "sx",
+                    "sy",
+                    "sz",
+                    "tc",
+                    "td",
+                    "tf",
+                    "tg",
+                    "th",
+                    "tj",
+                    "tk",
+                    "tl",
+                    "tm",
+                    "tn",
+                    "to",
+                    "tr",
+                    "tt",
+                    "tv",
+                    "tw",
+                    "tz",
+                    "ua",
+                    "ug",
+                    "uk",
+                    "us",
+                    "uy",
+                    "uz",
+                    "va",
+                    "vc",
+                    "ve",
+                    "vg",
+                    "vi",
+                    "vn",
+                    "vu",
+                    "wf",
+                    "ws",
+                    "xk",
+                    "ye",
+                    "yt",
+                    "za",
+                    "zm",
+                    "zw"
+                ],
+                "title": "ProxyCountryCode"
+            },
+            "RunTaskRequest": {
+                "properties": {
+                    "task": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Task"
+                    },
+                    "model": {
+                        "$ref": "#/components/schemas/BuModel",
+                        "default": "bu-mini"
+                    },
+                    "sessionId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Sessionid"
+                    },
+                    "keepAlive": {
+                        "type": "boolean",
+                        "title": "Keepalive",
+                        "default": false
+                    },
+                    "maxCostUsd": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Maxcostusd"
+                    },
+                    "profileId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Profileid"
+                    },
+                    "workspaceId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Workspaceid"
+                    },
+                    "proxyCountryCode": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ProxyCountryCode"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "default": "us"
+                    },
+                    "outputSchema": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Outputschema"
+                    },
+                    "enableScheduledTasks": {
+                        "type": "boolean",
+                        "title": "Enablescheduledtasks",
+                        "default": false
+                    },
+                    "enableRecording": {
+                        "type": "boolean",
+                        "title": "Enablerecording",
+                        "default": false
+                    },
+                    "skills": {
+                        "type": "boolean",
+                        "title": "Skills",
+                        "default": true
+                    },
+                    "agentmail": {
+                        "type": "boolean",
+                        "title": "Agentmail",
+                        "default": true
+                    }
+                },
+                "type": "object",
+                "title": "RunTaskRequest",
+                "description": "Unified request for creating a session or dispatching a task.\n\n- Without session_id + without task: creates a new idle session (for file uploads, etc.)\n- Without session_id + with task: creates a new session and dispatches the task\n- With session_id + with task: dispatches the task to an existing idle session\n- With session_id + without task: 422 (task required when dispatching to existing session)"
+            },
+            "SessionListResponse": {
+                "properties": {
+                    "sessions": {
+                        "items": {
+                            "$ref": "#/components/schemas/SessionResponse"
+                        },
+                        "type": "array",
+                        "title": "Sessions"
+                    },
+                    "total": {
+                        "type": "integer",
+                        "title": "Total"
+                    },
+                    "page": {
+                        "type": "integer",
+                        "title": "Page"
+                    },
+                    "pageSize": {
+                        "type": "integer",
+                        "title": "Pagesize"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "sessions",
+                    "total",
+                    "page",
+                    "pageSize"
+                ],
+                "title": "SessionListResponse"
+            },
+            "SessionNotFoundError": {
+                "properties": {
+                    "detail": {
+                        "type": "string",
+                        "title": "Detail",
+                        "default": "Session not found"
+                    }
+                },
+                "type": "object",
+                "title": "SessionNotFoundError",
+                "description": "Error response when a session is not found"
+            },
+            "SessionResponse": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/BuAgentSessionStatus"
+                    },
+                    "model": {
+                        "$ref": "#/components/schemas/BuModel"
+                    },
+                    "title": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Title"
+                    },
+                    "output": {
+                        "anyOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Output"
+                    },
+                    "outputSchema": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Outputschema"
+                    },
+                    "stepCount": {
+                        "type": "integer",
+                        "title": "Stepcount",
+                        "default": 0
+                    },
+                    "lastStepSummary": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Laststepsummary"
+                    },
+                    "isTaskSuccessful": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Istasksuccessful"
+                    },
+                    "liveUrl": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Liveurl"
+                    },
+                    "recordingUrls": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Recordingurls",
+                        "default": []
+                    },
+                    "profileId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Profileid"
+                    },
+                    "workspaceId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Workspaceid"
+                    },
+                    "proxyCountryCode": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ProxyCountryCode"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "maxCostUsd": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Maxcostusd"
+                    },
+                    "totalInputTokens": {
+                        "type": "integer",
+                        "title": "Totalinputtokens",
+                        "default": 0
+                    },
+                    "totalOutputTokens": {
+                        "type": "integer",
+                        "title": "Totaloutputtokens",
+                        "default": 0
+                    },
+                    "proxyUsedMb": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Proxyusedmb",
+                        "default": "0"
+                    },
+                    "llmCostUsd": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Llmcostusd",
+                        "default": "0"
+                    },
+                    "proxyCostUsd": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Proxycostusd",
+                        "default": "0"
+                    },
+                    "browserCostUsd": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Browsercostusd",
+                        "default": "0"
+                    },
+                    "totalCostUsd": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Totalcostusd",
+                        "default": "0"
+                    },
+                    "screenshotUrl": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Screenshoturl"
+                    },
+                    "agentmailEmail": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Agentmailemail"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Createdat"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Updatedat"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "status",
+                    "model",
+                    "createdAt",
+                    "updatedAt"
+                ],
+                "title": "SessionResponse"
+            },
+            "SessionTimeoutLimitExceededError": {
+                "properties": {
+                    "detail": {
+                        "type": "string",
+                        "title": "Detail",
+                        "default": "Maximum session timeout is 4 hours (240 minutes)."
+                    }
+                },
+                "type": "object",
+                "title": "SessionTimeoutLimitExceededError",
+                "description": "Error response when session timeout exceeds the maximum allowed limit"
+            },
+            "StopSessionRequest": {
+                "properties": {
+                    "strategy": {
+                        "$ref": "#/components/schemas/StopStrategy",
+                        "default": "session"
+                    }
+                },
+                "type": "object",
+                "title": "StopSessionRequest"
+            },
+            "StopStrategy": {
+                "type": "string",
+                "enum": [
+                    "task",
+                    "session"
+                ],
+                "title": "StopStrategy"
+            },
+            "TooManyConcurrentActiveSessionsError": {
+                "properties": {
+                    "detail": {
+                        "type": "string",
+                        "title": "Detail",
+                        "default": "Too many concurrent active sessions. Please wait for one to finish, kill one, or upgrade your plan."
+                    }
+                },
+                "type": "object",
+                "title": "TooManyConcurrentActiveSessionsError",
+                "description": "Error response when user has too many concurrent active sessions"
+            },
+            "UpdateBrowserSessionRequest": {
+                "properties": {
+                    "action": {
+                        "$ref": "#/components/schemas/BrowserSessionUpdateAction",
+                        "title": "Action",
+                        "description": "The action to perform on the session"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "action"
+                ],
+                "title": "UpdateBrowserSessionRequest",
+                "description": "Request model for updating browser session state."
+            },
+            "ValidationError": {
+                "properties": {
+                    "loc": {
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ]
+                        },
+                        "type": "array",
+                        "title": "Location"
+                    },
+                    "msg": {
+                        "type": "string",
+                        "title": "Message"
+                    },
+                    "type": {
+                        "type": "string",
+                        "title": "Error Type"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "loc",
+                    "msg",
+                    "type"
+                ],
+                "title": "ValidationError"
+            },
+            "WorkspaceCreateRequest": {
+                "properties": {
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 100
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name",
+                        "description": "Optional name for the workspace"
+                    }
+                },
+                "type": "object",
+                "title": "WorkspaceCreateRequest",
+                "description": "Request model for creating a new workspace."
+            },
+            "WorkspaceListResponse": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "$ref": "#/components/schemas/WorkspaceView"
+                        },
+                        "type": "array",
+                        "title": "Items",
+                        "description": "List of workspace views for the current page"
+                    },
+                    "totalItems": {
+                        "type": "integer",
+                        "title": "Total Items",
+                        "description": "Total number of items in the list"
+                    },
+                    "pageNumber": {
+                        "type": "integer",
+                        "title": "Page Number",
+                        "description": "Page number"
+                    },
+                    "pageSize": {
+                        "type": "integer",
+                        "title": "Page Size",
+                        "description": "Number of items per page"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "items",
+                    "totalItems",
+                    "pageNumber",
+                    "pageSize"
+                ],
+                "title": "WorkspaceListResponse",
+                "description": "Response model for paginated workspace list requests."
+            },
+            "WorkspaceUpdateRequest": {
+                "properties": {
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 100
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name",
+                        "description": "Optional name for the workspace"
+                    }
+                },
+                "type": "object",
+                "title": "WorkspaceUpdateRequest",
+                "description": "Request model for updating a workspace."
+            },
+            "WorkspaceView": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "ID",
+                        "description": "Unique identifier for the workspace"
+                    },
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name",
+                        "description": "Optional name for the workspace"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Created At",
+                        "description": "Timestamp when the workspace was created"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Updated At",
+                        "description": "Timestamp when the workspace was last updated"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "createdAt",
+                    "updatedAt"
+                ],
+                "title": "WorkspaceView",
+                "description": "View model for a workspace \u2014 persistent shared storage across sessions."
+            }
         },
-        "type": "object",
-        "title": "WorkspaceUpdateRequest",
-        "description": "Request model for updating a workspace."
-      },
-      "WorkspaceView": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "ID",
-            "description": "Unique identifier for the workspace"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name",
-            "description": "Optional name for the workspace"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At",
-            "description": "Timestamp when the workspace was created"
-          },
-          "updatedAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At",
-            "description": "Timestamp when the workspace was last updated"
-          }
+        "securitySchemes": {
+            "APIKeyHeader": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "X-Browser-Use-API-Key"
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "Sessions"
         },
-        "type": "object",
-        "required": [
-          "id",
-          "createdAt",
-          "updatedAt"
-        ],
-        "title": "WorkspaceView",
-        "description": "View model for a workspace \u2014 persistent shared storage across sessions."
-      }
-    },
-    "securitySchemes": {
-      "APIKeyHeader": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-Browser-Use-API-Key"
-      }
-    }
-  },
-  "tags": [
-    {
-      "name": "Sessions"
-    },
-    {
-      "name": "Browsers"
-    },
-    {
-      "name": "Profiles"
-    },
-    {
-      "name": "Workspaces",
-      "description": "File handling across sessions. Upload and download files, give the agent persistent memory."
-    },
-    {
-      "name": "Files"
-    },
-    {
-      "name": "Billing"
-    }
-  ]
+        {
+            "name": "Profiles"
+        },
+        {
+            "name": "Browsers"
+        },
+        {
+            "name": "Workspaces"
+        },
+        {
+            "name": "Files"
+        },
+        {
+            "name": "Billing"
+        }
+    ]
 }

--- a/docs/cloud/openapi/v3.json
+++ b/docs/cloud/openapi/v3.json
@@ -1,3644 +1,3623 @@
 {
-  "openapi": "3.1.0",
-  "info": {
-    "title": "Browser Use Public API v3",
-    "summary": "Browser Use session-based agent API (v3)",
-    "version": "3.0.0"
-  },
-  "servers": [
-    {
-      "url": "https://api.browser-use.com/api/v3",
-      "description": "Production server"
-    }
-  ],
-  "paths": {
-    "/sessions": {
-      "post": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "Create Session",
-        "description": "Create a session and/or dispatch a task.\n\n- Without session_id, without task: creates a new idle session (e.g. for file uploads).\n- Without session_id, with task: creates a new session and dispatches the task.\n- With session_id, with task: dispatches the task to an existing idle session.\n- With session_id, without task: 422 \u2014 task is required when targeting an existing session.\n\nIf keep_alive is false (default), the session auto-stops when the task finishes.\nIf keep_alive is true, the session stays idle after the task, ready for follow-ups.",
-        "operationId": "create_session_sessions_post",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RunTaskRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          },
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionResponse"
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "List Sessions",
-        "description": "List sessions for the authenticated project.",
-        "operationId": "list_sessions_sessions_get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1,
-              "title": "Page"
-            }
-          },
-          {
-            "name": "page_size",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 20,
-              "title": "Page Size"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionListResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Browser Use Public API v3",
+        "summary": "Browser Use session-based agent API (v3)",
+        "version": "3.0.0"
     },
-    "/sessions/{session_id}": {
-      "get": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "Get Session",
-        "description": "Get session details. Use this to poll for task completion and output.",
-        "operationId": "get_session_sessions__session_id__get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Session Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
+    "servers": [
+        {
+            "url": "https://api.browser-use.com/api/v3",
+            "description": "Production server"
         }
-      },
-      "delete": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "Delete Session",
-        "description": "Soft-delete a session. Stops the sandbox first if still running.",
-        "operationId": "delete_session_sessions__session_id__delete",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Session Id"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/sessions/{session_id}/stop": {
-      "post": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "Stop Session",
-        "description": "Stop a session or the running task.\n\n- strategy=session (default): destroy sandbox entirely, session \u2192 stopped.\n- strategy=task: stop the running query, session stays alive (\u2192 idle).",
-        "operationId": "stop_session_sessions__session_id__stop_post",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Session Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "anyOf": [
-                  {
-                    "$ref": "#/components/schemas/StopSessionRequest"
-                  },
-                  {
-                    "type": "null"
-                  }
+    ],
+    "paths": {
+        "/sessions": {
+            "post": {
+                "tags": [
+                    "Sessions"
                 ],
-                "title": "Body"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/sessions/{session_id}/messages": {
-      "get": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "List Session Messages",
-        "description": "Return messages for a session with cursor-based pagination (chronological order).",
-        "operationId": "list_session_messages_sessions__session_id__messages_get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Session Id"
-            }
-          },
-          {
-            "name": "after",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "uuid"
+                "summary": "Create Session",
+                "description": "Create a session and/or dispatch a task.\n\n- Without session_id, without task: creates a new idle session (e.g. for file uploads).\n- Without session_id, with task: creates a new session and dispatches the task.\n- With session_id, with task: dispatches the task to an existing idle session.\n- With session_id, without task: 422 \u2014 task is required when targeting an existing session.\n\nIf keep_alive is false (default), the session auto-stops when the task finishes.\nIf keep_alive is true, the session stays idle after the task, ready for follow-ups.",
+                "operationId": "create_session_sessions_post",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RunTaskRequest"
+                            }
+                        }
+                    }
                 },
-                {
-                  "type": "null"
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SessionResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              ],
-              "description": "Cursor: return messages after this message ID",
-              "title": "After"
             },
-            "description": "Cursor: return messages after this message ID"
-          },
-          {
-            "name": "before",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "format": "uuid"
-                },
-                {
-                  "type": "null"
+            "get": {
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "List Sessions",
+                "description": "List sessions for the authenticated project.",
+                "operationId": "list_sessions_sessions_get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 1,
+                            "title": "Page"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1,
+                            "default": 20,
+                            "title": "Page Size"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SessionListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              ],
-              "description": "Cursor: return messages before this message ID",
-              "title": "Before"
+            }
+        },
+        "/sessions/{session_id}": {
+            "get": {
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "Get Session",
+                "description": "Get session details. Use this to poll for task completion and output.",
+                "operationId": "get_session_sessions__session_id__get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SessionResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
             },
-            "description": "Cursor: return messages before this message ID"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 10,
-              "title": "Limit"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MessageListResponse"
+            "delete": {
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "Delete Session",
+                "description": "Soft-delete a session. Stops the sandbox first if still running.",
+                "operationId": "delete_session_sessions__session_id__delete",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful Response"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              }
             }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/sessions/{session_id}/files": {
-      "get": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "List Session Files",
-        "description": "List files in a session's workspace.\n\nReturns paginated file metadata. Pass includeUrls=true to get\npresigned download URLs (60s expiry) inline with each file.",
-        "operationId": "list_session_files_sessions__session_id__files_get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Session Id"
-            }
-          },
-          {
-            "name": "prefix",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "",
-              "title": "Prefix"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 50,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "cursor",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
+        },
+        "/sessions/{session_id}/stop": {
+            "post": {
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "Stop Session",
+                "description": "Stop a session or the running task.\n\n- strategy=session (default): destroy sandbox entirely, session \u2192 stopped.\n- strategy=task: stop the running query, session stays alive (\u2192 idle).",
+                "operationId": "stop_session_sessions__session_id__stop_post",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/components/schemas/StopSessionRequest"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ],
+                                "title": "Body"
+                            }
+                        }
+                    }
                 },
-                {
-                  "type": "null"
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SessionResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              ],
-              "title": "Cursor"
             }
-          },
-          {
-            "name": "includeUrls",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Includeurls"
-            }
-          },
-          {
-            "name": "shallow",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Shallow"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FileListResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/sessions/{session_id}/files/upload": {
-      "post": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Upload Session Files",
-        "description": "Get presigned PUT URLs for uploading files to a session's workspace.\n\nFiles are placed under ``uploads/`` in the session's S3 prefix. After\nreceiving the URLs, PUT each file directly to S3 using the returned\n``uploadUrl`` with the matching ``Content-Type`` header.",
-        "operationId": "upload_session_files_sessions__session_id__files_upload_post",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Session Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FileUploadRequest"
-              }
-            }
-          }
         },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FileUploadResponse"
+        "/sessions/{session_id}/messages": {
+            "get": {
+                "tags": [
+                    "Sessions"
+                ],
+                "summary": "List Session Messages",
+                "description": "Return messages for a session with cursor-based pagination (chronological order).",
+                "operationId": "list_session_messages_sessions__session_id__messages_get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    },
+                    {
+                        "name": "after",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "format": "uuid"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Cursor: return messages after this message ID",
+                            "title": "After"
+                        },
+                        "description": "Cursor: return messages after this message ID"
+                    },
+                    {
+                        "name": "before",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "format": "uuid"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Cursor: return messages before this message ID",
+                            "title": "Before"
+                        },
+                        "description": "Cursor: return messages before this message ID"
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1,
+                            "default": 10,
+                            "title": "Limit"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MessageListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              }
             }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+        },
+        "/sessions/{session_id}/files": {
+            "get": {
+                "tags": [
+                    "Files"
+                ],
+                "summary": "List Session Files",
+                "description": "List files in a session's workspace.\n\nReturns paginated file metadata. Pass includeUrls=true to get\npresigned download URLs (60s expiry) inline with each file.",
+                "operationId": "list_session_files_sessions__session_id__files_get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    },
+                    {
+                        "name": "prefix",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "",
+                            "title": "Prefix"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1,
+                            "default": 50,
+                            "title": "Limit"
+                        }
+                    },
+                    {
+                        "name": "cursor",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Cursor"
+                        }
+                    },
+                    {
+                        "name": "includeUrls",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false,
+                            "title": "Includeurls"
+                        }
+                    },
+                    {
+                        "name": "shallow",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false,
+                            "title": "Shallow"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FileListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              }
             }
-          }
-        }
-      }
-    },
-    "/profiles": {
-      "get": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "List Profiles",
-        "description": "Get paginated list of profiles.\n\nUse the `query` parameter to search profiles by name or user_id.\nThis is useful when you have many profiles and need to find a specific user.\n\nExample: If you set `user_id` to your internal user identifier when creating profiles,\nyou can later search for that user by passing their identifier as the `query` parameter.",
-        "operationId": "list_profiles_profiles_get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "pageSize",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 10,
-              "title": "Pagesize"
-            }
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1,
-              "title": "Pagenumber"
-            }
-          },
-          {
-            "name": "query",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "maxLength": 200
+        },
+        "/sessions/{session_id}/files/upload": {
+            "post": {
+                "tags": [
+                    "Files"
+                ],
+                "summary": "Upload Session Files",
+                "description": "Get presigned PUT URLs for uploading files to a session's workspace.\n\nFiles are placed under ``uploads/`` in the session's S3 prefix. After\nreceiving the URLs, PUT each file directly to S3 using the returned\n``uploadUrl`` with the matching ``Content-Type`` header.",
+                "operationId": "upload_session_files_sessions__session_id__files_upload_post",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FileUploadRequest"
+                            }
+                        }
+                    }
                 },
-                {
-                  "type": "null"
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FileUploadResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              ],
-              "title": "Query"
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileListResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "Create Profile",
-        "description": "Profiles allow you to preserve the state of the browser between tasks.\n\nThey are most commonly used to allow users to preserve the log-in state in the agent between tasks.\nYou'd normally create one profile per user and then use it for all their tasks.\n\nYou can set a `user_id` when creating a profile to associate it with a user in your system.\nThis allows you to later search for the profile using the GET /profiles endpoint with a query parameter.",
-        "operationId": "create_profile_profiles_post",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ProfileCreateRequest"
-              }
-            }
-          }
         },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileView"
+        "/profiles": {
+            "get": {
+                "tags": [
+                    "Profiles"
+                ],
+                "summary": "List Profiles",
+                "description": "Get paginated list of profiles.\n\nUse the `query` parameter to search profiles by name or user_id.\nThis is useful when you have many profiles and need to find a specific user.\n\nExample: If you set `user_id` to your internal user identifier when creating profiles,\nyou can later search for that user by passing their identifier as the `query` parameter.",
+                "operationId": "list_profiles_profiles_get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1,
+                            "default": 10,
+                            "title": "Pagesize"
+                        }
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 1,
+                            "title": "Pagenumber"
+                        }
+                    },
+                    {
+                        "name": "query",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "maxLength": 200
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Query"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProfileListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              }
-            }
-          },
-          "402": {
-            "description": "Subscription required for additional profiles",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InsufficientCreditsError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Request validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/profiles/{profile_id}": {
-      "get": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "Get Profile",
-        "description": "Get profile details.",
-        "operationId": "get_profile_profiles__profile_id__get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "profile_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Profile Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileView"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Profile not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileNotFoundError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "Update Profile",
-        "description": "Update a browser profile's information.",
-        "operationId": "update_profile_profiles__profile_id__patch",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "profile_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Profile Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ProfileUpdateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileView"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Profile not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileNotFoundError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Profiles"
-        ],
-        "summary": "Delete Browser Profile",
-        "description": "Permanently delete a browser profile and its configuration.",
-        "operationId": "delete_browser_profile_profiles__profile_id__delete",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "profile_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Profile Id"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/billing/account": {
-      "get": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "Get Account Billing",
-        "description": "Get authenticated account information including credit balance and account details.",
-        "operationId": "get_account_billing_billing_account_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AccountView"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Project for a given API key not found!",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AccountNotFoundError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ]
-      }
-    },
-    "/browsers": {
-      "get": {
-        "tags": [
-          "Browsers"
-        ],
-        "summary": "List Browser Sessions",
-        "description": "Get paginated list of browser sessions with optional status filtering.",
-        "operationId": "list_browser_sessions_browsers_get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "pageSize",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 10,
-              "title": "Pagesize"
-            }
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1,
-              "title": "Pagenumber"
-            }
-          },
-          {
-            "name": "filterBy",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "$ref": "#/components/schemas/BrowserSessionStatus"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Filterby"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BrowserSessionListResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Browsers"
-        ],
-        "summary": "Create Browser Session",
-        "description": "Create a new browser session.\n\n**Pricing:** Browser sessions are charged per hour with tiered pricing:\n- Pay As You Go users: $0.06/hour\n- Business/Scaleup subscribers: $0.03/hour (50% discount)\n\nThe full rate is charged upfront when the session starts.\nWhen you stop the session, any unused time is automatically refunded proportionally.\n\nBilling is rounded up to the minute (minimum 1 minute).\nFor example, if you stop a session after 30 minutes, you'll be refunded half the charged amount.\n\n**Session Limits:**\n- All users: Up to 4 hours per session",
-        "operationId": "create_browser_session_browsers_post",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateBrowserSessionRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BrowserSessionItemView"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Session timeout limit exceeded (maximum 4 hours)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionTimeoutLimitExceededError"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Profile not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProfileNotFoundError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Request validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Too many concurrent active sessions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TooManyConcurrentActiveSessionsError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/browsers/{session_id}": {
-      "get": {
-        "tags": [
-          "Browsers"
-        ],
-        "summary": "Get Browser Session",
-        "description": "Get detailed browser session information including status and URLs.",
-        "operationId": "get_browser_session_browsers__session_id__get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Session Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BrowserSessionView"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Session not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionNotFoundError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "Browsers"
-        ],
-        "summary": "Update Browser Session",
-        "description": "Stop a browser session.\n\n**Refund:** When you stop a session, unused time is automatically refunded.\nIf the session ran for less than 1 hour, you'll receive a proportional refund.\nBilling is ceil to the nearest minute (minimum 1 minute).",
-        "operationId": "update_browser_session_browsers__session_id__patch",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Session Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateBrowserSessionRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BrowserSessionView"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Session not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SessionNotFoundError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Request validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/workspaces": {
-      "get": {
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "List Workspaces",
-        "description": "Get paginated list of workspaces.",
-        "operationId": "list_workspaces_workspaces_get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "pageSize",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 10,
-              "title": "Pagesize"
-            }
-          },
-          {
-            "name": "pageNumber",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "default": 1,
-              "title": "Pagenumber"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkspaceListResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Create Workspace",
-        "description": "Create a new workspace for persistent shared file storage across sessions.",
-        "operationId": "create_workspace_workspaces_post",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorkspaceCreateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkspaceView"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/workspaces/{workspace_id}": {
-      "get": {
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Get Workspace",
-        "description": "Get workspace details.",
-        "operationId": "get_workspace_workspaces__workspace_id__get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkspaceView"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Update Workspace",
-        "description": "Update a workspace's name.",
-        "operationId": "update_workspace_workspaces__workspace_id__patch",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorkspaceUpdateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkspaceView"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Delete Workspace",
-        "description": "Delete a workspace and its S3 data.",
-        "operationId": "delete_workspace_workspaces__workspace_id__delete",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/workspaces/{workspace_id}/files": {
-      "get": {
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "List Workspace Files",
-        "description": "List files in a workspace's S3 prefix.",
-        "operationId": "list_workspace_files_workspaces__workspace_id__files_get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          },
-          {
-            "name": "prefix",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": "",
-              "title": "Prefix"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 100,
-              "minimum": 1,
-              "default": 50,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "cursor",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Cursor"
-            }
-          },
-          {
-            "name": "includeUrls",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Includeurls"
-            }
-          },
-          {
-            "name": "shallow",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "title": "Shallow"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FileListResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Delete Workspace File",
-        "description": "Delete a single file from a workspace.",
-        "operationId": "delete_workspace_file_workspaces__workspace_id__files_delete",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          },
-          {
-            "name": "path",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Relative file path to delete",
-              "title": "Path"
             },
-            "description": "Relative file path to delete"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+            "post": {
+                "tags": [
+                    "Profiles"
+                ],
+                "summary": "Create Profile",
+                "description": "Profiles allow you to preserve the state of the browser between tasks.\n\nThey are most commonly used to allow users to preserve the log-in state in the agent between tasks.\nYou'd normally create one profile per user and then use it for all their tasks.\n\nYou can set a `user_id` when creating a profile to associate it with a user in your system.\nThis allows you to later search for the profile using the GET /profiles endpoint with a query parameter.",
+                "operationId": "create_profile_profiles_post",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProfileCreateRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProfileView"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Subscription required for additional profiles",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InsufficientCreditsError"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Request validation failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              }
             }
-          }
-        }
-      }
-    },
-    "/workspaces/{workspace_id}/size": {
-      "get": {
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Get Workspace Size",
-        "description": "Get current storage usage for a workspace.",
-        "operationId": "get_workspace_size_workspaces__workspace_id__size_get",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/workspaces/{workspace_id}/files/upload": {
-      "post": {
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Upload Workspace Files",
-        "description": "Get presigned PUT URLs for uploading files to a workspace.",
-        "operationId": "upload_workspace_files_workspaces__workspace_id__files_upload_post",
-        "security": [
-          {
-            "APIKeyHeader": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "workspace_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Workspace Id"
-            }
-          },
-          {
-            "name": "prefix",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "description": "Directory prefix to upload into (e.g. \"uploads/\")",
-              "default": "",
-              "title": "Prefix"
-            },
-            "description": "Directory prefix to upload into (e.g. \"uploads/\")"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FileUploadRequest"
-              }
-            }
-          }
         },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FileUploadResponse"
+        "/profiles/{profile_id}": {
+            "get": {
+                "tags": [
+                    "Profiles"
+                ],
+                "summary": "Get Profile",
+                "description": "Get profile details.",
+                "operationId": "get_profile_profiles__profile_id__get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "profile_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Profile Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProfileView"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Profile not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProfileNotFoundError"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+            },
+            "patch": {
+                "tags": [
+                    "Profiles"
+                ],
+                "summary": "Update Profile",
+                "description": "Update a browser profile's information.",
+                "operationId": "update_profile_profiles__profile_id__patch",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "profile_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Profile Id"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProfileUpdateRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProfileView"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Profile not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProfileNotFoundError"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
                 }
-              }
+            },
+            "delete": {
+                "tags": [
+                    "Profiles"
+                ],
+                "summary": "Delete Browser Profile",
+                "description": "Permanently delete a browser profile and its configuration.",
+                "operationId": "delete_browser_profile_profiles__profile_id__delete",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "profile_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Profile Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful Response"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
             }
-          }
+        },
+        "/billing/account": {
+            "get": {
+                "tags": [
+                    "Billing"
+                ],
+                "summary": "Get Account Billing",
+                "description": "Get authenticated account information including credit balance and account details.",
+                "operationId": "get_account_billing_billing_account_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AccountView"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Project for a given API key not found!",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AccountNotFoundError"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ]
+            }
+        },
+        "/browsers": {
+            "get": {
+                "tags": [
+                    "Browsers"
+                ],
+                "summary": "List Browser Sessions",
+                "description": "Get paginated list of browser sessions with optional status filtering.",
+                "operationId": "list_browser_sessions_browsers_get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1,
+                            "default": 10,
+                            "title": "Pagesize"
+                        }
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 1,
+                            "title": "Pagenumber"
+                        }
+                    },
+                    {
+                        "name": "filterBy",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/BrowserSessionStatus"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Filterby"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BrowserSessionListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Browsers"
+                ],
+                "summary": "Create Browser Session",
+                "description": "Create a new browser session.\n\n**Pricing:** Browser sessions are charged per hour with tiered pricing:\n- Pay As You Go users: $0.06/hour\n- Business/Scaleup subscribers: $0.03/hour (50% discount)\n\nThe full rate is charged upfront when the session starts.\nWhen you stop the session, any unused time is automatically refunded proportionally.\n\nBilling is rounded up to the minute (minimum 1 minute).\nFor example, if you stop a session after 30 minutes, you'll be refunded half the charged amount.\n\n**Session Limits:**\n- All users: Up to 4 hours per session",
+                "operationId": "create_browser_session_browsers_post",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateBrowserSessionRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BrowserSessionItemView"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Session timeout limit exceeded (maximum 4 hours)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SessionTimeoutLimitExceededError"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Profile not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ProfileNotFoundError"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Request validation failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "Too many concurrent active sessions",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TooManyConcurrentActiveSessionsError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/browsers/{session_id}": {
+            "get": {
+                "tags": [
+                    "Browsers"
+                ],
+                "summary": "Get Browser Session",
+                "description": "Get detailed browser session information including status and URLs.",
+                "operationId": "get_browser_session_browsers__session_id__get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BrowserSessionView"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Session not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SessionNotFoundError"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "tags": [
+                    "Browsers"
+                ],
+                "summary": "Update Browser Session",
+                "description": "Stop a browser session.\n\n**Refund:** When you stop a session, unused time is automatically refunded.\nIf the session ran for less than 1 hour, you'll receive a proportional refund.\nBilling is ceil to the nearest minute (minimum 1 minute).",
+                "operationId": "update_browser_session_browsers__session_id__patch",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateBrowserSessionRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BrowserSessionView"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Session not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SessionNotFoundError"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Request validation failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces": {
+            "get": {
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "List Workspaces",
+                "description": "Get paginated list of workspaces.",
+                "operationId": "list_workspaces_workspaces_get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "pageSize",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1,
+                            "default": 10,
+                            "title": "Pagesize"
+                        }
+                    },
+                    {
+                        "name": "pageNumber",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 1,
+                            "title": "Pagenumber"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/WorkspaceListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "Create Workspace",
+                "description": "Create a new workspace for persistent shared file storage across sessions.",
+                "operationId": "create_workspace_workspaces_post",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/WorkspaceCreateRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/WorkspaceView"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{workspace_id}": {
+            "get": {
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "Get Workspace",
+                "description": "Get workspace details.",
+                "operationId": "get_workspace_workspaces__workspace_id__get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "workspace_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Workspace Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/WorkspaceView"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "Update Workspace",
+                "description": "Update a workspace's name.",
+                "operationId": "update_workspace_workspaces__workspace_id__patch",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "workspace_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Workspace Id"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/WorkspaceUpdateRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/WorkspaceView"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "Delete Workspace",
+                "description": "Delete a workspace and its S3 data.",
+                "operationId": "delete_workspace_workspaces__workspace_id__delete",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "workspace_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Workspace Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful Response"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{workspace_id}/files": {
+            "get": {
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "List Workspace Files",
+                "description": "List files in a workspace's S3 prefix.",
+                "operationId": "list_workspace_files_workspaces__workspace_id__files_get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "workspace_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Workspace Id"
+                        }
+                    },
+                    {
+                        "name": "prefix",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "",
+                            "title": "Prefix"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1,
+                            "default": 50,
+                            "title": "Limit"
+                        }
+                    },
+                    {
+                        "name": "cursor",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Cursor"
+                        }
+                    },
+                    {
+                        "name": "includeUrls",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false,
+                            "title": "Includeurls"
+                        }
+                    },
+                    {
+                        "name": "shallow",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false,
+                            "title": "Shallow"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FileListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "Delete Workspace File",
+                "description": "Delete a single file from a workspace.",
+                "operationId": "delete_workspace_file_workspaces__workspace_id__files_delete",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "workspace_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Workspace Id"
+                        }
+                    },
+                    {
+                        "name": "path",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "description": "Relative file path to delete",
+                            "title": "Path"
+                        },
+                        "description": "Relative file path to delete"
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful Response"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{workspace_id}/size": {
+            "get": {
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "Get Workspace Size",
+                "description": "Get current storage usage for a workspace.",
+                "operationId": "get_workspace_size_workspaces__workspace_id__size_get",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "workspace_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Workspace Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{workspace_id}/files/upload": {
+            "post": {
+                "tags": [
+                    "Workspaces"
+                ],
+                "summary": "Upload Workspace Files",
+                "description": "Get presigned PUT URLs for uploading files to a workspace.",
+                "operationId": "upload_workspace_files_workspaces__workspace_id__files_upload_post",
+                "security": [
+                    {
+                        "APIKeyHeader": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "workspace_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Workspace Id"
+                        }
+                    },
+                    {
+                        "name": "prefix",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "description": "Directory prefix to upload into (e.g. \"uploads/\")",
+                            "default": "",
+                            "title": "Prefix"
+                        },
+                        "description": "Directory prefix to upload into (e.g. \"uploads/\")"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/FileUploadRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FileUploadResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
-      }
+    },
+    "components": {
+        "schemas": {
+            "AccountNotFoundError": {
+                "properties": {
+                    "detail": {
+                        "type": "string",
+                        "title": "Detail",
+                        "default": "Account not found"
+                    }
+                },
+                "type": "object",
+                "title": "AccountNotFoundError",
+                "description": "Error response when an account is not found"
+            },
+            "AccountView": {
+                "properties": {
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name",
+                        "description": "The name of the user"
+                    },
+                    "totalCreditsBalanceUsd": {
+                        "type": "number",
+                        "title": "Credits Balance USD",
+                        "description": "The total credits balance in USD"
+                    },
+                    "monthlyCreditsBalanceUsd": {
+                        "type": "number",
+                        "title": "Monthly Credits Balance USD",
+                        "description": "Monthly subscription credits balance in USD"
+                    },
+                    "additionalCreditsBalanceUsd": {
+                        "type": "number",
+                        "title": "Additional Credits Balance USD",
+                        "description": "Additional top-up credits balance in USD"
+                    },
+                    "rateLimit": {
+                        "type": "integer",
+                        "title": "Rate Limit",
+                        "description": "The rate limit for the account"
+                    },
+                    "planInfo": {
+                        "$ref": "#/components/schemas/PlanInfo",
+                        "title": "Plan Info",
+                        "description": "The plan information"
+                    },
+                    "projectId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Project ID",
+                        "description": "The ID of the project"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "totalCreditsBalanceUsd",
+                    "monthlyCreditsBalanceUsd",
+                    "additionalCreditsBalanceUsd",
+                    "rateLimit",
+                    "planInfo",
+                    "projectId"
+                ],
+                "title": "AccountView",
+                "description": "View model for account information."
+            },
+            "BrowserSessionItemView": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "ID",
+                        "description": "Unique identifier for the session"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/BrowserSessionStatus",
+                        "title": "Status",
+                        "description": "Current status of the session (active/stopped)"
+                    },
+                    "liveUrl": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Live URL",
+                        "description": "URL where the browser can be viewed live in real-time"
+                    },
+                    "cdpUrl": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "CDP URL",
+                        "description": "Chrome DevTools Protocol URL for browser automation"
+                    },
+                    "timeoutAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Timeout At",
+                        "description": "Timestamp when the session will timeout"
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Started At",
+                        "description": "Timestamp when the session was created and started"
+                    },
+                    "finishedAt": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Finished At",
+                        "description": "Timestamp when the session was stopped (None if still active)"
+                    },
+                    "proxyUsedMb": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Proxy Used MB",
+                        "description": "Amount of proxy data used in MB",
+                        "default": "0"
+                    },
+                    "proxyCost": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Proxy Cost",
+                        "description": "Cost of proxy usage in USD",
+                        "default": "0"
+                    },
+                    "browserCost": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Browser Cost",
+                        "description": "Cost of browser session hosting in USD",
+                        "default": "0"
+                    },
+                    "agentSessionId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Agent Session ID",
+                        "description": "ID of the agent session that created this browser (None for standalone BaaS sessions)"
+                    },
+                    "recordingUrl": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Recording URL",
+                        "description": "Presigned URL to download the session recording (available after session ends, if recording was enabled)"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "status",
+                    "timeoutAt",
+                    "startedAt"
+                ],
+                "title": "BrowserSessionItemView",
+                "description": "View model for representing a browser session in list views."
+            },
+            "BrowserSessionListResponse": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "$ref": "#/components/schemas/BrowserSessionItemView"
+                        },
+                        "type": "array",
+                        "title": "Items",
+                        "description": "List of browser session views for the current page"
+                    },
+                    "totalItems": {
+                        "type": "integer",
+                        "title": "Total Items",
+                        "description": "Total number of items in the list"
+                    },
+                    "pageNumber": {
+                        "type": "integer",
+                        "title": "Page Number",
+                        "description": "Page number"
+                    },
+                    "pageSize": {
+                        "type": "integer",
+                        "title": "Page Size",
+                        "description": "Number of items per page"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "items",
+                    "totalItems",
+                    "pageNumber",
+                    "pageSize"
+                ],
+                "title": "BrowserSessionListResponse",
+                "description": "Response model for paginated browser session list requests."
+            },
+            "BrowserSessionStatus": {
+                "type": "string",
+                "enum": [
+                    "active",
+                    "stopped"
+                ],
+                "title": "BrowserSessionStatus",
+                "description": "Enumeration of possible browser session states\n\nAttributes:\n    ACTIVE: Session is currently active and running (browser is running)\n    STOPPED: Session has been stopped and is no longer active (browser is stopped)"
+            },
+            "BrowserSessionUpdateAction": {
+                "type": "string",
+                "enum": [
+                    "stop"
+                ],
+                "title": "BrowserSessionUpdateAction",
+                "description": "Available actions that can be performed on a browser session\n\nAttributes:\n    STOP: Stop the browser session (cannot be undone)"
+            },
+            "BrowserSessionView": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "ID",
+                        "description": "Unique identifier for the session"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/BrowserSessionStatus",
+                        "title": "Status",
+                        "description": "Current status of the session (active/stopped)"
+                    },
+                    "liveUrl": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Live URL",
+                        "description": "URL where the browser can be viewed live in real-time"
+                    },
+                    "cdpUrl": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "CDP URL",
+                        "description": "Chrome DevTools Protocol URL for browser automation"
+                    },
+                    "timeoutAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Timeout At",
+                        "description": "Timestamp when the session will timeout"
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Started At",
+                        "description": "Timestamp when the session was created and started"
+                    },
+                    "finishedAt": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Finished At",
+                        "description": "Timestamp when the session was stopped (None if still active)"
+                    },
+                    "proxyUsedMb": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Proxy Used MB",
+                        "description": "Amount of proxy data used in MB",
+                        "default": "0"
+                    },
+                    "proxyCost": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Proxy Cost",
+                        "description": "Cost of proxy usage in USD",
+                        "default": "0"
+                    },
+                    "browserCost": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Browser Cost",
+                        "description": "Cost of browser session hosting in USD",
+                        "default": "0"
+                    },
+                    "agentSessionId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Agent Session ID",
+                        "description": "ID of the agent session that created this browser (None for standalone BaaS sessions)"
+                    },
+                    "recordingUrl": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Recording URL",
+                        "description": "Presigned URL to download the session recording (available after session ends, if recording was enabled)"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "status",
+                    "timeoutAt",
+                    "startedAt"
+                ],
+                "title": "BrowserSessionView",
+                "description": "View model for representing a browser session."
+            },
+            "BuAgentSessionStatus": {
+                "type": "string",
+                "enum": [
+                    "created",
+                    "idle",
+                    "running",
+                    "stopped",
+                    "timed_out",
+                    "error"
+                ],
+                "title": "BuAgentSessionStatus"
+            },
+            "BuModel": {
+                "type": "string",
+                "enum": [
+                    "bu-mini",
+                    "bu-max",
+                    "bu-ultra"
+                ],
+                "title": "BuModel"
+            },
+            "CreateBrowserSessionRequest": {
+                "properties": {
+                    "profileId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Profile ID",
+                        "description": "The ID of the profile to use for the session"
+                    },
+                    "proxyCountryCode": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ProxyCountryCode"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Proxy Country Code",
+                        "description": "Country code for proxy location. Defaults to US. Set to null to disable proxy.",
+                        "default": "us"
+                    },
+                    "timeout": {
+                        "type": "integer",
+                        "title": "Timeout",
+                        "description": "The timeout for the session in minutes. All users can use up to 240 minutes (4 hours). Pay As You Go users are charged $0.06/hour, subscribers get 50% off.",
+                        "default": 60,
+                        "ge": 1,
+                        "le": 240
+                    },
+                    "browserScreenWidth": {
+                        "anyOf": [
+                            {
+                                "type": "integer",
+                                "maximum": 6144.0,
+                                "minimum": 320.0
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Browser Screen Width",
+                        "description": "Custom screen width in pixels for the browser."
+                    },
+                    "browserScreenHeight": {
+                        "anyOf": [
+                            {
+                                "type": "integer",
+                                "maximum": 3456.0,
+                                "minimum": 320.0
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Browser Screen Height",
+                        "description": "Custom screen height in pixels for the browser."
+                    },
+                    "allowResizing": {
+                        "type": "boolean",
+                        "title": "Allow Resizing",
+                        "description": "Whether to allow the browser to be resized during the session (not recommended since it reduces stealthiness).",
+                        "default": false
+                    },
+                    "customProxy": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/CustomProxy"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Custom Proxy",
+                        "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are only available on the Custom Enterprise plan."
+                    },
+                    "enableRecording": {
+                        "type": "boolean",
+                        "title": "Enable Recording",
+                        "description": "If True, enables session recording. Defaults to False.",
+                        "default": false
+                    }
+                },
+                "type": "object",
+                "title": "CreateBrowserSessionRequest",
+                "description": "Request model for creating a browser session."
+            },
+            "CustomProxy": {
+                "properties": {
+                    "host": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "minLength": 1,
+                        "title": "Host",
+                        "description": "Host of the proxy."
+                    },
+                    "port": {
+                        "type": "integer",
+                        "maximum": 65535.0,
+                        "minimum": 1.0,
+                        "title": "Port",
+                        "description": "Port of the proxy."
+                    },
+                    "username": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 255,
+                                "minLength": 1
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Username",
+                        "description": "Username for proxy authentication."
+                    },
+                    "password": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 255,
+                                "minLength": 1
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Password",
+                        "description": "Password for proxy authentication."
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "host",
+                    "port"
+                ],
+                "title": "CustomProxy",
+                "description": "Request model for creating a custom proxy."
+            },
+            "FileInfo": {
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "title": "Path"
+                    },
+                    "size": {
+                        "type": "integer",
+                        "title": "Size"
+                    },
+                    "lastModified": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Lastmodified"
+                    },
+                    "url": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Url"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "path",
+                    "size",
+                    "lastModified"
+                ],
+                "title": "FileInfo",
+                "description": "A file in a session's workspace."
+            },
+            "FileListResponse": {
+                "properties": {
+                    "files": {
+                        "items": {
+                            "$ref": "#/components/schemas/FileInfo"
+                        },
+                        "type": "array",
+                        "title": "Files"
+                    },
+                    "folders": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Folders",
+                        "description": "Immediate sub-folder names at this prefix level"
+                    },
+                    "nextCursor": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Nextcursor"
+                    },
+                    "hasMore": {
+                        "type": "boolean",
+                        "title": "Hasmore",
+                        "default": false
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "files"
+                ],
+                "title": "FileListResponse",
+                "description": "Paginated file listing with optional presigned download URLs."
+            },
+            "FileUploadItem": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "minLength": 1,
+                        "title": "Name",
+                        "description": "Filename, e.g. \"data.csv\""
+                    },
+                    "contentType": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "title": "Contenttype",
+                        "description": "MIME type, e.g. \"text/csv\"",
+                        "default": "application/octet-stream"
+                    },
+                    "size": {
+                        "anyOf": [
+                            {
+                                "type": "integer",
+                                "minimum": 1.0
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Size",
+                        "description": "File size in bytes (required for workspace uploads)"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "title": "FileUploadItem",
+                "description": "A single file to upload."
+            },
+            "FileUploadRequest": {
+                "properties": {
+                    "files": {
+                        "items": {
+                            "$ref": "#/components/schemas/FileUploadItem"
+                        },
+                        "type": "array",
+                        "maxItems": 10,
+                        "minItems": 1,
+                        "title": "Files"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "files"
+                ],
+                "title": "FileUploadRequest",
+                "description": "Request body for generating presigned upload URLs."
+            },
+            "FileUploadResponse": {
+                "properties": {
+                    "files": {
+                        "items": {
+                            "$ref": "#/components/schemas/FileUploadResponseItem"
+                        },
+                        "type": "array",
+                        "title": "Files"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "files"
+                ],
+                "title": "FileUploadResponse",
+                "description": "Presigned upload URLs for the requested files."
+            },
+            "FileUploadResponseItem": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "title": "Name"
+                    },
+                    "uploadUrl": {
+                        "type": "string",
+                        "title": "Uploadurl"
+                    },
+                    "path": {
+                        "type": "string",
+                        "title": "Path",
+                        "description": "S3-relative path, e.g. \"uploads/data.csv\""
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "name",
+                    "uploadUrl",
+                    "path"
+                ],
+                "title": "FileUploadResponseItem",
+                "description": "Presigned upload URL for a single file."
+            },
+            "HTTPValidationError": {
+                "properties": {
+                    "detail": {
+                        "items": {
+                            "$ref": "#/components/schemas/ValidationError"
+                        },
+                        "type": "array",
+                        "title": "Detail"
+                    }
+                },
+                "type": "object",
+                "title": "HTTPValidationError"
+            },
+            "InsufficientCreditsError": {
+                "properties": {
+                    "detail": {
+                        "type": "string",
+                        "title": "Detail",
+                        "default": "Insufficient credits"
+                    }
+                },
+                "type": "object",
+                "title": "InsufficientCreditsError",
+                "description": "Error response when there are insufficient credits"
+            },
+            "MessageListResponse": {
+                "properties": {
+                    "messages": {
+                        "items": {
+                            "$ref": "#/components/schemas/MessageResponse"
+                        },
+                        "type": "array",
+                        "title": "Messages"
+                    },
+                    "hasMore": {
+                        "type": "boolean",
+                        "title": "Hasmore"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "messages",
+                    "hasMore"
+                ],
+                "title": "MessageListResponse"
+            },
+            "MessageResponse": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "sessionId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Sessionid"
+                    },
+                    "role": {
+                        "type": "string",
+                        "title": "Role"
+                    },
+                    "data": {
+                        "type": "string",
+                        "title": "Data"
+                    },
+                    "type": {
+                        "type": "string",
+                        "title": "Type",
+                        "description": "Coarse category: user_message, assistant_message, browser_action, file_operation, code_execution, integration, planning, completion, browser_action_result, browser_action_error, etc.",
+                        "default": ""
+                    },
+                    "summary": {
+                        "type": "string",
+                        "title": "Summary",
+                        "description": "One-liner human-readable description of the message (e.g. \"Navigating to google.com\", \"Clicking element #5\").",
+                        "default": ""
+                    },
+                    "screenshotUrl": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Screenshoturl"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Createdat"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "sessionId",
+                    "role",
+                    "data",
+                    "createdAt"
+                ],
+                "title": "MessageResponse"
+            },
+            "PlanInfo": {
+                "properties": {
+                    "planName": {
+                        "type": "string",
+                        "title": "Plan Name",
+                        "description": "The name of the plan"
+                    },
+                    "subscriptionStatus": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Subscription Status",
+                        "description": "The status of the subscription"
+                    },
+                    "subscriptionId": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Subscription ID",
+                        "description": "The ID of the subscription"
+                    },
+                    "subscriptionCurrentPeriodEnd": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Subscription Current Period End",
+                        "description": "The end of the current period"
+                    },
+                    "subscriptionCanceledAt": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Subscription Canceled At",
+                        "description": "The date the subscription was canceled"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "planName",
+                    "subscriptionStatus",
+                    "subscriptionId",
+                    "subscriptionCurrentPeriodEnd",
+                    "subscriptionCanceledAt"
+                ],
+                "title": "PlanInfo",
+                "description": "View model for plan information"
+            },
+            "ProfileCreateRequest": {
+                "properties": {
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 100
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name",
+                        "description": "Optional name for the profile"
+                    },
+                    "userId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 255
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "User ID",
+                        "description": "Your internal user identifier for this profile. Use this to associate a profile with a user in your system."
+                    }
+                },
+                "type": "object",
+                "title": "ProfileCreateRequest",
+                "description": "Request model for creating a new profile."
+            },
+            "ProfileListResponse": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "$ref": "#/components/schemas/ProfileView"
+                        },
+                        "type": "array",
+                        "title": "Items",
+                        "description": "List of profile views for the current page"
+                    },
+                    "totalItems": {
+                        "type": "integer",
+                        "title": "Total Items",
+                        "description": "Total number of items in the list"
+                    },
+                    "pageNumber": {
+                        "type": "integer",
+                        "title": "Page Number",
+                        "description": "Page number"
+                    },
+                    "pageSize": {
+                        "type": "integer",
+                        "title": "Page Size",
+                        "description": "Number of items per page"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "items",
+                    "totalItems",
+                    "pageNumber",
+                    "pageSize"
+                ],
+                "title": "ProfileListResponse",
+                "description": "Response model for paginated profile list requests."
+            },
+            "ProfileNotFoundError": {
+                "properties": {
+                    "detail": {
+                        "type": "string",
+                        "title": "Detail",
+                        "default": "Profile not found"
+                    }
+                },
+                "type": "object",
+                "title": "ProfileNotFoundError",
+                "description": "Error response when a profile is not found"
+            },
+            "ProfileUpdateRequest": {
+                "properties": {
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 100
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name",
+                        "description": "Optional name for the profile"
+                    },
+                    "userId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 255
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "User ID",
+                        "description": "Your internal user identifier for this profile. Use this to associate a profile with a user in your system."
+                    }
+                },
+                "type": "object",
+                "title": "ProfileUpdateRequest",
+                "description": "Request model for updating a profile."
+            },
+            "ProfileView": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "ID",
+                        "description": "Unique identifier for the profile"
+                    },
+                    "userId": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "User ID",
+                        "description": "Your internal user identifier for this profile. Use this to associate a profile with a user in your system."
+                    },
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name",
+                        "description": "Optional name for the profile"
+                    },
+                    "lastUsedAt": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Last Used At",
+                        "description": "Timestamp when the profile was last used"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Created At",
+                        "description": "Timestamp when the profile was created"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Updated At",
+                        "description": "Timestamp when the profile was last updated"
+                    },
+                    "cookieDomains": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cookie Domains",
+                        "description": "List of domain URLs that have cookies stored for this profile"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "createdAt",
+                    "updatedAt"
+                ],
+                "title": "ProfileView",
+                "description": "View model for representing a profile. A profile lets you preserve the login state between sessions.\n\nWe recommend that you create a separate profile for each user of your app.\nYou can assign a user_id to each profile to easily identify which user the profile belongs to."
+            },
+            "ProxyCountryCode": {
+                "type": "string",
+                "enum": [
+                    "ad",
+                    "ae",
+                    "af",
+                    "ag",
+                    "ai",
+                    "al",
+                    "am",
+                    "an",
+                    "ao",
+                    "aq",
+                    "ar",
+                    "as",
+                    "at",
+                    "au",
+                    "aw",
+                    "az",
+                    "ba",
+                    "bb",
+                    "bd",
+                    "be",
+                    "bf",
+                    "bg",
+                    "bh",
+                    "bi",
+                    "bj",
+                    "bl",
+                    "bm",
+                    "bn",
+                    "bo",
+                    "bq",
+                    "br",
+                    "bs",
+                    "bt",
+                    "bv",
+                    "bw",
+                    "by",
+                    "bz",
+                    "ca",
+                    "cc",
+                    "cd",
+                    "cf",
+                    "cg",
+                    "ch",
+                    "ck",
+                    "cl",
+                    "cm",
+                    "co",
+                    "cr",
+                    "cs",
+                    "cu",
+                    "cv",
+                    "cw",
+                    "cx",
+                    "cy",
+                    "cz",
+                    "de",
+                    "dj",
+                    "dk",
+                    "dm",
+                    "do",
+                    "dz",
+                    "ec",
+                    "ee",
+                    "eg",
+                    "eh",
+                    "er",
+                    "es",
+                    "et",
+                    "fi",
+                    "fj",
+                    "fk",
+                    "fm",
+                    "fo",
+                    "fr",
+                    "ga",
+                    "gd",
+                    "ge",
+                    "gf",
+                    "gg",
+                    "gh",
+                    "gi",
+                    "gl",
+                    "gm",
+                    "gn",
+                    "gp",
+                    "gq",
+                    "gr",
+                    "gs",
+                    "gt",
+                    "gu",
+                    "gw",
+                    "gy",
+                    "hk",
+                    "hm",
+                    "hn",
+                    "hr",
+                    "ht",
+                    "hu",
+                    "id",
+                    "ie",
+                    "il",
+                    "im",
+                    "in",
+                    "iq",
+                    "ir",
+                    "is",
+                    "it",
+                    "je",
+                    "jm",
+                    "jo",
+                    "jp",
+                    "ke",
+                    "kg",
+                    "kh",
+                    "ki",
+                    "km",
+                    "kn",
+                    "kp",
+                    "kr",
+                    "kw",
+                    "ky",
+                    "kz",
+                    "la",
+                    "lb",
+                    "lc",
+                    "li",
+                    "lk",
+                    "lr",
+                    "ls",
+                    "lt",
+                    "lu",
+                    "lv",
+                    "ly",
+                    "ma",
+                    "mc",
+                    "md",
+                    "me",
+                    "mf",
+                    "mg",
+                    "mh",
+                    "mk",
+                    "ml",
+                    "mm",
+                    "mn",
+                    "mo",
+                    "mp",
+                    "mq",
+                    "mr",
+                    "ms",
+                    "mt",
+                    "mu",
+                    "mv",
+                    "mw",
+                    "mx",
+                    "my",
+                    "mz",
+                    "na",
+                    "nc",
+                    "ne",
+                    "nf",
+                    "ng",
+                    "ni",
+                    "nl",
+                    "no",
+                    "np",
+                    "nr",
+                    "nu",
+                    "nz",
+                    "om",
+                    "pa",
+                    "pe",
+                    "pf",
+                    "pg",
+                    "ph",
+                    "pk",
+                    "pl",
+                    "pm",
+                    "pn",
+                    "pr",
+                    "ps",
+                    "pt",
+                    "pw",
+                    "py",
+                    "qa",
+                    "re",
+                    "ro",
+                    "rs",
+                    "ru",
+                    "rw",
+                    "sa",
+                    "sb",
+                    "sc",
+                    "sd",
+                    "se",
+                    "sg",
+                    "sh",
+                    "si",
+                    "sj",
+                    "sk",
+                    "sl",
+                    "sm",
+                    "sn",
+                    "so",
+                    "sr",
+                    "ss",
+                    "st",
+                    "sv",
+                    "sx",
+                    "sy",
+                    "sz",
+                    "tc",
+                    "td",
+                    "tf",
+                    "tg",
+                    "th",
+                    "tj",
+                    "tk",
+                    "tl",
+                    "tm",
+                    "tn",
+                    "to",
+                    "tr",
+                    "tt",
+                    "tv",
+                    "tw",
+                    "tz",
+                    "ua",
+                    "ug",
+                    "uk",
+                    "us",
+                    "uy",
+                    "uz",
+                    "va",
+                    "vc",
+                    "ve",
+                    "vg",
+                    "vi",
+                    "vn",
+                    "vu",
+                    "wf",
+                    "ws",
+                    "xk",
+                    "ye",
+                    "yt",
+                    "za",
+                    "zm",
+                    "zw"
+                ],
+                "title": "ProxyCountryCode"
+            },
+            "RunTaskRequest": {
+                "properties": {
+                    "task": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Task"
+                    },
+                    "model": {
+                        "$ref": "#/components/schemas/BuModel",
+                        "default": "bu-mini"
+                    },
+                    "sessionId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Sessionid"
+                    },
+                    "keepAlive": {
+                        "type": "boolean",
+                        "title": "Keepalive",
+                        "default": false
+                    },
+                    "maxCostUsd": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Maxcostusd"
+                    },
+                    "profileId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Profileid"
+                    },
+                    "workspaceId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Workspaceid"
+                    },
+                    "proxyCountryCode": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ProxyCountryCode"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "default": "us"
+                    },
+                    "outputSchema": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Outputschema"
+                    },
+                    "enableScheduledTasks": {
+                        "type": "boolean",
+                        "title": "Enablescheduledtasks",
+                        "default": false
+                    },
+                    "enableRecording": {
+                        "type": "boolean",
+                        "title": "Enablerecording",
+                        "default": false
+                    },
+                    "skills": {
+                        "type": "boolean",
+                        "title": "Skills",
+                        "default": true
+                    },
+                    "agentmail": {
+                        "type": "boolean",
+                        "title": "Agentmail",
+                        "default": true
+                    }
+                },
+                "type": "object",
+                "title": "RunTaskRequest",
+                "description": "Unified request for creating a session or dispatching a task.\n\n- Without session_id + without task: creates a new idle session (for file uploads, etc.)\n- Without session_id + with task: creates a new session and dispatches the task\n- With session_id + with task: dispatches the task to an existing idle session\n- With session_id + without task: 422 (task required when dispatching to existing session)"
+            },
+            "SessionListResponse": {
+                "properties": {
+                    "sessions": {
+                        "items": {
+                            "$ref": "#/components/schemas/SessionResponse"
+                        },
+                        "type": "array",
+                        "title": "Sessions"
+                    },
+                    "total": {
+                        "type": "integer",
+                        "title": "Total"
+                    },
+                    "page": {
+                        "type": "integer",
+                        "title": "Page"
+                    },
+                    "pageSize": {
+                        "type": "integer",
+                        "title": "Pagesize"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "sessions",
+                    "total",
+                    "page",
+                    "pageSize"
+                ],
+                "title": "SessionListResponse"
+            },
+            "SessionNotFoundError": {
+                "properties": {
+                    "detail": {
+                        "type": "string",
+                        "title": "Detail",
+                        "default": "Session not found"
+                    }
+                },
+                "type": "object",
+                "title": "SessionNotFoundError",
+                "description": "Error response when a session is not found"
+            },
+            "SessionResponse": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/BuAgentSessionStatus"
+                    },
+                    "model": {
+                        "$ref": "#/components/schemas/BuModel"
+                    },
+                    "title": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Title"
+                    },
+                    "output": {
+                        "anyOf": [
+                            {},
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Output"
+                    },
+                    "outputSchema": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Outputschema"
+                    },
+                    "stepCount": {
+                        "type": "integer",
+                        "title": "Stepcount",
+                        "default": 0
+                    },
+                    "lastStepSummary": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Laststepsummary"
+                    },
+                    "isTaskSuccessful": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Istasksuccessful"
+                    },
+                    "liveUrl": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Liveurl"
+                    },
+                    "recordingUrls": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Recordingurls",
+                        "default": []
+                    },
+                    "profileId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Profileid"
+                    },
+                    "workspaceId": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Workspaceid"
+                    },
+                    "proxyCountryCode": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ProxyCountryCode"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "maxCostUsd": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Maxcostusd"
+                    },
+                    "totalInputTokens": {
+                        "type": "integer",
+                        "title": "Totalinputtokens",
+                        "default": 0
+                    },
+                    "totalOutputTokens": {
+                        "type": "integer",
+                        "title": "Totaloutputtokens",
+                        "default": 0
+                    },
+                    "proxyUsedMb": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Proxyusedmb",
+                        "default": "0"
+                    },
+                    "llmCostUsd": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Llmcostusd",
+                        "default": "0"
+                    },
+                    "proxyCostUsd": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Proxycostusd",
+                        "default": "0"
+                    },
+                    "browserCostUsd": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Browsercostusd",
+                        "default": "0"
+                    },
+                    "totalCostUsd": {
+                        "type": "string",
+                        "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+                        "title": "Totalcostusd",
+                        "default": "0"
+                    },
+                    "screenshotUrl": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Screenshoturl"
+                    },
+                    "agentmailEmail": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Agentmailemail"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Createdat"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Updatedat"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "status",
+                    "model",
+                    "createdAt",
+                    "updatedAt"
+                ],
+                "title": "SessionResponse"
+            },
+            "SessionTimeoutLimitExceededError": {
+                "properties": {
+                    "detail": {
+                        "type": "string",
+                        "title": "Detail",
+                        "default": "Maximum session timeout is 4 hours (240 minutes)."
+                    }
+                },
+                "type": "object",
+                "title": "SessionTimeoutLimitExceededError",
+                "description": "Error response when session timeout exceeds the maximum allowed limit"
+            },
+            "StopSessionRequest": {
+                "properties": {
+                    "strategy": {
+                        "$ref": "#/components/schemas/StopStrategy",
+                        "default": "session"
+                    }
+                },
+                "type": "object",
+                "title": "StopSessionRequest"
+            },
+            "StopStrategy": {
+                "type": "string",
+                "enum": [
+                    "task",
+                    "session"
+                ],
+                "title": "StopStrategy"
+            },
+            "TooManyConcurrentActiveSessionsError": {
+                "properties": {
+                    "detail": {
+                        "type": "string",
+                        "title": "Detail",
+                        "default": "Too many concurrent active sessions. Please wait for one to finish, kill one, or upgrade your plan."
+                    }
+                },
+                "type": "object",
+                "title": "TooManyConcurrentActiveSessionsError",
+                "description": "Error response when user has too many concurrent active sessions"
+            },
+            "UpdateBrowserSessionRequest": {
+                "properties": {
+                    "action": {
+                        "$ref": "#/components/schemas/BrowserSessionUpdateAction",
+                        "title": "Action",
+                        "description": "The action to perform on the session"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "action"
+                ],
+                "title": "UpdateBrowserSessionRequest",
+                "description": "Request model for updating browser session state."
+            },
+            "ValidationError": {
+                "properties": {
+                    "loc": {
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ]
+                        },
+                        "type": "array",
+                        "title": "Location"
+                    },
+                    "msg": {
+                        "type": "string",
+                        "title": "Message"
+                    },
+                    "type": {
+                        "type": "string",
+                        "title": "Error Type"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "loc",
+                    "msg",
+                    "type"
+                ],
+                "title": "ValidationError"
+            },
+            "WorkspaceCreateRequest": {
+                "properties": {
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 100
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name",
+                        "description": "Optional name for the workspace"
+                    }
+                },
+                "type": "object",
+                "title": "WorkspaceCreateRequest",
+                "description": "Request model for creating a new workspace."
+            },
+            "WorkspaceListResponse": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "$ref": "#/components/schemas/WorkspaceView"
+                        },
+                        "type": "array",
+                        "title": "Items",
+                        "description": "List of workspace views for the current page"
+                    },
+                    "totalItems": {
+                        "type": "integer",
+                        "title": "Total Items",
+                        "description": "Total number of items in the list"
+                    },
+                    "pageNumber": {
+                        "type": "integer",
+                        "title": "Page Number",
+                        "description": "Page number"
+                    },
+                    "pageSize": {
+                        "type": "integer",
+                        "title": "Page Size",
+                        "description": "Number of items per page"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "items",
+                    "totalItems",
+                    "pageNumber",
+                    "pageSize"
+                ],
+                "title": "WorkspaceListResponse",
+                "description": "Response model for paginated workspace list requests."
+            },
+            "WorkspaceUpdateRequest": {
+                "properties": {
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 100
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name",
+                        "description": "Optional name for the workspace"
+                    }
+                },
+                "type": "object",
+                "title": "WorkspaceUpdateRequest",
+                "description": "Request model for updating a workspace."
+            },
+            "WorkspaceView": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "ID",
+                        "description": "Unique identifier for the workspace"
+                    },
+                    "name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Name",
+                        "description": "Optional name for the workspace"
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Created At",
+                        "description": "Timestamp when the workspace was created"
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Updated At",
+                        "description": "Timestamp when the workspace was last updated"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "createdAt",
+                    "updatedAt"
+                ],
+                "title": "WorkspaceView",
+                "description": "View model for a workspace \u2014 persistent shared storage across sessions."
+            }
+        },
+        "securitySchemes": {
+            "APIKeyHeader": {
+                "type": "apiKey",
+                "in": "header",
+                "name": "X-Browser-Use-API-Key"
+            }
+        }
     }
-  },
-  "components": {
-    "schemas": {
-      "AccountNotFoundError": {
-        "properties": {
-          "detail": {
-            "type": "string",
-            "title": "Detail",
-            "default": "Account not found"
-          }
-        },
-        "type": "object",
-        "title": "AccountNotFoundError",
-        "description": "Error response when an account is not found"
-      },
-      "AccountView": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name",
-            "description": "The name of the user"
-          },
-          "totalCreditsBalanceUsd": {
-            "type": "number",
-            "title": "Credits Balance USD",
-            "description": "The total credits balance in USD"
-          },
-          "monthlyCreditsBalanceUsd": {
-            "type": "number",
-            "title": "Monthly Credits Balance USD",
-            "description": "Monthly subscription credits balance in USD"
-          },
-          "additionalCreditsBalanceUsd": {
-            "type": "number",
-            "title": "Additional Credits Balance USD",
-            "description": "Additional top-up credits balance in USD"
-          },
-          "rateLimit": {
-            "type": "integer",
-            "title": "Rate Limit",
-            "description": "The rate limit for the account"
-          },
-          "planInfo": {
-            "$ref": "#/components/schemas/PlanInfo",
-            "title": "Plan Info",
-            "description": "The plan information"
-          },
-          "projectId": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Project ID",
-            "description": "The ID of the project"
-          }
-        },
-        "type": "object",
-        "required": [
-          "totalCreditsBalanceUsd",
-          "monthlyCreditsBalanceUsd",
-          "additionalCreditsBalanceUsd",
-          "rateLimit",
-          "planInfo",
-          "projectId"
-        ],
-        "title": "AccountView",
-        "description": "View model for account information."
-      },
-      "BrowserSessionItemView": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "ID",
-            "description": "Unique identifier for the session"
-          },
-          "status": {
-            "$ref": "#/components/schemas/BrowserSessionStatus",
-            "title": "Status",
-            "description": "Current status of the session (active/stopped)"
-          },
-          "liveUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Live URL",
-            "description": "URL where the browser can be viewed live in real-time"
-          },
-          "cdpUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "CDP URL",
-            "description": "Chrome DevTools Protocol URL for browser automation"
-          },
-          "timeoutAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Timeout At",
-            "description": "Timestamp when the session will timeout"
-          },
-          "startedAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Started At",
-            "description": "Timestamp when the session was created and started"
-          },
-          "finishedAt": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Finished At",
-            "description": "Timestamp when the session was stopped (None if still active)"
-          },
-          "proxyUsedMb": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Proxy Used MB",
-            "description": "Amount of proxy data used in MB",
-            "default": "0"
-          },
-          "proxyCost": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Proxy Cost",
-            "description": "Cost of proxy usage in USD",
-            "default": "0"
-          },
-          "browserCost": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Browser Cost",
-            "description": "Cost of browser session hosting in USD",
-            "default": "0"
-          },
-          "agentSessionId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Agent Session ID",
-            "description": "ID of the agent session that created this browser (None for standalone BaaS sessions)"
-          },
-          "recordingUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Recording URL",
-            "description": "Presigned URL to download the session recording (available after session ends, if recording was enabled)"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "status",
-          "timeoutAt",
-          "startedAt"
-        ],
-        "title": "BrowserSessionItemView",
-        "description": "View model for representing a browser session in list views."
-      },
-      "BrowserSessionListResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/BrowserSessionItemView"
-            },
-            "type": "array",
-            "title": "Items",
-            "description": "List of browser session views for the current page"
-          },
-          "totalItems": {
-            "type": "integer",
-            "title": "Total Items",
-            "description": "Total number of items in the list"
-          },
-          "pageNumber": {
-            "type": "integer",
-            "title": "Page Number",
-            "description": "Page number"
-          },
-          "pageSize": {
-            "type": "integer",
-            "title": "Page Size",
-            "description": "Number of items per page"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items",
-          "totalItems",
-          "pageNumber",
-          "pageSize"
-        ],
-        "title": "BrowserSessionListResponse",
-        "description": "Response model for paginated browser session list requests."
-      },
-      "BrowserSessionStatus": {
-        "type": "string",
-        "enum": [
-          "active",
-          "stopped"
-        ],
-        "title": "BrowserSessionStatus",
-        "description": "Enumeration of possible browser session states\n\nAttributes:\n    ACTIVE: Session is currently active and running (browser is running)\n    STOPPED: Session has been stopped and is no longer active (browser is stopped)"
-      },
-      "BrowserSessionUpdateAction": {
-        "type": "string",
-        "enum": [
-          "stop"
-        ],
-        "title": "BrowserSessionUpdateAction",
-        "description": "Available actions that can be performed on a browser session\n\nAttributes:\n    STOP: Stop the browser session (cannot be undone)"
-      },
-      "BrowserSessionView": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "ID",
-            "description": "Unique identifier for the session"
-          },
-          "status": {
-            "$ref": "#/components/schemas/BrowserSessionStatus",
-            "title": "Status",
-            "description": "Current status of the session (active/stopped)"
-          },
-          "liveUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Live URL",
-            "description": "URL where the browser can be viewed live in real-time"
-          },
-          "cdpUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "CDP URL",
-            "description": "Chrome DevTools Protocol URL for browser automation"
-          },
-          "timeoutAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Timeout At",
-            "description": "Timestamp when the session will timeout"
-          },
-          "startedAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Started At",
-            "description": "Timestamp when the session was created and started"
-          },
-          "finishedAt": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Finished At",
-            "description": "Timestamp when the session was stopped (None if still active)"
-          },
-          "proxyUsedMb": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Proxy Used MB",
-            "description": "Amount of proxy data used in MB",
-            "default": "0"
-          },
-          "proxyCost": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Proxy Cost",
-            "description": "Cost of proxy usage in USD",
-            "default": "0"
-          },
-          "browserCost": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Browser Cost",
-            "description": "Cost of browser session hosting in USD",
-            "default": "0"
-          },
-          "agentSessionId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Agent Session ID",
-            "description": "ID of the agent session that created this browser (None for standalone BaaS sessions)"
-          },
-          "recordingUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Recording URL",
-            "description": "Presigned URL to download the session recording (available after session ends, if recording was enabled)"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "status",
-          "timeoutAt",
-          "startedAt"
-        ],
-        "title": "BrowserSessionView",
-        "description": "View model for representing a browser session."
-      },
-      "BuAgentSessionStatus": {
-        "type": "string",
-        "enum": [
-          "created",
-          "idle",
-          "running",
-          "stopped",
-          "timed_out",
-          "error"
-        ],
-        "title": "BuAgentSessionStatus"
-      },
-      "BuModel": {
-        "type": "string",
-        "enum": [
-          "bu-mini",
-          "bu-max",
-          "bu-ultra"
-        ],
-        "title": "BuModel"
-      },
-      "CreateBrowserSessionRequest": {
-        "properties": {
-          "profileId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Profile ID",
-            "description": "The ID of the profile to use for the session"
-          },
-          "proxyCountryCode": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ProxyCountryCode"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Proxy Country Code",
-            "description": "Country code for proxy location. Defaults to US. Set to null to disable proxy.",
-            "default": "us"
-          },
-          "timeout": {
-            "type": "integer",
-            "title": "Timeout",
-            "description": "The timeout for the session in minutes. All users can use up to 240 minutes (4 hours). Pay As You Go users are charged $0.06/hour, subscribers get 50% off.",
-            "default": 60,
-            "ge": 1,
-            "le": 240
-          },
-          "browserScreenWidth": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "maximum": 6144.0,
-                "minimum": 320.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Browser Screen Width",
-            "description": "Custom screen width in pixels for the browser."
-          },
-          "browserScreenHeight": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "maximum": 3456.0,
-                "minimum": 320.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Browser Screen Height",
-            "description": "Custom screen height in pixels for the browser."
-          },
-          "allowResizing": {
-            "type": "boolean",
-            "title": "Allow Resizing",
-            "description": "Whether to allow the browser to be resized during the session (not recommended since it reduces stealthiness).",
-            "default": false
-          },
-          "customProxy": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/CustomProxy"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Custom Proxy",
-            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are only available on the Custom Enterprise plan."
-          },
-          "enableRecording": {
-            "type": "boolean",
-            "title": "Enable Recording",
-            "description": "If True, enables session recording. Defaults to False.",
-            "default": false
-          }
-        },
-        "type": "object",
-        "title": "CreateBrowserSessionRequest",
-        "description": "Request model for creating a browser session."
-      },
-      "CustomProxy": {
-        "properties": {
-          "host": {
-            "type": "string",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Host",
-            "description": "Host of the proxy."
-          },
-          "port": {
-            "type": "integer",
-            "maximum": 65535.0,
-            "minimum": 1.0,
-            "title": "Port",
-            "description": "Port of the proxy."
-          },
-          "username": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Username",
-            "description": "Username for proxy authentication."
-          },
-          "password": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255,
-                "minLength": 1
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Password",
-            "description": "Password for proxy authentication."
-          }
-        },
-        "type": "object",
-        "required": [
-          "host",
-          "port"
-        ],
-        "title": "CustomProxy",
-        "description": "Request model for creating a custom proxy."
-      },
-      "FileInfo": {
-        "properties": {
-          "path": {
-            "type": "string",
-            "title": "Path"
-          },
-          "size": {
-            "type": "integer",
-            "title": "Size"
-          },
-          "lastModified": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Lastmodified"
-          },
-          "url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Url"
-          }
-        },
-        "type": "object",
-        "required": [
-          "path",
-          "size",
-          "lastModified"
-        ],
-        "title": "FileInfo",
-        "description": "A file in a session's workspace."
-      },
-      "FileListResponse": {
-        "properties": {
-          "files": {
-            "items": {
-              "$ref": "#/components/schemas/FileInfo"
-            },
-            "type": "array",
-            "title": "Files"
-          },
-          "folders": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Folders",
-            "description": "Immediate sub-folder names at this prefix level"
-          },
-          "nextCursor": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Nextcursor"
-          },
-          "hasMore": {
-            "type": "boolean",
-            "title": "Hasmore",
-            "default": false
-          }
-        },
-        "type": "object",
-        "required": [
-          "files"
-        ],
-        "title": "FileListResponse",
-        "description": "Paginated file listing with optional presigned download URLs."
-      },
-      "FileUploadItem": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Name",
-            "description": "Filename, e.g. \"data.csv\""
-          },
-          "contentType": {
-            "type": "string",
-            "maxLength": 255,
-            "title": "Contenttype",
-            "description": "MIME type, e.g. \"text/csv\"",
-            "default": "application/octet-stream"
-          },
-          "size": {
-            "anyOf": [
-              {
-                "type": "integer",
-                "minimum": 1.0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Size",
-            "description": "File size in bytes (required for workspace uploads)"
-          }
-        },
-        "type": "object",
-        "required": [
-          "name"
-        ],
-        "title": "FileUploadItem",
-        "description": "A single file to upload."
-      },
-      "FileUploadRequest": {
-        "properties": {
-          "files": {
-            "items": {
-              "$ref": "#/components/schemas/FileUploadItem"
-            },
-            "type": "array",
-            "maxItems": 10,
-            "minItems": 1,
-            "title": "Files"
-          }
-        },
-        "type": "object",
-        "required": [
-          "files"
-        ],
-        "title": "FileUploadRequest",
-        "description": "Request body for generating presigned upload URLs."
-      },
-      "FileUploadResponse": {
-        "properties": {
-          "files": {
-            "items": {
-              "$ref": "#/components/schemas/FileUploadResponseItem"
-            },
-            "type": "array",
-            "title": "Files"
-          }
-        },
-        "type": "object",
-        "required": [
-          "files"
-        ],
-        "title": "FileUploadResponse",
-        "description": "Presigned upload URLs for the requested files."
-      },
-      "FileUploadResponseItem": {
-        "properties": {
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "uploadUrl": {
-            "type": "string",
-            "title": "Uploadurl"
-          },
-          "path": {
-            "type": "string",
-            "title": "Path",
-            "description": "S3-relative path, e.g. \"uploads/data.csv\""
-          }
-        },
-        "type": "object",
-        "required": [
-          "name",
-          "uploadUrl",
-          "path"
-        ],
-        "title": "FileUploadResponseItem",
-        "description": "Presigned upload URL for a single file."
-      },
-      "HTTPValidationError": {
-        "properties": {
-          "detail": {
-            "items": {
-              "$ref": "#/components/schemas/ValidationError"
-            },
-            "type": "array",
-            "title": "Detail"
-          }
-        },
-        "type": "object",
-        "title": "HTTPValidationError"
-      },
-      "InsufficientCreditsError": {
-        "properties": {
-          "detail": {
-            "type": "string",
-            "title": "Detail",
-            "default": "Insufficient credits"
-          }
-        },
-        "type": "object",
-        "title": "InsufficientCreditsError",
-        "description": "Error response when there are insufficient credits"
-      },
-      "MessageListResponse": {
-        "properties": {
-          "messages": {
-            "items": {
-              "$ref": "#/components/schemas/MessageResponse"
-            },
-            "type": "array",
-            "title": "Messages"
-          },
-          "hasMore": {
-            "type": "boolean",
-            "title": "Hasmore"
-          }
-        },
-        "type": "object",
-        "required": [
-          "messages",
-          "hasMore"
-        ],
-        "title": "MessageListResponse"
-      },
-      "MessageResponse": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Id"
-          },
-          "sessionId": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Sessionid"
-          },
-          "role": {
-            "type": "string",
-            "title": "Role"
-          },
-          "data": {
-            "type": "string",
-            "title": "Data"
-          },
-          "type": {
-            "type": "string",
-            "title": "Type",
-            "description": "Coarse category: user_message, assistant_message, browser_action, file_operation, code_execution, integration, planning, completion, browser_action_result, browser_action_error, etc.",
-            "default": ""
-          },
-          "summary": {
-            "type": "string",
-            "title": "Summary",
-            "description": "One-liner human-readable description of the message (e.g. \"Navigating to google.com\", \"Clicking element #5\").",
-            "default": ""
-          },
-          "screenshotUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Screenshoturl"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Createdat"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "sessionId",
-          "role",
-          "data",
-          "createdAt"
-        ],
-        "title": "MessageResponse"
-      },
-      "PlanInfo": {
-        "properties": {
-          "planName": {
-            "type": "string",
-            "title": "Plan Name",
-            "description": "The name of the plan"
-          },
-          "subscriptionStatus": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Subscription Status",
-            "description": "The status of the subscription"
-          },
-          "subscriptionId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Subscription ID",
-            "description": "The ID of the subscription"
-          },
-          "subscriptionCurrentPeriodEnd": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Subscription Current Period End",
-            "description": "The end of the current period"
-          },
-          "subscriptionCanceledAt": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Subscription Canceled At",
-            "description": "The date the subscription was canceled"
-          }
-        },
-        "type": "object",
-        "required": [
-          "planName",
-          "subscriptionStatus",
-          "subscriptionId",
-          "subscriptionCurrentPeriodEnd",
-          "subscriptionCanceledAt"
-        ],
-        "title": "PlanInfo",
-        "description": "View model for plan information"
-      },
-      "ProfileCreateRequest": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 100
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name",
-            "description": "Optional name for the profile"
-          },
-          "userId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User ID",
-            "description": "Your internal user identifier for this profile. Use this to associate a profile with a user in your system."
-          }
-        },
-        "type": "object",
-        "title": "ProfileCreateRequest",
-        "description": "Request model for creating a new profile."
-      },
-      "ProfileListResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/ProfileView"
-            },
-            "type": "array",
-            "title": "Items",
-            "description": "List of profile views for the current page"
-          },
-          "totalItems": {
-            "type": "integer",
-            "title": "Total Items",
-            "description": "Total number of items in the list"
-          },
-          "pageNumber": {
-            "type": "integer",
-            "title": "Page Number",
-            "description": "Page number"
-          },
-          "pageSize": {
-            "type": "integer",
-            "title": "Page Size",
-            "description": "Number of items per page"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items",
-          "totalItems",
-          "pageNumber",
-          "pageSize"
-        ],
-        "title": "ProfileListResponse",
-        "description": "Response model for paginated profile list requests."
-      },
-      "ProfileNotFoundError": {
-        "properties": {
-          "detail": {
-            "type": "string",
-            "title": "Detail",
-            "default": "Profile not found"
-          }
-        },
-        "type": "object",
-        "title": "ProfileNotFoundError",
-        "description": "Error response when a profile is not found"
-      },
-      "ProfileUpdateRequest": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 100
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name",
-            "description": "Optional name for the profile"
-          },
-          "userId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 255
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User ID",
-            "description": "Your internal user identifier for this profile. Use this to associate a profile with a user in your system."
-          }
-        },
-        "type": "object",
-        "title": "ProfileUpdateRequest",
-        "description": "Request model for updating a profile."
-      },
-      "ProfileView": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "ID",
-            "description": "Unique identifier for the profile"
-          },
-          "userId": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "User ID",
-            "description": "Your internal user identifier for this profile. Use this to associate a profile with a user in your system."
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name",
-            "description": "Optional name for the profile"
-          },
-          "lastUsedAt": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date-time"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Last Used At",
-            "description": "Timestamp when the profile was last used"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At",
-            "description": "Timestamp when the profile was created"
-          },
-          "updatedAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At",
-            "description": "Timestamp when the profile was last updated"
-          },
-          "cookieDomains": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Cookie Domains",
-            "description": "List of domain URLs that have cookies stored for this profile"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "createdAt",
-          "updatedAt"
-        ],
-        "title": "ProfileView",
-        "description": "View model for representing a profile. A profile lets you preserve the login state between sessions.\n\nWe recommend that you create a separate profile for each user of your app.\nYou can assign a user_id to each profile to easily identify which user the profile belongs to."
-      },
-      "ProxyCountryCode": {
-        "type": "string",
-        "enum": [
-          "ad",
-          "ae",
-          "af",
-          "ag",
-          "ai",
-          "al",
-          "am",
-          "an",
-          "ao",
-          "aq",
-          "ar",
-          "as",
-          "at",
-          "au",
-          "aw",
-          "az",
-          "ba",
-          "bb",
-          "bd",
-          "be",
-          "bf",
-          "bg",
-          "bh",
-          "bi",
-          "bj",
-          "bl",
-          "bm",
-          "bn",
-          "bo",
-          "bq",
-          "br",
-          "bs",
-          "bt",
-          "bv",
-          "bw",
-          "by",
-          "bz",
-          "ca",
-          "cc",
-          "cd",
-          "cf",
-          "cg",
-          "ch",
-          "ck",
-          "cl",
-          "cm",
-          "co",
-          "cr",
-          "cs",
-          "cu",
-          "cv",
-          "cw",
-          "cx",
-          "cy",
-          "cz",
-          "de",
-          "dj",
-          "dk",
-          "dm",
-          "do",
-          "dz",
-          "ec",
-          "ee",
-          "eg",
-          "eh",
-          "er",
-          "es",
-          "et",
-          "fi",
-          "fj",
-          "fk",
-          "fm",
-          "fo",
-          "fr",
-          "ga",
-          "gd",
-          "ge",
-          "gf",
-          "gg",
-          "gh",
-          "gi",
-          "gl",
-          "gm",
-          "gn",
-          "gp",
-          "gq",
-          "gr",
-          "gs",
-          "gt",
-          "gu",
-          "gw",
-          "gy",
-          "hk",
-          "hm",
-          "hn",
-          "hr",
-          "ht",
-          "hu",
-          "id",
-          "ie",
-          "il",
-          "im",
-          "in",
-          "iq",
-          "ir",
-          "is",
-          "it",
-          "je",
-          "jm",
-          "jo",
-          "jp",
-          "ke",
-          "kg",
-          "kh",
-          "ki",
-          "km",
-          "kn",
-          "kp",
-          "kr",
-          "kw",
-          "ky",
-          "kz",
-          "la",
-          "lb",
-          "lc",
-          "li",
-          "lk",
-          "lr",
-          "ls",
-          "lt",
-          "lu",
-          "lv",
-          "ly",
-          "ma",
-          "mc",
-          "md",
-          "me",
-          "mf",
-          "mg",
-          "mh",
-          "mk",
-          "ml",
-          "mm",
-          "mn",
-          "mo",
-          "mp",
-          "mq",
-          "mr",
-          "ms",
-          "mt",
-          "mu",
-          "mv",
-          "mw",
-          "mx",
-          "my",
-          "mz",
-          "na",
-          "nc",
-          "ne",
-          "nf",
-          "ng",
-          "ni",
-          "nl",
-          "no",
-          "np",
-          "nr",
-          "nu",
-          "nz",
-          "om",
-          "pa",
-          "pe",
-          "pf",
-          "pg",
-          "ph",
-          "pk",
-          "pl",
-          "pm",
-          "pn",
-          "pr",
-          "ps",
-          "pt",
-          "pw",
-          "py",
-          "qa",
-          "re",
-          "ro",
-          "rs",
-          "ru",
-          "rw",
-          "sa",
-          "sb",
-          "sc",
-          "sd",
-          "se",
-          "sg",
-          "sh",
-          "si",
-          "sj",
-          "sk",
-          "sl",
-          "sm",
-          "sn",
-          "so",
-          "sr",
-          "ss",
-          "st",
-          "sv",
-          "sx",
-          "sy",
-          "sz",
-          "tc",
-          "td",
-          "tf",
-          "tg",
-          "th",
-          "tj",
-          "tk",
-          "tl",
-          "tm",
-          "tn",
-          "to",
-          "tr",
-          "tt",
-          "tv",
-          "tw",
-          "tz",
-          "ua",
-          "ug",
-          "uk",
-          "us",
-          "uy",
-          "uz",
-          "va",
-          "vc",
-          "ve",
-          "vg",
-          "vi",
-          "vn",
-          "vu",
-          "wf",
-          "ws",
-          "xk",
-          "ye",
-          "yt",
-          "za",
-          "zm",
-          "zw"
-        ],
-        "title": "ProxyCountryCode"
-      },
-      "RunTaskRequest": {
-        "properties": {
-          "task": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Task"
-          },
-          "model": {
-            "$ref": "#/components/schemas/BuModel",
-            "default": "bu-mini"
-          },
-          "sessionId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Sessionid"
-          },
-          "keepAlive": {
-            "type": "boolean",
-            "title": "Keepalive",
-            "default": false
-          },
-          "maxCostUsd": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Maxcostusd"
-          },
-          "profileId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Profileid"
-          },
-          "workspaceId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Workspaceid"
-          },
-          "proxyCountryCode": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ProxyCountryCode"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": "us"
-          },
-          "outputSchema": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Outputschema"
-          },
-          "enableScheduledTasks": {
-            "type": "boolean",
-            "title": "Enablescheduledtasks",
-            "default": false
-          },
-          "enableRecording": {
-            "type": "boolean",
-            "title": "Enablerecording",
-            "default": false
-          },
-          "skills": {
-            "type": "boolean",
-            "title": "Skills",
-            "default": true
-          },
-          "agentmail": {
-            "type": "boolean",
-            "title": "Agentmail",
-            "default": true
-          }
-        },
-        "type": "object",
-        "title": "RunTaskRequest",
-        "description": "Unified request for creating a session or dispatching a task.\n\n- Without session_id + without task: creates a new idle session (for file uploads, etc.)\n- Without session_id + with task: creates a new session and dispatches the task\n- With session_id + with task: dispatches the task to an existing idle session\n- With session_id + without task: 422 (task required when dispatching to existing session)"
-      },
-      "SessionListResponse": {
-        "properties": {
-          "sessions": {
-            "items": {
-              "$ref": "#/components/schemas/SessionResponse"
-            },
-            "type": "array",
-            "title": "Sessions"
-          },
-          "total": {
-            "type": "integer",
-            "title": "Total"
-          },
-          "page": {
-            "type": "integer",
-            "title": "Page"
-          },
-          "pageSize": {
-            "type": "integer",
-            "title": "Pagesize"
-          }
-        },
-        "type": "object",
-        "required": [
-          "sessions",
-          "total",
-          "page",
-          "pageSize"
-        ],
-        "title": "SessionListResponse"
-      },
-      "SessionNotFoundError": {
-        "properties": {
-          "detail": {
-            "type": "string",
-            "title": "Detail",
-            "default": "Session not found"
-          }
-        },
-        "type": "object",
-        "title": "SessionNotFoundError",
-        "description": "Error response when a session is not found"
-      },
-      "SessionResponse": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "Id"
-          },
-          "status": {
-            "$ref": "#/components/schemas/BuAgentSessionStatus"
-          },
-          "model": {
-            "$ref": "#/components/schemas/BuModel"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          },
-          "output": {
-            "anyOf": [
-              {},
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Output"
-          },
-          "outputSchema": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Outputschema"
-          },
-          "stepCount": {
-            "type": "integer",
-            "title": "Stepcount",
-            "default": 0
-          },
-          "lastStepSummary": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Laststepsummary"
-          },
-          "isTaskSuccessful": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Istasksuccessful"
-          },
-          "liveUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Liveurl"
-          },
-          "recordingUrls": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Recordingurls",
-            "default": []
-          },
-          "profileId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Profileid"
-          },
-          "workspaceId": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "uuid"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Workspaceid"
-          },
-          "proxyCountryCode": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ProxyCountryCode"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "maxCostUsd": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Maxcostusd"
-          },
-          "totalInputTokens": {
-            "type": "integer",
-            "title": "Totalinputtokens",
-            "default": 0
-          },
-          "totalOutputTokens": {
-            "type": "integer",
-            "title": "Totaloutputtokens",
-            "default": 0
-          },
-          "proxyUsedMb": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Proxyusedmb",
-            "default": "0"
-          },
-          "llmCostUsd": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Llmcostusd",
-            "default": "0"
-          },
-          "proxyCostUsd": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Proxycostusd",
-            "default": "0"
-          },
-          "browserCostUsd": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Browsercostusd",
-            "default": "0"
-          },
-          "totalCostUsd": {
-            "type": "string",
-            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
-            "title": "Totalcostusd",
-            "default": "0"
-          },
-          "screenshotUrl": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Screenshoturl"
-          },
-          "agentmailEmail": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Agentmailemail"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Createdat"
-          },
-          "updatedAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updatedat"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "status",
-          "model",
-          "createdAt",
-          "updatedAt"
-        ],
-        "title": "SessionResponse"
-      },
-      "SessionTimeoutLimitExceededError": {
-        "properties": {
-          "detail": {
-            "type": "string",
-            "title": "Detail",
-            "default": "Maximum session timeout is 4 hours (240 minutes)."
-          }
-        },
-        "type": "object",
-        "title": "SessionTimeoutLimitExceededError",
-        "description": "Error response when session timeout exceeds the maximum allowed limit"
-      },
-      "StopSessionRequest": {
-        "properties": {
-          "strategy": {
-            "$ref": "#/components/schemas/StopStrategy",
-            "default": "session"
-          }
-        },
-        "type": "object",
-        "title": "StopSessionRequest"
-      },
-      "StopStrategy": {
-        "type": "string",
-        "enum": [
-          "task",
-          "session"
-        ],
-        "title": "StopStrategy"
-      },
-      "TooManyConcurrentActiveSessionsError": {
-        "properties": {
-          "detail": {
-            "type": "string",
-            "title": "Detail",
-            "default": "Too many concurrent active sessions. Please wait for one to finish, kill one, or upgrade your plan."
-          }
-        },
-        "type": "object",
-        "title": "TooManyConcurrentActiveSessionsError",
-        "description": "Error response when user has too many concurrent active sessions"
-      },
-      "UpdateBrowserSessionRequest": {
-        "properties": {
-          "action": {
-            "$ref": "#/components/schemas/BrowserSessionUpdateAction",
-            "title": "Action",
-            "description": "The action to perform on the session"
-          }
-        },
-        "type": "object",
-        "required": [
-          "action"
-        ],
-        "title": "UpdateBrowserSessionRequest",
-        "description": "Request model for updating browser session state."
-      },
-      "ValidationError": {
-        "properties": {
-          "loc": {
-            "items": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "integer"
-                }
-              ]
-            },
-            "type": "array",
-            "title": "Location"
-          },
-          "msg": {
-            "type": "string",
-            "title": "Message"
-          },
-          "type": {
-            "type": "string",
-            "title": "Error Type"
-          }
-        },
-        "type": "object",
-        "required": [
-          "loc",
-          "msg",
-          "type"
-        ],
-        "title": "ValidationError"
-      },
-      "WorkspaceCreateRequest": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 100
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name",
-            "description": "Optional name for the workspace"
-          }
-        },
-        "type": "object",
-        "title": "WorkspaceCreateRequest",
-        "description": "Request model for creating a new workspace."
-      },
-      "WorkspaceListResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/WorkspaceView"
-            },
-            "type": "array",
-            "title": "Items",
-            "description": "List of workspace views for the current page"
-          },
-          "totalItems": {
-            "type": "integer",
-            "title": "Total Items",
-            "description": "Total number of items in the list"
-          },
-          "pageNumber": {
-            "type": "integer",
-            "title": "Page Number",
-            "description": "Page number"
-          },
-          "pageSize": {
-            "type": "integer",
-            "title": "Page Size",
-            "description": "Number of items per page"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items",
-          "totalItems",
-          "pageNumber",
-          "pageSize"
-        ],
-        "title": "WorkspaceListResponse",
-        "description": "Response model for paginated workspace list requests."
-      },
-      "WorkspaceUpdateRequest": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string",
-                "maxLength": 100
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name",
-            "description": "Optional name for the workspace"
-          }
-        },
-        "type": "object",
-        "title": "WorkspaceUpdateRequest",
-        "description": "Request model for updating a workspace."
-      },
-      "WorkspaceView": {
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid",
-            "title": "ID",
-            "description": "Unique identifier for the workspace"
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name",
-            "description": "Optional name for the workspace"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Created At",
-            "description": "Timestamp when the workspace was created"
-          },
-          "updatedAt": {
-            "type": "string",
-            "format": "date-time",
-            "title": "Updated At",
-            "description": "Timestamp when the workspace was last updated"
-          }
-        },
-        "type": "object",
-        "required": [
-          "id",
-          "createdAt",
-          "updatedAt"
-        ],
-        "title": "WorkspaceView",
-        "description": "View model for a workspace \u2014 persistent shared storage across sessions."
-      }
-    },
-    "securitySchemes": {
-      "APIKeyHeader": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-Browser-Use-API-Key"
-      }
-    }
-  },
-  "tags": [
-    {
-      "name": "Sessions"
-    },
-    {
-      "name": "Browsers"
-    },
-    {
-      "name": "Profiles"
-    },
-    {
-      "name": "Workspaces",
-      "description": "File handling across sessions. Upload and download files, give the agent persistent memory."
-    },
-    {
-      "name": "Files"
-    },
-    {
-      "name": "Billing"
-    }
-  ]
 }


### PR DESCRIPTION
## Summary

### Message streaming (non-breaking, additive)

**Python async** — `async for msg in client.run()`:
```python
run = client.run("Find the top story on HN")
async for msg in run:
    print(f"[{msg.role}] {msg.summary}")
print(run.result.output)
```

**Python sync** — `client.stream()`:
```python
stream = client.stream("Find the top story on HN")
for msg in stream:
    print(f"[{msg.role}] {msg.summary}")
print(stream.result.output)
```

**TypeScript** — `for await...of`:
```typescript
const run = client.run("Find the top story on HN");
for await (const msg of run) {
    console.log(`[${msg.role}] ${msg.summary}`);
}
console.log(run.result.output);
```

Uses `sessions.messages(after=cursor)` for incremental fetching. Existing `await client.run()` is unchanged.

### Minor docs fixes
- Use `m.summary` instead of `m.data[:200]` in streaming examples
- Remove `str(m.id)` — use `m.id` directly
- Remove `s.status.value` — use `s.status` (consistent with TS)
- Fix `sessions.create()` positional arg to keyword arg

## Test plan
- [ ] `await client.run()` still works (no regression)
- [ ] `async for msg in client.run()` yields messages
- [ ] `client.stream()` yields messages (sync)
- [ ] `.result` is populated after iteration
- [ ] Follow-up tasks with `session_id` only stream new messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds message streaming for Python and TypeScript so you can iterate messages as they arrive, with `await client.run()` unchanged. Also updates the streaming docs and refreshes the v3 OpenAPI spec.

- **New Features**
  - Python async: `async for msg in client.run("...")` yields messages; `.result` is set after.
  - Python sync: `client.stream("...")` returns an iterator; `.result` is available after.
  - TypeScript: `for await (const msg of client.run("..."))` via an async iterator on `SessionRun`.
  - Incremental fetch with `sessions.messages(after=cursor)`.

- **Bug Fixes**
  - Streaming: drain all remaining message pages after terminal status (not just the first 100).
  - Docs: streamlined guide with a message fields table; manual polling moved below; consistent `m.summary`, `m.id`, `s.status`; fixed `sessions.create(task=...)` in live preview.
  - API: pulled latest v3 OpenAPI spec from production (includes `MessageResponse` fields); no behavior change.

<sup>Written for commit 23506027032682d857a5ec992fdeea6cf990fa3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

