### PR TITLE
Fix PR #77 review: status enum, terminal states, llms grouping

### DIFF
--- a/docs/cloud/agent/streaming.mdx
+++ b/docs/cloud/agent/streaming.mdx
@@ -65,7 +65,7 @@ while True:
         cursor = m.id
 
     s = await client.sessions.get(session.id)
-    if s.status in ("idle", "stopped", "error", "timed_out"):
+    if s.status.value in ("idle", "stopped", "error", "timed_out"):
         break
     await asyncio.sleep(2)
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -40,17 +40,6 @@ const client = new BrowserUse();
 const result = await client.run("List the top 20 posts on Hacker News today with their points");
 console.log(result.output);
 ```
-```bash curl
-# Create a session
-curl -X POST https://api.browser-use.com/api/v3/sessions \
-  -H "Authorization: Bearer YOUR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"task": "List the top 20 posts on Hacker News today with their points"}'
-
-# Poll for result (replace SESSION_ID from the response above)
-curl https://api.browser-use.com/api/v3/sessions/SESSION_ID \
-  -H "Authorization: Bearer YOUR_API_KEY"
-```
 
   Want a full working app? See the [Chat UI example](https://docs.browser-use.com/cloud/tutorials/chat-ui) — a complete Next.js app with live browser preview, streaming messages, authentication, and session management.
 
@@ -259,7 +248,7 @@ while True:
         cursor = m.id
 
     s = await client.sessions.get(session.id)
-    if s.status in ("idle", "stopped", "error", "timed_out"):
+    if s.status.value in ("idle", "stopped", "error", "timed_out"):
         break
     await asyncio.sleep(2)
 
@@ -1333,7 +1322,7 @@ Add a second **HTTP Request** node in a loop:
 | URL | `https://api.browser-use.com/api/v3/sessions/{{ $json.id }}` |
 | Authentication | Header Auth (from step 1) |
 
-Check the `status` field. The session is done when status is `finished` or `stopped`. Use an **If** node to loop back with a **Wait** node (5–10 seconds) until complete.
+Check the `status` field. The session is done when status is `idle`, `stopped`, `error`, or `timed_out`. Use an **If** node to loop back with a **Wait** node (5–10 seconds) until complete.
 
 The final response contains `output` with the agent's result.
 
@@ -1440,14 +1429,10 @@ useEffect(() => {
 
 ## 3. Follow-up tasks
 
-Follow-ups call the same `streamTask` function. Add an optimistic user message so it appears instantly:
+Follow-ups call the same `streamTask` function — the stream already includes the user message, so no optimistic insert is needed:
 
 ```typescript session-context.tsx
 const sendMessage = useCallback(async (task: string) => {
-  // Optimistic: show the user message immediately
-  setMessages((prev) => [...prev, { id: `opt-${Date.now()}`, role: "user", summary: task }]);
-
-  // Stream the agent's response
   await streamTask(task);
 }, [streamTask]);
 ```

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -62,6 +62,10 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 - [Skills](https://docs.browser-use.com/cloud/legacy/skills): Turn any website into a deterministic API endpoint. Create once, call repeatedly.
 - [1Password & 2FA](https://docs.browser-use.com/cloud/guides/1password): Auto-fill passwords and TOTP codes from 1Password during agent tasks.
 - [Secrets](https://docs.browser-use.com/cloud/guides/secrets): Pass domain-scoped credentials to the agent securely.
+
+## API v3
 - [API Reference](https://docs.browser-use.com/cloud/api-reference): Authenticate and start using the Browser Use REST API.
+
+## API v2
 - [API key](https://docs.browser-use.com/cloud/api-v2-overview): Set your API key to access the Browser Use v2 REST API.
 

--- a/docs/cloud/tutorials/integrations/n8n.mdx
+++ b/docs/cloud/tutorials/integrations/n8n.mdx
@@ -46,7 +46,7 @@ Add a second **HTTP Request** node in a loop:
 | URL | `https://api.browser-use.com/api/v3/sessions/{{ $json.id }}` |
 | Authentication | Header Auth (from step 1) |
 
-Check the `status` field. The session is done when status is `finished` or `stopped`. Use an **If** node to loop back with a **Wait** node (5–10 seconds) until complete.
+Check the `status` field. The session is done when status is `idle`, `stopped`, `error`, or `timed_out`. Use an **If** node to loop back with a **Wait** node (5–10 seconds) until complete.
 
 The final response contains `output` with the agent's result.
 

--- a/docs/generate-llms-txt.sh
+++ b/docs/generate-llms-txt.sh
@@ -111,6 +111,11 @@ for product_nav in d['navigation']['products']:
         if 'tabs' in product_nav:
             for tab in product_nav['tabs']:
                 if isinstance(tab, dict):
+                    tab_name = tab.get('tab', '')
+                    # Emit tab header for non-primary tabs to separate API sections
+                    if tab_name and tab_name != product_nav['tabs'][0].get('tab', ''):
+                        lines.append(f'')
+                        lines.append(f'## {tab_name}')
                     for g in tab.get('groups', []):
                         lines.extend(process_group(g))
         if 'groups' in product_nav:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -40,17 +40,6 @@ const client = new BrowserUse();
 const result = await client.run("List the top 20 posts on Hacker News today with their points");
 console.log(result.output);
 ```
-```bash curl
-# Create a session
-curl -X POST https://api.browser-use.com/api/v3/sessions \
-  -H "Authorization: Bearer YOUR_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"task": "List the top 20 posts on Hacker News today with their points"}'
-
-# Poll for result (replace SESSION_ID from the response above)
-curl https://api.browser-use.com/api/v3/sessions/SESSION_ID \
-  -H "Authorization: Bearer YOUR_API_KEY"
-```
 
   Want a full working app? See the [Chat UI example](https://docs.browser-use.com/cloud/tutorials/chat-ui) — a complete Next.js app with live browser preview, streaming messages, authentication, and session management.
 
@@ -259,7 +248,7 @@ while True:
         cursor = m.id
 
     s = await client.sessions.get(session.id)
-    if s.status in ("idle", "stopped", "error", "timed_out"):
+    if s.status.value in ("idle", "stopped", "error", "timed_out"):
         break
     await asyncio.sleep(2)
 
@@ -1333,7 +1322,7 @@ Add a second **HTTP Request** node in a loop:
 | URL | `https://api.browser-use.com/api/v3/sessions/{{ $json.id }}` |
 | Authentication | Header Auth (from step 1) |
 
-Check the `status` field. The session is done when status is `finished` or `stopped`. Use an **If** node to loop back with a **Wait** node (5–10 seconds) until complete.
+Check the `status` field. The session is done when status is `idle`, `stopped`, `error`, or `timed_out`. Use an **If** node to loop back with a **Wait** node (5–10 seconds) until complete.
 
 The final response contains `output` with the agent's result.
 
@@ -1440,14 +1429,10 @@ useEffect(() => {
 
 ## 3. Follow-up tasks
 
-Follow-ups call the same `streamTask` function. Add an optimistic user message so it appears instantly:
+Follow-ups call the same `streamTask` function — the stream already includes the user message, so no optimistic insert is needed:
 
 ```typescript session-context.tsx
 const sendMessage = useCallback(async (task: string) => {
-  // Optimistic: show the user message immediately
-  setMessages((prev) => [...prev, { id: `opt-${Date.now()}`, role: "user", summary: task }]);
-
-  // Stream the agent's response
   await streamTask(task);
 }, [streamTask]);
 ```

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -62,6 +62,10 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 - [Skills](https://docs.browser-use.com/cloud/legacy/skills): Turn any website into a deterministic API endpoint. Create once, call repeatedly.
 - [1Password & 2FA](https://docs.browser-use.com/cloud/guides/1password): Auto-fill passwords and TOTP codes from 1Password during agent tasks.
 - [Secrets](https://docs.browser-use.com/cloud/guides/secrets): Pass domain-scoped credentials to the agent securely.
+
+## API v3
 - [API Reference](https://docs.browser-use.com/cloud/api-reference): Authenticate and start using the Browser Use REST API.
+
+## API v2
 - [API key](https://docs.browser-use.com/cloud/api-v2-overview): Set your API key to access the Browser Use v2 REST API.
 


### PR DESCRIPTION
## Summary
Addresses review comments from #77:

- **P1: `s.status` vs `s.status.value`** — Python SDK session status is an enum. Fixed polling example in `streaming.mdx` to use `s.status.value`
- **P2: `finished` not a valid v3 status** — Fixed `n8n.mdx` to list correct terminal statuses: `idle`, `stopped`, `error`, `timed_out`
- **P2: API Reference under Legacy (v2) in llms.txt** — Fixed generation script to emit tab headers, so API Reference now appears under its own "API v3" section
- **Not a bug: `$json.id`** — v3 API returns `id` (not `session_id`), so the n8n template was already correct

Regenerated all llms.txt and llms-full.txt files.

## Test plan
- [ ] Verify `llms.txt` has API Reference under "API v3", not "Legacy (v2)"
- [ ] Verify `llms-full.txt` uses `s.status.value` in Python polling example
- [ ] Verify n8n.mdx lists correct terminal statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes doc issues raised in #77: correct Python polling to use the enum value, update terminal statuses, and group the API Reference under an "API v3" section in generated `llms*.txt`.

- **Bug Fixes**
  - Python: use `s.status.value` in polling examples (`streaming.mdx`, `llms-full.txt`).
  - n8n: terminal statuses now `idle`, `stopped`, `error`, `timed_out` (no `finished`).
  - Docs generator: update `docs/generate-llms-txt.sh` to emit tab headers so API Reference appears under "API v3"; regenerated `llms.txt` and `llms-full.txt`.

<sup>Written for commit ad58296bee34335b2e1608f9db62f01adcfe37dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

