### PR TITLE
Replace Google Flights examples with amazon/reddit

### DIFF
--- a/docs/cloud/agent/human-in-the-loop.mdx
+++ b/docs/cloud/agent/human-in-the-loop.mdx
@@ -28,17 +28,17 @@ print(f"Live view: {session.live_url}")
 
 # 2. Agent does the first part
 result = await client.run(
-    "Go to Google Flights and search for flights from NYC to London",
+    "Go to amazon.com and search for noise cancelling headphones",
     session_id=session.id,
 )
 print(result.output)
 
 # 3. Human opens live_url and picks a flight
-input("Press Enter after you've selected a flight in the live view...")
+input("Press Enter after you've selected a product in the live view...")
 
 # 4. Agent continues where the human left off
 result = await client.run(
-    "Get the details of the selected flight — airline, price, departure and arrival times",
+    "Get the details of the selected product — name, price, and rating",
     session_id=session.id,
 )
 print(result.output)
@@ -58,7 +58,7 @@ console.log(`Live view: ${session.liveUrl}`);
 
 // 2. Agent does the first part
 const searchResult = await client.run(
-  "Go to Google Flights and search for flights from NYC to London",
+  "Go to amazon.com and search for noise cancelling headphones",
   { sessionId: session.id },
 );
 console.log(searchResult.output);
@@ -66,13 +66,13 @@ console.log(searchResult.output);
 // 3. Human opens liveUrl and picks a flight
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 await new Promise((resolve) =>
-  rl.question("Press Enter after you've selected a flight in the live view...", resolve),
+  rl.question("Press Enter after you've selected a product in the live view...", resolve),
 );
 rl.close();
 
 // 4. Agent continues where the human left off
 const result = await client.run(
-  "Get the details of the selected flight — airline, price, departure and arrival times",
+  "Get the details of the selected product — name, price, and rating",
   { sessionId: session.id },
 );
 console.log(result.output);

--- a/docs/cloud/legacy/agent.mdx
+++ b/docs/cloud/legacy/agent.mdx
@@ -116,7 +116,7 @@ Use `async for` to yield steps as the agent works.
 from browser_use_sdk import AsyncBrowserUse
 
 client = AsyncBrowserUse()
-run = client.run("Find the cheapest flight from NYC to London on Google Flights")
+run = client.run("Find the most upvoted post on Reddit r/technology today")
 async for step in run:
     print(f"Step {step.number}: {step.next_goal}")
     print(f"  URL: {step.url}")
@@ -127,7 +127,7 @@ print(run.result.output)  # final result after iteration
 import { BrowserUse } from "browser-use-sdk";
 
 const client = new BrowserUse();
-const run = client.run("Find the cheapest flight from NYC to London on Google Flights");
+const run = client.run("Find the most upvoted post on Reddit r/technology today");
 for await (const step of run) {
   console.log(`Step ${step.number}: ${step.nextGoal}`);
   console.log(`  URL: ${step.url}`);


### PR DESCRIPTION
Remove all Google Flights references.

- human-in-the-loop: flights → amazon headphones search + product selection
- legacy agent: flights → Reddit r/technology

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced Google Flights examples with Amazon product search and Reddit r/technology tasks in the docs. The human-in-the-loop example now selects a product and reads its details; the legacy agent example now finds today’s most upvoted r/technology post.

<sup>Written for commit cf3dfc3ef61d4e244b474a40c03d4c494df3cfa1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

