### PR TITLE
Update intro example: list top 20 HN posts with points

### DIFF
--- a/docs/cloud/agent/follow-up-tasks.mdx
+++ b/docs/cloud/agent/follow-up-tasks.mdx
@@ -4,7 +4,7 @@ description: "Run multiple tasks in the same browser session."
 icon: list-check
 ---
 
-When you pass a `session_id`, the session automatically stays alive between tasks.
+When you pass a `session_id`, the session automatically stays alive between tasks. Each task runs a new agent that reuses the same browser — the agents don't share context, but the browser state (page, cookies, tabs) carries over.
 
 <CodeGroup>
 ```python Python
@@ -16,11 +16,11 @@ client = AsyncBrowserUse()
 session = await client.sessions.create()
 
 result1 = await client.run(
-    "Log into example.com with user@test.com",
+    "Go to amazon.com, search for laptops, and open the first result",
     session_id=session.id,
 )
 result2 = await client.run(
-    "Now go to settings and change the timezone",
+    "Extract the customer reviews",
     session_id=session.id,
 )
 
@@ -34,10 +34,10 @@ const client = new BrowserUse();
 // Create a session, then run tasks inside it
 const session = await client.sessions.create();
 
-const result1 = await client.run("Log into example.com with user@test.com", {
+const result1 = await client.run("Go to amazon.com, search for laptops, and open the first result", {
   sessionId: session.id,
 });
-const result2 = await client.run("Now go to settings and change the timezone", {
+const result2 = await client.run("Extract the customer reviews", {
   sessionId: session.id,
 });
 

--- a/docs/cloud/agent/quickstart.mdx
+++ b/docs/cloud/agent/quickstart.mdx
@@ -13,14 +13,14 @@ The SDK is a thin wrapper around the [API v3 Reference](/cloud/api-reference).
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
-result = await client.run("Find the top 3 trending repos on GitHub today")
+result = await client.run("List the top 20 posts on Hacker News today with their points")
 print(result.output)
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
 
 const client = new BrowserUse();
-const result = await client.run("Find the top 3 trending repos on GitHub today");
+const result = await client.run("List the top 20 posts on Hacker News today with their points");
 console.log(result.output);
 ```
 </CodeGroup>

--- a/docs/cloud/agent/structured-output.mdx
+++ b/docs/cloud/agent/structured-output.mdx
@@ -11,33 +11,43 @@ Pass a Pydantic model (Python) or Zod schema (TypeScript) — `result.output` is
 from browser_use_sdk.v3 import AsyncBrowserUse
 from pydantic import BaseModel
 
-class Contact(BaseModel):
+class Post(BaseModel):
     name: str
-    title: str
-    company: str
+    points: int
+    comments: int
+
+class HNPosts(BaseModel):
+    posts: list[Post]
 
 client = AsyncBrowserUse()
 result = await client.run(
-    "Find the founding team of Browser Use on LinkedIn",
-    output_schema=Contact,
+    "List the top 20 posts on Hacker News today with their points",
+    output_schema=HNPosts,
 )
-print(result.output)
+for post in result.output.posts:
+    print(f"{post.name} ({post.points} pts, {post.comments} comments)")
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
 import { z } from "zod";
 
-const Contact = z.object({
+const Post = z.object({
   name: z.string(),
-  title: z.string(),
-  company: z.string(),
+  points: z.number(),
+  comments: z.number(),
+});
+
+const HNPosts = z.object({
+  posts: z.array(Post),
 });
 
 const client = new BrowserUse();
 const result = await client.run(
-  "Find the founding team of Browser Use on LinkedIn",
-  { schema: Contact },
+  "List the top 20 posts on Hacker News today with their points",
+  { schema: HNPosts },
 );
-console.log(result.output);
+for (const post of result.output.posts) {
+  console.log(`${post.name} (${post.points} pts, ${post.comments} comments)`);
+}
 ```
 </CodeGroup>

--- a/docs/cloud/new-features/api-v3.mdx
+++ b/docs/cloud/new-features/api-v3.mdx
@@ -23,7 +23,7 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 
 async def main():
     client = AsyncBrowserUse()
-    result = await client.run("Find the top 3 trending repos on GitHub today")
+    result = await client.run("List the top 20 posts on Hacker News today with their points")
     print(result.output)
 
 asyncio.run(main())
@@ -32,7 +32,7 @@ asyncio.run(main())
 import { BrowserUse } from "browser-use-sdk/v3";
 
 const client = new BrowserUse();
-const result = await client.run("Find the top 3 trending repos on GitHub today");
+const result = await client.run("List the top 20 posts on Hacker News today with their points");
 console.log(result.output);
 ```
 </CodeGroup>

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -30,7 +30,7 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 
 async def main():
     client = AsyncBrowserUse()
-    result = await client.run("Find the top 3 trending repos on GitHub today")
+    result = await client.run("List the top 20 posts on Hacker News today with their points")
     print(result.output)
 
 asyncio.run(main())
@@ -39,7 +39,7 @@ asyncio.run(main())
 import { BrowserUse } from "browser-use-sdk/v3";
 
 const client = new BrowserUse();
-const result = await client.run("Find the top 3 trending repos on GitHub today");
+const result = await client.run("List the top 20 posts on Hacker News today with their points");
 console.log(result.output);
 ```
 </CodeGroup>


### PR DESCRIPTION
Replace "Find the top 3 trending repos on GitHub today" with "List the top 20 posts on Hacker News today with their points" across quickstart, agent intro, and api-v3 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swapped the intro example to “List the top 20 posts on Hacker News today with their points” across quickstart, agent quickstart, and API v3 docs. Updated structured-output to `Post`/`HNPosts` schemas that print points and comments, refreshed follow-up tasks to an Amazon laptop search and reviews extraction, and added a note that sessions reuse the same browser but each task runs a new agent.

<sup>Written for commit b68da9119a2c3b7a5ca9fcdd4a98c1e2a6bc056d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

