### PR TITLE
Simplify live URL docs: available immediately, no polling

### DIFF
--- a/docs/cloud/agent/human-in-the-loop.mdx
+++ b/docs/cloud/agent/human-in-the-loop.mdx
@@ -12,19 +12,19 @@ icon: hand
 ## Flow
 
 1. Create a session with `keep_alive=True` so it stays alive between tasks
-2. Run an agent task — poll `sessions.get()` for `live_url` (~3-5 seconds)
+2. Run an agent task
 3. Human interacts with the live browser
 4. Send a new follow-up task
 
 <CodeGroup>
 ```python Python
-import asyncio
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 
 # 1. Create a persistent session
 session = await client.sessions.create(keep_alive=True)
+print(f"Live view: {session.live_url}")
 
 # 2. Agent does the first part
 result = await client.run(
@@ -32,13 +32,6 @@ result = await client.run(
     session_id=session.id,
 )
 print(result.output)
-
-# Get the live URL (available while session is alive with keep_alive)
-s = await client.sessions.get(session.id)
-while not s.live_url:
-    await asyncio.sleep(1)
-    s = await client.sessions.get(session.id)
-print(f"Live view: {s.live_url}")
 
 # 3. Human opens live_url and picks a flight
 input("Press Enter after you've selected a flight in the live view...")
@@ -61,6 +54,7 @@ const client = new BrowserUse();
 
 // 1. Create a persistent session
 const session = await client.sessions.create({ keepAlive: true });
+console.log(`Live view: ${session.liveUrl}`);
 
 // 2. Agent does the first part
 const searchResult = await client.run(
@@ -68,14 +62,6 @@ const searchResult = await client.run(
   { sessionId: session.id },
 );
 console.log(searchResult.output);
-
-// Get the live URL (available while session is alive with keepAlive)
-let s = await client.sessions.get(session.id);
-while (!s.liveUrl) {
-  await new Promise((r) => setTimeout(r, 1000));
-  s = await client.sessions.get(session.id);
-}
-console.log(`Live view: ${s.liveUrl}`);
 
 // 3. Human opens liveUrl and picks a flight
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });

--- a/docs/cloud/browser/live-preview.mdx
+++ b/docs/cloud/browser/live-preview.mdx
@@ -8,21 +8,15 @@ icon: eye
   Want a ready-made UI? See the [Chat UI tutorial](/cloud/tutorials/chat-ui).
 </Note>
 
+`liveUrl` is returned on session creation.
+
 <CodeGroup>
 ```python Python
-import asyncio
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 session = await client.sessions.create(task="Check how many GitHub stars browser-use has")
-
-# liveUrl becomes available once the browser is ready
-while True:
-    s = await client.sessions.get(session.id)
-    if s.live_url:
-        print(s.live_url)
-        break
-    await asyncio.sleep(0.5)
+print(session.live_url)
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
@@ -31,16 +25,7 @@ const client = new BrowserUse();
 const session = await client.sessions.create({
   task: "Check how many GitHub stars browser-use has",
 });
-
-// liveUrl becomes available once the browser is ready
-while (true) {
-  const s = await client.sessions.get(session.id);
-  if (s.liveUrl) {
-    console.log(s.liveUrl);
-    break;
-  }
-  await new Promise((r) => setTimeout(r, 500));
-}
+console.log(session.liveUrl);
 ```
 </CodeGroup>
 

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -15,14 +15,12 @@ Set `max_cost_usd` to cap spending per task. Default is $20. A typical task cost
 
 ## How do I get the live browser URL?
 
-`live_url` is available while the browser is running. Use `keep_alive=True` so the session stays alive after the task — otherwise `live_url` goes to null when the task finishes.
+`live_url` is returned on session creation. Embed it in an iframe or open it in a browser.
 
 ```python
-result = await client.run("Go to example.com", keep_alive=True)
-print(result.live_url)  # available because session is still alive
+session = await client.sessions.create(task="Go to example.com")
+print(session.live_url)
 ```
-
-If you use `sessions.create()` directly, poll `sessions.get()` until `live_url` appears (~3-5 seconds).
 
 ## How do I authenticate on websites?
 


### PR DESCRIPTION
## Summary

`liveUrl` is now returned immediately on session creation (cloud#3710 + preview-use#9). Remove all polling loops:

- **live-preview.mdx**: 15-line polling loop → 1 line (`session.live_url`)
- **human-in-the-loop.mdx**: 6-line polling loop → `session.live_url` on create
- **faq.mdx**: Simplified to "available immediately"

+13 -44 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs now show `liveUrl` is returned on session creation (deterministic `/session/{id}`), so no polling is needed. Updated `live-preview.mdx`, `human-in-the-loop.mdx`, and `faq.mdx` to use `session.live_url`/`session.liveUrl` directly.

<sup>Written for commit d072273a7aeeb410139f74271f12d1c5f3b83a61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

