### PR TITLE
Streaming docs: show screenshot_url and all message fields

### DIFF
--- a/docs/cloud/agent/streaming.mdx
+++ b/docs/cloud/agent/streaming.mdx
@@ -8,7 +8,7 @@ icon: message-lines
   Want a ready-made UI? See the [Chat UI tutorial](/cloud/tutorials/chat-ui).
 </Note>
 
-Stream messages as the agent works — reasoning, tool calls, browser actions, and results. Each message has a `summary` for display and a `role` (`user`, `assistant`, `tool`). See [List session messages](/cloud/api-v3/sessions/list-session-messages) for all fields.
+Stream messages as the agent works — reasoning, tool calls, browser actions, and results. Each message has `role`, `type`, `summary`, `data`, and `screenshot_url`. See [List session messages](/cloud/api-v3/sessions/list-session-messages) for all fields.
 
 <CodeGroup>
 ```python Python


### PR DESCRIPTION
Show screenshot_url in streaming example code and output. Mention all available fields (role, type, summary, data, screenshot_url) with link to API reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the streaming docs to show `screenshot_url` in Python and JS examples and list all message fields inline.
Replaced the fields table with a short note listing `role`, `type`, `summary`, `data`, `screenshot_url`, linked to “List session messages”, and added a small sample message stream.

<sup>Written for commit e17c7f307dc9e26e91a7e24e34d84bd8e9596194. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

