### PR TITLE
Fix chat UI tutorial: remove optimistic insert

### DIFF
--- a/docs/cloud/tutorials/chat-ui.mdx
+++ b/docs/cloud/tutorials/chat-ui.mdx
@@ -93,14 +93,10 @@ useEffect(() => {
 
 ## 3. Follow-up tasks
 
-Follow-ups call the same `streamTask` function. Add an optimistic user message so it appears instantly:
+Follow-ups call the same `streamTask` function — the stream already includes the user message, so no optimistic insert is needed:
 
 ```typescript session-context.tsx
 const sendMessage = useCallback(async (task: string) => {
-  // Optimistic: show the user message immediately
-  setMessages((prev) => [...prev, { id: `opt-${Date.now()}`, role: "user", summary: task }]);
-
-  // Stream the agent's response
   await streamTask(task);
 }, [streamTask]);
 ```

--- a/docs/openapi/v3.json
+++ b/docs/openapi/v3.json
@@ -3066,7 +3066,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Maxcostusd"
+                        "title": "Maxcostusd",
+                        "description": "Maximum total cost in USD allowed for this session. The task will be stopped if this limit is reached. Defaults to $20 if omitted."
                     },
                     "profileId": {
                         "anyOf": [
@@ -3118,7 +3119,8 @@
                     "enableScheduledTasks": {
                         "type": "boolean",
                         "title": "Enablescheduledtasks",
-                        "default": false
+                        "default": false,
+                        "description": "If true, enables the agent to schedule follow-up tasks (e.g. \"check this page again in 1 hour\"). Most useful with `keepAlive=true` so the session stays alive to execute scheduled tasks."
                     },
                     "enableRecording": {
                         "type": "boolean",
@@ -3214,7 +3216,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Output"
+                        "title": "Output",
+                        "description": "The agent's final output. If `outputSchema` was provided, this will be structured data conforming to that schema. Otherwise it may be a free-form string or null. Populated once the task completes, regardless of whether `isTaskSuccessful` is true or false."
                     },
                     "outputSchema": {
                         "anyOf": [


### PR DESCRIPTION
Follow-up to #74. The `client.run()` stream already includes the user message, so the optimistic insert in the docs was wrong (would cause duplicates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the optimistic user message insert from the chat UI tutorial for follow-ups; the `streamTask`/`client.run()` stream already includes the user message, preventing duplicates. Also clarified OpenAPI docs for `maxCostUsd` (default $20 and hard limit), `enableScheduledTasks` (what it does and that it’s best with `keepAlive=true`), and `output` (final value semantics and relation to `outputSchema`).

<sup>Written for commit cd72f2c9855a98ffbd4fa5b1f383b544141e8668. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

