### PR TITLE
Auto keep_alive when session_id is passed to run()

### DIFF
--- a/browser-use-node/src/v3/client.ts
+++ b/browser-use-node/src/v3/client.ts
@@ -66,6 +66,10 @@ export class BrowserUse {
     if (schema) {
       body.outputSchema = z.toJSONSchema(schema) as Record<string, unknown>;
     }
+    // Auto keep_alive when dispatching to an existing session
+    if (body.sessionId && body.keepAlive === undefined) {
+      body.keepAlive = true;
+    }
     const promise = this.sessions.create(body);
     return new SessionRun(promise, this.sessions, schema, { timeout, interval });
   }

--- a/browser-use-python/src/browser_use_sdk/v3/client.py
+++ b/browser-use-python/src/browser_use_sdk/v3/client.py
@@ -109,6 +109,10 @@ class BrowserUse:
         if resolved_schema is not None and issubclass(resolved_schema, BaseModel):
             schema_dict = resolved_schema.model_json_schema()
 
+        # Auto keep_alive when dispatching to an existing session
+        if session_id is not None and keep_alive is None:
+            keep_alive = True
+
         data = self.sessions.create(
             task,
             model=model,
@@ -151,6 +155,9 @@ class BrowserUse:
         schema_dict: dict[str, Any] | None = None
         if resolved_schema is not None and issubclass(resolved_schema, BaseModel):
             schema_dict = resolved_schema.model_json_schema()
+
+        if session_id is not None and keep_alive is None:
+            keep_alive = True
 
         data = self.sessions.create(
             task,
@@ -268,12 +275,17 @@ class AsyncBrowserUse:
         if resolved_schema is not None and issubclass(resolved_schema, BaseModel):
             schema_dict = resolved_schema.model_json_schema()
 
+        # Auto keep_alive when dispatching to an existing session
+        effective_keep_alive = keep_alive
+        if session_id is not None and keep_alive is None:
+            effective_keep_alive = True
+
         def create_fn() -> Awaitable[SessionResponse]:
             return self.sessions.create(
                 task,
                 model=model,
                 session_id=session_id,
-                keep_alive=keep_alive,
+                keep_alive=effective_keep_alive,
                 max_cost_usd=max_cost_usd,
                 profile_id=profile_id,
                 proxy_country_code=proxy_country_code,

--- a/docs/cloud/agent/follow-up-tasks.mdx
+++ b/docs/cloud/agent/follow-up-tasks.mdx
@@ -4,19 +4,20 @@ description: "Run multiple tasks in the same browser session."
 icon: list-check
 ---
 
+When you pass a `session_id`, the session automatically stays alive between tasks.
+
 <CodeGroup>
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 
-# Create a session first, then run tasks inside it
+# Create a session, then run tasks inside it
 session = await client.sessions.create()
 
 result1 = await client.run(
     "Log into example.com with user@test.com",
     session_id=session.id,
-    keep_alive=True,
 )
 result2 = await client.run(
     "Now go to settings and change the timezone",
@@ -30,12 +31,11 @@ import { BrowserUse } from "browser-use-sdk/v3";
 
 const client = new BrowserUse();
 
-// Create a session first, then run tasks inside it
+// Create a session, then run tasks inside it
 const session = await client.sessions.create();
 
 const result1 = await client.run("Log into example.com with user@test.com", {
   sessionId: session.id,
-  keepAlive: true,
 });
 const result2 = await client.run("Now go to settings and change the timezone", {
   sessionId: session.id,
@@ -44,5 +44,3 @@ const result2 = await client.run("Now go to settings and change the timezone", {
 await client.sessions.stop(session.id);
 ```
 </CodeGroup>
-
-Use `keep_alive: true` to keep the session running after a task completes. Without it, the session auto-stops when the task finishes.

--- a/docs/cloud/agent/human-in-the-loop.mdx
+++ b/docs/cloud/agent/human-in-the-loop.mdx
@@ -11,7 +11,7 @@ icon: hand
 
 ## Flow
 
-1. Create a session with `keep_alive=True` so it stays alive between tasks
+1. Create a session — it stays alive automatically when you pass `session_id` to `run()`
 2. Run an agent task
 3. Human interacts with the live browser
 4. Send a new follow-up task
@@ -22,8 +22,8 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 
-# 1. Create a persistent session
-session = await client.sessions.create(keep_alive=True)
+# 1. Create a session
+session = await client.sessions.create()
 print(f"Live view: {session.live_url}")
 
 # 2. Agent does the first part
@@ -52,8 +52,8 @@ import * as readline from "readline";
 
 const client = new BrowserUse();
 
-// 1. Create a persistent session
-const session = await client.sessions.create({ keepAlive: true });
+// 1. Create a session
+const session = await client.sessions.create();
 console.log(`Live view: ${session.liveUrl}`);
 
 // 2. Agent does the first part


### PR DESCRIPTION
## Summary

When `session_id` is passed to `client.run()`, automatically set `keep_alive=True` (unless explicitly set to `False`). This simplifies follow-up tasks.

## Before
```python
result1 = await client.run("task 1", session_id=session.id, keep_alive=True)
result2 = await client.run("task 2", session_id=session.id)
```

## After
```python
result1 = await client.run("task 1", session_id=session.id)
result2 = await client.run("task 2", session_id=session.id)
```

No backend changes needed — purely SDK-side. Non-breaking: users who already pass `keep_alive=True` explicitly are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-enable keep_alive when a session_id is passed to run(), unless explicitly set to False. This simplifies follow-up tasks in both Python and Node SDKs; docs updated; no backend changes.

- **New Features**
  - Python `browser_use_sdk.v3`: `run()` (sync/async) and `stream()` default to `keep_alive=True` when `session_id` is set.
  - Node `browser-use-sdk/v3`: `run()` defaults to `keepAlive=true` when `sessionId` is set.
  - Docs: removed explicit keep_alive from follow-up tasks and human-in-the-loop examples.

- **Migration**
  - No action required. To auto-stop even when passing a session ID, set `keep_alive=False` (Python) or `keepAlive=false` (Node).

<sup>Written for commit 42a8768f7f72561e0cc7586e745d175925385431. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

