### PR TITLE
Add descriptions to all v3 API schemas

### DIFF
--- a/docs/cloud/tutorials/chat-ui.mdx
+++ b/docs/cloud/tutorials/chat-ui.mdx
@@ -15,34 +15,31 @@ The app has two pages:
 1. **Home** — the user types a task, the app creates a session and sends the task.
 2. **Session** — live browser preview, streaming messages, follow-ups, and recording download.
 
-The API key never leaves the server — SDK calls use [Server Actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations) and a [Route Handler](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) for streaming.
+All SDK calls live in a single file: `src/lib/api.ts`.
 
 ## Setup
 
 ```typescript api.ts
-// Server-only — no NEXT_PUBLIC_ prefix, never sent to the browser
 import { BrowserUse } from "browser-use-sdk/v3";
 
-export const client = new BrowserUse({
-  apiKey: process.env.BROWSER_USE_API_KEY,
-});
+const apiKey = process.env.NEXT_PUBLIC_BROWSER_USE_API_KEY ?? "";
+export const client = new BrowserUse({ apiKey });
 ```
+
+<Warning>
+  `NEXT_PUBLIC_` exposes the key to the browser. In production, move SDK calls to server actions or API routes.
+</Warning>
 
 ---
 
-## 1. Create a session (Server Action)
+## 1. Create a session
 
-```typescript actions.ts
-"use server";
-
-import { client } from "./api";
-
+```typescript api.ts
 export async function createSession() {
-  const session = await client.sessions.create({
+  return client.sessions.create({
     keepAlive: true,
     enableRecording: true,
   });
-  return { id: session.id, liveUrl: session.liveUrl, status: session.status };
 }
 ```
 
@@ -50,7 +47,7 @@ export async function createSession() {
 - **`enableRecording: true`** produces an MP4 video of the browser session.
 - **`liveUrl`** is returned immediately — no waiting or extra call needed.
 
-The home page calls the server action, then navigates (passing `liveUrl` and the initial task via URL params):
+The home page creates the session, navigates to the session page (passing `liveUrl` and the initial task via URL params), and the session page takes over from there:
 
 ```typescript page.tsx
 async function handleSend(message: string) {
@@ -64,85 +61,42 @@ async function handleSend(message: string) {
 
 ---
 
-## 2. Stream messages (SSE Route Handler)
+## 2. Stream messages with `for await`
 
-The streaming happens server-side in a Route Handler. `client.run()` with `for await` streams messages as the agent works:
-
-```typescript app/api/stream/[sessionId]/route.ts
-import { client } from "@/lib/api";
-
-export async function POST(request: Request, { params }: { params: Promise<{ sessionId: string }> }) {
-  const { sessionId } = await params;
-  const { task } = await request.json();
-
-  const encoder = new TextEncoder();
-  const stream = new ReadableStream({
-    async start(controller) {
-      const run = client.run(task, { sessionId });
-
-      for await (const msg of run) {
-        controller.enqueue(encoder.encode(`data: ${JSON.stringify(msg)}\n\n`));
-      }
-
-      // Send the final session result when the task completes
-      controller.enqueue(encoder.encode(`data: ${JSON.stringify({ __done: true, ...run.result })}\n\n`));
-      controller.close();
-    },
-  });
-
-  return new Response(stream, {
-    headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache" },
-  });
-}
-```
-
-The client reads this SSE stream with `fetch`:
+Instead of polling `sessions.get()` and `sessions.messages()` separately, use `client.run()` — it streams messages and resolves when the task completes:
 
 ```typescript session-context.tsx
 const streamTask = useCallback(async (task: string) => {
-  const res = await fetch(`/api/stream/${sessionId}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ task }),
-  });
+  const run = client.run(task, { sessionId });
 
-  const reader = res.body!.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-
-    buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split("\n\n");
-    buffer = lines.pop() ?? "";
-
-    for (const line of lines) {
-      if (!line.startsWith("data: ")) continue;
-      const json = JSON.parse(line.slice(6));
-
-      if (json.__done) {
-        setSession(json); // final state
-      } else {
-        setMessages((prev) => [...prev, json]);
-      }
-    }
+  for await (const msg of run) {
+    setMessages((prev) => [...prev, msg]);
   }
+
+  // Iterator done — task reached terminal state
+  setSession(run.result);
 }, [sessionId]);
 ```
 
-No `sessions.get()` or `sessions.messages()` polling needed — one stream covers both messages and status.
+The `for await` loop yields each message as it arrives. When the loop ends, `run.result` contains the final session state (status, output, etc.). No separate status polling needed.
+
+Wire it up in a `useEffect` to auto-run the initial task from URL params:
+
+```typescript session-context.tsx
+useEffect(() => {
+  if (!initialTask) return;
+  sendMessage(initialTask);
+}, []);
+```
 
 ---
 
 ## 3. Follow-up tasks
 
-Follow-ups call the same `streamTask`. Add an optimistic user message so it appears instantly:
+Follow-ups call the same `streamTask` function — the stream already includes the user message, so no optimistic insert is needed:
 
 ```typescript session-context.tsx
 const sendMessage = useCallback(async (task: string) => {
-  setMessages((prev) => [...prev, { id: `opt-${Date.now()}`, role: "user", summary: task }]);
   await streamTask(task);
 }, [streamTask]);
 ```
@@ -151,35 +105,27 @@ The SDK auto-sets `keepAlive: true` when targeting an existing session, so follo
 
 ---
 
-## 4. Recording (Server Action)
+## 4. Recording
 
-Fetch the MP4 URL after the session ends:
-
-```typescript actions.ts
-"use server";
-
-export async function waitForRecording(id: string) {
-  return client.sessions.waitForRecording(id);
-}
-```
+Fetch the MP4 URL after the session ends (recording was enabled in step 1):
 
 ```typescript session-context.tsx
 useEffect(() => {
   if (!isTerminal) return;
 
-  waitForRecording(sessionId).then((urls) => {
+  client.sessions.waitForRecording(sessionId).then((urls) => {
     if (urls.length) setRecordingUrls(urls);
   });
 }, [isTerminal, sessionId]);
 ```
 
+`waitForRecording` polls for up to 15 seconds and returns presigned MP4 download URLs. Returns an empty array if the agent answered without opening a browser.
+
 ---
 
-## 5. Stop a task (Server Action)
+## 5. Stop a task
 
-```typescript actions.ts
-"use server";
-
+```typescript api.ts
 export async function stopTask(id: string) {
   await client.sessions.stop(id, { strategy: "task" });
 }
@@ -189,11 +135,41 @@ Using `strategy: "task"` stops only the current task, keeping the session alive 
 
 ---
 
+## 6. Session page
+
+The session page consumes everything through a context provider:
+
+```typescript session/[id]/page.tsx
+function SessionPage() {
+  const { session, turns, isBusy, isTerminal, recordingUrls, sendMessage, stopTask } =
+    useSession();
+
+  return (
+    <div className="flex h-screen w-full overflow-hidden">
+      {/* Chat column */}
+      <div className="flex-1 flex flex-col min-w-0">
+        <ChatMessages turns={turns} isBusy={isBusy} />
+        <ChatInput
+          onSend={sendMessage}
+          onStop={stopTask}
+          disabled={isTerminal}
+        />
+      </div>
+
+      {/* Live browser view — liveUrl available from session creation */}
+      <BrowserPanel liveUrl={session?.liveUrl} />
+    </div>
+  );
+}
+```
+
+---
+
 ## Summary
 
-| Method | Where | Purpose |
-|--------|-------|---------|
-| `client.sessions.create()` | Server Action | Create a session (returns `liveUrl` immediately) |
-| `client.run()` | Route Handler (SSE) | Stream messages with `for await` |
-| `client.sessions.stop()` | Server Action | Stop the current task |
-| `client.sessions.waitForRecording()` | Server Action | Get MP4 recording URLs |
+| Method | Purpose |
+|--------|---------|
+| `client.sessions.create()` | Create a session (returns `liveUrl` immediately) |
+| `client.run()` | Send a task and stream messages with `for await` |
+| `client.sessions.stop()` | Stop the current task |
+| `client.sessions.waitForRecording()` | Get MP4 recording URLs |

--- a/docs/cloud/tutorials/chat-ui.mdx
+++ b/docs/cloud/tutorials/chat-ui.mdx
@@ -15,31 +15,34 @@ The app has two pages:
 1. **Home** — the user types a task, the app creates a session and sends the task.
 2. **Session** — live browser preview, streaming messages, follow-ups, and recording download.
 
-All SDK calls live in a single file: `src/lib/api.ts`.
+The API key never leaves the server — SDK calls use [Server Actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations) and a [Route Handler](https://nextjs.org/docs/app/building-your-application/routing/route-handlers) for streaming.
 
 ## Setup
 
 ```typescript api.ts
+// Server-only — no NEXT_PUBLIC_ prefix, never sent to the browser
 import { BrowserUse } from "browser-use-sdk/v3";
 
-const apiKey = process.env.NEXT_PUBLIC_BROWSER_USE_API_KEY ?? "";
-export const client = new BrowserUse({ apiKey });
+export const client = new BrowserUse({
+  apiKey: process.env.BROWSER_USE_API_KEY,
+});
 ```
-
-<Warning>
-  `NEXT_PUBLIC_` exposes the key to the browser. In production, move SDK calls to server actions or API routes.
-</Warning>
 
 ---
 
-## 1. Create a session
+## 1. Create a session (Server Action)
 
-```typescript api.ts
+```typescript actions.ts
+"use server";
+
+import { client } from "./api";
+
 export async function createSession() {
-  return client.sessions.create({
+  const session = await client.sessions.create({
     keepAlive: true,
     enableRecording: true,
   });
+  return { id: session.id, liveUrl: session.liveUrl, status: session.status };
 }
 ```
 
@@ -47,7 +50,7 @@ export async function createSession() {
 - **`enableRecording: true`** produces an MP4 video of the browser session.
 - **`liveUrl`** is returned immediately — no waiting or extra call needed.
 
-The home page creates the session, navigates to the session page (passing `liveUrl` and the initial task via URL params), and the session page takes over from there:
+The home page calls the server action, then navigates (passing `liveUrl` and the initial task via URL params):
 
 ```typescript page.tsx
 async function handleSend(message: string) {
@@ -61,42 +64,85 @@ async function handleSend(message: string) {
 
 ---
 
-## 2. Stream messages with `for await`
+## 2. Stream messages (SSE Route Handler)
 
-Instead of polling `sessions.get()` and `sessions.messages()` separately, use `client.run()` — it streams messages and resolves when the task completes:
+The streaming happens server-side in a Route Handler. `client.run()` with `for await` streams messages as the agent works:
+
+```typescript app/api/stream/[sessionId]/route.ts
+import { client } from "@/lib/api";
+
+export async function POST(request: Request, { params }: { params: Promise<{ sessionId: string }> }) {
+  const { sessionId } = await params;
+  const { task } = await request.json();
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    async start(controller) {
+      const run = client.run(task, { sessionId });
+
+      for await (const msg of run) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(msg)}\n\n`));
+      }
+
+      // Send the final session result when the task completes
+      controller.enqueue(encoder.encode(`data: ${JSON.stringify({ __done: true, ...run.result })}\n\n`));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache" },
+  });
+}
+```
+
+The client reads this SSE stream with `fetch`:
 
 ```typescript session-context.tsx
 const streamTask = useCallback(async (task: string) => {
-  const run = client.run(task, { sessionId });
+  const res = await fetch(`/api/stream/${sessionId}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ task }),
+  });
 
-  for await (const msg of run) {
-    setMessages((prev) => [...prev, msg]);
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n\n");
+    buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      if (!line.startsWith("data: ")) continue;
+      const json = JSON.parse(line.slice(6));
+
+      if (json.__done) {
+        setSession(json); // final state
+      } else {
+        setMessages((prev) => [...prev, json]);
+      }
+    }
   }
-
-  // Iterator done — task reached terminal state
-  setSession(run.result);
 }, [sessionId]);
 ```
 
-The `for await` loop yields each message as it arrives. When the loop ends, `run.result` contains the final session state (status, output, etc.). No separate status polling needed.
-
-Wire it up in a `useEffect` to auto-run the initial task from URL params:
-
-```typescript session-context.tsx
-useEffect(() => {
-  if (!initialTask) return;
-  sendMessage(initialTask);
-}, []);
-```
+No `sessions.get()` or `sessions.messages()` polling needed — one stream covers both messages and status.
 
 ---
 
 ## 3. Follow-up tasks
 
-Follow-ups call the same `streamTask` function — the stream already includes the user message, so no optimistic insert is needed:
+Follow-ups call the same `streamTask`. Add an optimistic user message so it appears instantly:
 
 ```typescript session-context.tsx
 const sendMessage = useCallback(async (task: string) => {
+  setMessages((prev) => [...prev, { id: `opt-${Date.now()}`, role: "user", summary: task }]);
   await streamTask(task);
 }, [streamTask]);
 ```
@@ -105,27 +151,35 @@ The SDK auto-sets `keepAlive: true` when targeting an existing session, so follo
 
 ---
 
-## 4. Recording
+## 4. Recording (Server Action)
 
-Fetch the MP4 URL after the session ends (recording was enabled in step 1):
+Fetch the MP4 URL after the session ends:
+
+```typescript actions.ts
+"use server";
+
+export async function waitForRecording(id: string) {
+  return client.sessions.waitForRecording(id);
+}
+```
 
 ```typescript session-context.tsx
 useEffect(() => {
   if (!isTerminal) return;
 
-  client.sessions.waitForRecording(sessionId).then((urls) => {
+  waitForRecording(sessionId).then((urls) => {
     if (urls.length) setRecordingUrls(urls);
   });
 }, [isTerminal, sessionId]);
 ```
 
-`waitForRecording` polls for up to 15 seconds and returns presigned MP4 download URLs. Returns an empty array if the agent answered without opening a browser.
-
 ---
 
-## 5. Stop a task
+## 5. Stop a task (Server Action)
 
-```typescript api.ts
+```typescript actions.ts
+"use server";
+
 export async function stopTask(id: string) {
   await client.sessions.stop(id, { strategy: "task" });
 }
@@ -135,41 +189,11 @@ Using `strategy: "task"` stops only the current task, keeping the session alive 
 
 ---
 
-## 6. Session page
-
-The session page consumes everything through a context provider:
-
-```typescript session/[id]/page.tsx
-function SessionPage() {
-  const { session, turns, isBusy, isTerminal, recordingUrls, sendMessage, stopTask } =
-    useSession();
-
-  return (
-    <div className="flex h-screen w-full overflow-hidden">
-      {/* Chat column */}
-      <div className="flex-1 flex flex-col min-w-0">
-        <ChatMessages turns={turns} isBusy={isBusy} />
-        <ChatInput
-          onSend={sendMessage}
-          onStop={stopTask}
-          disabled={isTerminal}
-        />
-      </div>
-
-      {/* Live browser view — liveUrl available from session creation */}
-      <BrowserPanel liveUrl={session?.liveUrl} />
-    </div>
-  );
-}
-```
-
----
-
 ## Summary
 
-| Method | Purpose |
-|--------|---------|
-| `client.sessions.create()` | Create a session (returns `liveUrl` immediately) |
-| `client.run()` | Send a task and stream messages with `for await` |
-| `client.sessions.stop()` | Stop the current task |
-| `client.sessions.waitForRecording()` | Get MP4 recording URLs |
+| Method | Where | Purpose |
+|--------|-------|---------|
+| `client.sessions.create()` | Server Action | Create a session (returns `liveUrl` immediately) |
+| `client.run()` | Route Handler (SSE) | Stream messages with `for await` |
+| `client.sessions.stop()` | Server Action | Stop the current task |
+| `client.sessions.waitForRecording()` | Server Action | Get MP4 recording URLs |

--- a/docs/openapi/v3.json
+++ b/docs/openapi/v3.json
@@ -80,7 +80,8 @@
                             "minimum": 1,
                             "default": 1,
                             "title": "Page"
-                        }
+                        },
+                        "description": "Page number (1-indexed)."
                     },
                     {
                         "name": "page_size",
@@ -92,7 +93,8 @@
                             "minimum": 1,
                             "default": 20,
                             "title": "Page Size"
-                        }
+                        },
+                        "description": "Number of sessions per page (max 100)."
                     }
                 ],
                 "responses": {
@@ -346,7 +348,8 @@
                             "minimum": 1,
                             "default": 10,
                             "title": "Limit"
-                        }
+                        },
+                        "description": "Maximum number of messages to return (max 100)."
                     }
                 ],
                 "responses": {
@@ -2066,7 +2069,8 @@
                     "timed_out",
                     "error"
                 ],
-                "title": "BuAgentSessionStatus"
+                "title": "BuAgentSessionStatus",
+                "description": "Session lifecycle status. Progresses through: created -> idle -> running -> idle -> ... -> stopped / timed_out / error.\n\n- `created`: Sandbox is starting up. The session is not yet ready to accept tasks.\n- `idle`: Sandbox is healthy and waiting for a task. You can dispatch a task or upload files.\n- `running`: A task is currently being executed by the agent.\n- `stopped`: Session was stopped \u2014 either explicitly via the stop endpoint, or automatically after task completion (when `keepAlive` is false).\n- `timed_out`: Session was cleaned up due to inactivity timeout.\n- `error`: Sandbox failed to start or encountered an unrecoverable error."
             },
             "BuModel": {
                 "type": "string",
@@ -2075,7 +2079,8 @@
                     "bu-max",
                     "bu-ultra"
                 ],
-                "title": "BuModel"
+                "title": "BuModel",
+                "description": "The model tier to use for the agent. Each tier uses a different underlying LLM with different capabilities and pricing.\n\n- `bu-mini`: Fast and cost-effective. Best for simple, well-defined tasks like form filling or data extraction.\n- `bu-max`: Balanced performance. Best for multi-step workflows that require reasoning and decision-making.\n- `bu-ultra`: Most capable. Best for complex tasks that require advanced reasoning, long-horizon planning, or handling ambiguous instructions."
             },
             "CreateBrowserSessionRequest": {
                 "properties": {
@@ -2227,16 +2232,19 @@
                 "properties": {
                     "path": {
                         "type": "string",
-                        "title": "Path"
+                        "title": "Path",
+                        "description": "File path relative to the session workspace root."
                     },
                     "size": {
                         "type": "integer",
-                        "title": "Size"
+                        "title": "Size",
+                        "description": "File size in bytes."
                     },
                     "lastModified": {
                         "type": "string",
                         "format": "date-time",
-                        "title": "Lastmodified"
+                        "title": "Lastmodified",
+                        "description": "When the file was last modified."
                     },
                     "url": {
                         "anyOf": [
@@ -2247,7 +2255,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Url"
+                        "title": "Url",
+                        "description": "Presigned download URL (60s expiry). Only included when `includeUrls=true`."
                     }
                 },
                 "type": "object",
@@ -2266,7 +2275,8 @@
                             "$ref": "#/components/schemas/FileInfo"
                         },
                         "type": "array",
-                        "title": "Files"
+                        "title": "Files",
+                        "description": "List of files matching the query."
                     },
                     "folders": {
                         "items": {
@@ -2274,7 +2284,7 @@
                         },
                         "type": "array",
                         "title": "Folders",
-                        "description": "Immediate sub-folder names at this prefix level"
+                        "description": "Immediate sub-folder names at this prefix level."
                     },
                     "nextCursor": {
                         "anyOf": [
@@ -2285,12 +2295,14 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Nextcursor"
+                        "title": "Nextcursor",
+                        "description": "Cursor for the next page. Pass as the `cursor` query parameter to fetch the next page."
                     },
                     "hasMore": {
                         "type": "boolean",
                         "title": "Hasmore",
-                        "default": false
+                        "default": false,
+                        "description": "Whether there are more files beyond this page."
                     }
                 },
                 "type": "object",
@@ -2377,16 +2389,18 @@
                 "properties": {
                     "name": {
                         "type": "string",
-                        "title": "Name"
+                        "title": "Name",
+                        "description": "Original filename as requested."
                     },
                     "uploadUrl": {
                         "type": "string",
-                        "title": "Uploadurl"
+                        "title": "Uploadurl",
+                        "description": "Presigned PUT URL. Upload the file by sending a PUT request to this URL with the file content and matching Content-Type header. Expires after 5 minutes."
                     },
                     "path": {
                         "type": "string",
                         "title": "Path",
-                        "description": "S3-relative path, e.g. \"uploads/data.csv\""
+                        "description": "Path where the file will be stored in the workspace, e.g. \"uploads/data.csv\"."
                     }
                 },
                 "type": "object",
@@ -2430,11 +2444,13 @@
                             "$ref": "#/components/schemas/MessageResponse"
                         },
                         "type": "array",
-                        "title": "Messages"
+                        "title": "Messages",
+                        "description": "List of messages in chronological order."
                     },
                     "hasMore": {
                         "type": "boolean",
-                        "title": "Hasmore"
+                        "title": "Hasmore",
+                        "description": "Whether there are more messages available beyond this page. Use cursor-based pagination with the `after` or `before` query parameters to fetch more."
                     }
                 },
                 "type": "object",
@@ -2449,31 +2465,35 @@
                     "id": {
                         "type": "string",
                         "format": "uuid",
-                        "title": "Id"
+                        "title": "Id",
+                        "description": "Unique message identifier."
                     },
                     "sessionId": {
                         "type": "string",
                         "format": "uuid",
-                        "title": "Sessionid"
+                        "title": "Sessionid",
+                        "description": "ID of the session this message belongs to."
                     },
                     "role": {
                         "type": "string",
-                        "title": "Role"
+                        "title": "Role",
+                        "description": "Message role: \"human\" for user-submitted tasks, \"ai\" for agent actions and responses."
                     },
                     "data": {
                         "type": "string",
-                        "title": "Data"
+                        "title": "Data",
+                        "description": "Raw message content. Format depends on the message type \u2014 may be plain text, JSON, or structured action data."
                     },
                     "type": {
                         "type": "string",
                         "title": "Type",
-                        "description": "Coarse category: user_message, assistant_message, browser_action, file_operation, code_execution, integration, planning, completion, browser_action_result, browser_action_error, etc.",
+                        "description": "Message category. Common values: `user_message`, `assistant_message`, `browser_action`, `file_operation`, `code_execution`, `integration`, `planning`, `completion`, `browser_action_result`, `browser_action_error`.",
                         "default": ""
                     },
                     "summary": {
                         "type": "string",
                         "title": "Summary",
-                        "description": "One-liner human-readable description of the message (e.g. \"Navigating to google.com\", \"Clicking element #5\").",
+                        "description": "One-liner human-readable description of the message (e.g. \"Navigating to google.com\", \"Clicking element #5\"). Useful for building activity feeds.",
                         "default": ""
                     },
                     "screenshotUrl": {
@@ -2485,12 +2505,14 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Screenshoturl"
+                        "title": "Screenshoturl",
+                        "description": "Browser screenshot captured at the time of this message. Presigned URL, expires after 5 minutes."
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "title": "Createdat"
+                        "title": "Createdat",
+                        "description": "When this message was created."
                     }
                 },
                 "type": "object",
@@ -2501,7 +2523,8 @@
                     "data",
                     "createdAt"
                 ],
-                "title": "MessageResponse"
+                "title": "MessageResponse",
+                "description": "A single message from the session message stream.\n\nMessages represent the agent actions, observations, and decisions as it executes a task."
             },
             "PlanInfo": {
                 "properties": {
@@ -3030,11 +3053,13 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Task"
+                        "title": "Task",
+                        "description": "The natural-language instruction for the agent to execute (e.g. \"Go to amazon.com and find the best-rated wireless mouse under $50\"). Required when dispatching to an existing session."
                     },
                     "model": {
                         "$ref": "#/components/schemas/BuModel",
-                        "default": "bu-mini"
+                        "default": "bu-mini",
+                        "description": "The model tier to use. `bu-mini` is fast and cheap, `bu-max` is balanced, `bu-ultra` is most capable. See BuModel for details."
                     },
                     "sessionId": {
                         "anyOf": [
@@ -3046,12 +3071,14 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Sessionid"
+                        "title": "Sessionid",
+                        "description": "ID of an existing idle session to dispatch the task to. If omitted, a new session is created."
                     },
                     "keepAlive": {
                         "type": "boolean",
                         "title": "Keepalive",
-                        "default": false
+                        "default": false,
+                        "description": "If true, the session stays alive in idle state after the task completes instead of automatically stopping. This lets you dispatch follow-up tasks to the same session, preserving browser state and files."
                     },
                     "maxCostUsd": {
                         "anyOf": [
@@ -3079,7 +3106,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Profileid"
+                        "title": "Profileid",
+                        "description": "ID of a browser profile to load into the session. Profiles persist cookies, local storage, and other browser state across sessions. Create profiles via the Profiles API."
                     },
                     "workspaceId": {
                         "anyOf": [
@@ -3091,7 +3119,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Workspaceid"
+                        "title": "Workspaceid",
+                        "description": "ID of a workspace to attach to the session. Workspaces provide persistent file storage that carries across sessions. Create workspaces via the Workspaces API."
                     },
                     "proxyCountryCode": {
                         "anyOf": [
@@ -3102,7 +3131,8 @@
                                 "type": "null"
                             }
                         ],
-                        "default": "us"
+                        "default": "us",
+                        "description": "Country code for the browser proxy (e.g. \"us\", \"de\", \"jp\"). Set to null to disable the proxy. The proxy routes browser traffic through the specified country, useful for accessing geo-restricted content."
                     },
                     "outputSchema": {
                         "anyOf": [
@@ -3114,33 +3144,37 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Outputschema"
+                        "title": "Outputschema",
+                        "description": "A JSON Schema that the agent final output must conform to. When set, the agent will return structured data matching this schema in the `output` field of the response."
                     },
                     "enableScheduledTasks": {
                         "type": "boolean",
                         "title": "Enablescheduledtasks",
                         "default": false,
-                        "description": "If true, enables the agent to schedule follow-up tasks (e.g. \"check this page again in 1 hour\"). Most useful with `keepAlive=true` so the session stays alive to execute scheduled tasks."
+                        "description": "If true, the agent can create scheduled tasks that run on a recurring basis (e.g. \"every Monday morning, check my inbox and summarize new emails\"). Scheduled tasks are tied to your project and persist beyond the session. Note: all scheduled tasks are visible project-wide, so avoid enabling this in multi-user setups where task isolation is needed."
                     },
                     "enableRecording": {
                         "type": "boolean",
                         "title": "Enablerecording",
-                        "default": false
+                        "default": false,
+                        "description": "If true, records a video of the browser session. The recording URLs will be available in the `recordingUrls` field of the session response after the task completes."
                     },
                     "skills": {
                         "type": "boolean",
                         "title": "Skills",
-                        "default": true
+                        "default": true,
+                        "description": "If true, enables built-in agent skills like Google Sheets integration and file management. Set to false to restrict the agent to browser-only actions."
                     },
                     "agentmail": {
                         "type": "boolean",
                         "title": "Agentmail",
-                        "default": true
+                        "default": true,
+                        "description": "If true, provisions a temporary email inbox (via AgentMail) for the session. The email address is available in the `agentmailEmail` field of the session response. Useful for tasks that require email verification or sign-ups."
                     }
                 },
                 "type": "object",
                 "title": "RunTaskRequest",
-                "description": "Unified request for creating a session or dispatching a task.\n\n- Without session_id + without task: creates a new idle session (for file uploads, etc.)\n- Without session_id + with task: creates a new session and dispatches the task\n- With session_id + with task: dispatches the task to an existing idle session\n- With session_id + without task: 422 (task required when dispatching to existing session)"
+                "description": "Create a new session, dispatch a task, or both.\n\n- **No `sessionId` + no `task`**: creates an idle session (useful for uploading files before running a task).\n- **No `sessionId` + `task`**: creates a new session and immediately runs the task.\n- **`sessionId` + `task`**: dispatches the task to an existing idle session.\n- **`sessionId` + no `task`**: returns 422 \u2014 a task is required when targeting an existing session."
             },
             "SessionListResponse": {
                 "properties": {
@@ -3149,19 +3183,23 @@
                             "$ref": "#/components/schemas/SessionResponse"
                         },
                         "type": "array",
-                        "title": "Sessions"
+                        "title": "Sessions",
+                        "description": "List of sessions."
                     },
                     "total": {
                         "type": "integer",
-                        "title": "Total"
+                        "title": "Total",
+                        "description": "Total number of sessions matching the query."
                     },
                     "page": {
                         "type": "integer",
-                        "title": "Page"
+                        "title": "Page",
+                        "description": "Current page number (1-indexed)."
                     },
                     "pageSize": {
                         "type": "integer",
-                        "title": "Pagesize"
+                        "title": "Pagesize",
+                        "description": "Number of sessions per page."
                     }
                 },
                 "type": "object",
@@ -3190,13 +3228,16 @@
                     "id": {
                         "type": "string",
                         "format": "uuid",
-                        "title": "Id"
+                        "title": "Id",
+                        "description": "Unique session identifier."
                     },
                     "status": {
-                        "$ref": "#/components/schemas/BuAgentSessionStatus"
+                        "$ref": "#/components/schemas/BuAgentSessionStatus",
+                        "description": "Current session lifecycle status. Progresses through: `created` (sandbox starting) -> `idle` (ready, waiting for task) -> `running` (task executing) -> `stopped` / `timed_out` / `error`. Poll this field to track progress."
                     },
                     "model": {
-                        "$ref": "#/components/schemas/BuModel"
+                        "$ref": "#/components/schemas/BuModel",
+                        "description": "The model tier used for this session."
                     },
                     "title": {
                         "anyOf": [
@@ -3207,7 +3248,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Title"
+                        "title": "Title",
+                        "description": "Auto-generated short title summarizing the task. Available after the task starts running."
                     },
                     "output": {
                         "anyOf": [
@@ -3229,12 +3271,14 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Outputschema"
+                        "title": "Outputschema",
+                        "description": "The JSON Schema that was requested for structured output, if any."
                     },
                     "stepCount": {
                         "type": "integer",
                         "title": "Stepcount",
-                        "default": 0
+                        "default": 0,
+                        "description": "Number of steps the agent has executed so far."
                     },
                     "lastStepSummary": {
                         "anyOf": [
@@ -3245,7 +3289,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Laststepsummary"
+                        "title": "Laststepsummary",
+                        "description": "Human-readable summary of the most recent agent step (e.g. \"Clicking the Submit button\"). Useful for showing real-time progress."
                     },
                     "isTaskSuccessful": {
                         "anyOf": [
@@ -3256,7 +3301,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Istasksuccessful"
+                        "title": "Istasksuccessful",
+                        "description": "Whether the task completed successfully. `true` if the agent achieved the goal, `false` if it failed or gave up, `null` if the task is still running or no task was dispatched."
                     },
                     "liveUrl": {
                         "anyOf": [
@@ -3267,7 +3313,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Liveurl"
+                        "title": "Liveurl",
+                        "description": "URL to view the live browser session. Available immediately on session creation \u2014 can be embedded in an iframe to show the browser in real time."
                     },
                     "recordingUrls": {
                         "items": {
@@ -3275,7 +3322,8 @@
                         },
                         "type": "array",
                         "title": "Recordingurls",
-                        "default": []
+                        "default": [],
+                        "description": "URLs to download session recordings. Only populated if `enableRecording` was set to true and the task has completed."
                     },
                     "profileId": {
                         "anyOf": [
@@ -3287,7 +3335,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Profileid"
+                        "title": "Profileid",
+                        "description": "ID of the browser profile loaded in this session, if any."
                     },
                     "workspaceId": {
                         "anyOf": [
@@ -3299,7 +3348,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Workspaceid"
+                        "title": "Workspaceid",
+                        "description": "ID of the workspace attached to this session, if any."
                     },
                     "proxyCountryCode": {
                         "anyOf": [
@@ -3309,7 +3359,8 @@
                             {
                                 "type": "null"
                             }
-                        ]
+                        ],
+                        "description": "Country code of the proxy used for this session, or null if no proxy."
                     },
                     "maxCostUsd": {
                         "anyOf": [
@@ -3321,47 +3372,55 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Maxcostusd"
+                        "title": "Maxcostusd",
+                        "description": "Maximum cost limit in USD set for this session."
                     },
                     "totalInputTokens": {
                         "type": "integer",
                         "title": "Totalinputtokens",
-                        "default": 0
+                        "default": 0,
+                        "description": "Total LLM input tokens consumed by this session."
                     },
                     "totalOutputTokens": {
                         "type": "integer",
                         "title": "Totaloutputtokens",
-                        "default": 0
+                        "default": 0,
+                        "description": "Total LLM output tokens consumed by this session."
                     },
                     "proxyUsedMb": {
                         "type": "string",
                         "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                         "title": "Proxyusedmb",
-                        "default": "0"
+                        "default": "0",
+                        "description": "Proxy bandwidth used in megabytes."
                     },
                     "llmCostUsd": {
                         "type": "string",
                         "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                         "title": "Llmcostusd",
-                        "default": "0"
+                        "default": "0",
+                        "description": "Cost of LLM usage in USD."
                     },
                     "proxyCostUsd": {
                         "type": "string",
                         "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                         "title": "Proxycostusd",
-                        "default": "0"
+                        "default": "0",
+                        "description": "Cost of proxy bandwidth in USD."
                     },
                     "browserCostUsd": {
                         "type": "string",
                         "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                         "title": "Browsercostusd",
-                        "default": "0"
+                        "default": "0",
+                        "description": "Cost of browser compute time in USD."
                     },
                     "totalCostUsd": {
                         "type": "string",
                         "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                         "title": "Totalcostusd",
-                        "default": "0"
+                        "default": "0",
+                        "description": "Total session cost in USD (LLM + proxy + browser)."
                     },
                     "screenshotUrl": {
                         "anyOf": [
@@ -3372,7 +3431,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Screenshoturl"
+                        "title": "Screenshoturl",
+                        "description": "URL of the latest browser screenshot. Presigned URL that expires after 5 minutes. A new URL is generated each time you fetch the session."
                     },
                     "agentmailEmail": {
                         "anyOf": [
@@ -3383,17 +3443,20 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Agentmailemail"
+                        "title": "Agentmailemail",
+                        "description": "Temporary email address provisioned for this session (via AgentMail). Only present if `agentmail` was enabled."
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "title": "Createdat"
+                        "title": "Createdat",
+                        "description": "When the session was created."
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "title": "Updatedat"
+                        "title": "Updatedat",
+                        "description": "When the session was last updated."
                     }
                 },
                 "type": "object",
@@ -3404,7 +3467,8 @@
                     "createdAt",
                     "updatedAt"
                 ],
-                "title": "SessionResponse"
+                "title": "SessionResponse",
+                "description": "Represents a session and its current state.\n\nPoll this endpoint to track task progress. The `status` field indicates the session lifecycle stage, and `output` contains the agent structured result once the task completes."
             },
             "SessionTimeoutLimitExceededError": {
                 "properties": {
@@ -3422,7 +3486,8 @@
                 "properties": {
                     "strategy": {
                         "$ref": "#/components/schemas/StopStrategy",
-                        "default": "session"
+                        "default": "session",
+                        "description": "How to stop the session. Use `task` to stop only the current task and keep the session alive, or `session` to destroy the sandbox entirely."
                     }
                 },
                 "type": "object",
@@ -3434,7 +3499,8 @@
                     "task",
                     "session"
                 ],
-                "title": "StopStrategy"
+                "title": "StopStrategy",
+                "description": "Strategy for stopping a session.\n\n- `task`: Stop the currently running task but keep the session alive in idle state. You can dispatch another task to the same session afterwards.\n- `session`: Stop the session entirely and destroy the sandbox. The session cannot be reused after this."
             },
             "TooManyConcurrentActiveSessionsError": {
                 "properties": {


### PR DESCRIPTION
## Summary
- Add `description` to every field in `RunTaskRequest`, `SessionResponse`, `MessageResponse`, `FileInfo`, and related schemas in the v3 OpenAPI spec
- Add enum-level descriptions to `BuModel` (model tiers), `BuAgentSessionStatus` (lifecycle states), and `StopStrategy`
- Add descriptions to query parameters (`page`, `page_size`, `limit`)

Previously every field in the v3 API reference showed with no description — users had zero context on what `keepAlive`, `outputSchema`, `skills`, `agentmail`, `isTaskSuccessful`, etc. do.

## Test plan
- [ ] Run `mintlify dev` locally and verify descriptions render on all v3 API reference pages
- [ ] Verify no field names, types, or defaults changed (description-only, no breaking changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds human-readable descriptions to all v3 OpenAPI schemas to make the API reference clear and self-explanatory. No types, defaults, or endpoints changed.

- **New Features**
  - Added field descriptions to `RunTaskRequest`, `SessionResponse`, `MessageResponse`, `FileInfo`, and list responses; clarified `output`, `enableScheduledTasks` (recurring tasks + project-wide visibility warning), `maxCostUsd`.
  - Added enum descriptions for `BuModel`, `BuAgentSessionStatus`, `StopStrategy`; clarified pagination params `page`, `page_size`, `limit`.

<sup>Written for commit d1c96d9c6a7784940de90bb1dfcaa039c760572e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

