### PR TITLE
Move public share links from live-preview docs to legacy (v2)

### DIFF
--- a/docs/cloud/browser/live-preview.mdx
+++ b/docs/cloud/browser/live-preview.mdx
@@ -96,17 +96,3 @@ for (const url of urls) {
   Recording URLs are presigned and **expire after 1 hour**. Download or serve the recording promptly. If you need to access it later, save the MP4 to your own storage.
 </Warning>
 
-## Public share links
-
-Generate a public URL that anyone can open to watch the entire agent session — no API key needed. Useful for sharing with teammates, stakeholders, or embedding in dashboards.
-
-<CodeGroup>
-```python Python
-share = await client.sessions.create_share(session.id)
-print(share.url)
-```
-```typescript TypeScript
-const share = await client.sessions.createShare(session.id);
-console.log(share.url);
-```
-</CodeGroup>

--- a/docs/cloud/legacy/public-share.mdx
+++ b/docs/cloud/legacy/public-share.mdx
@@ -1,0 +1,18 @@
+---
+title: "Public share links (v2)"
+description: "Generate shareable URLs for agent sessions using the v2 API."
+icon: share-nodes
+---
+
+Generate a public URL that anyone can open to watch the entire agent session — no API key needed. Useful for sharing with teammates, stakeholders, or embedding in dashboards.
+
+<CodeGroup>
+```python Python
+share = await client.sessions.create_share(session.id)
+print(share.url)
+```
+```typescript TypeScript
+const share = await client.sessions.createShare(session.id);
+console.log(share.url);
+```
+</CodeGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -119,6 +119,7 @@
                     "isDefaultOpen": false,
                     "pages": [
                       "cloud/legacy/agent",
+                      "cloud/legacy/public-share",
                       "cloud/legacy/skills",
                       "cloud/guides/1password",
                       "cloud/guides/secrets"


### PR DESCRIPTION
The create_share/createShare methods only exist in the v2 API. Remove the section from the main live-preview page and add a dedicated legacy page so existing users can still find the docs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved public share link docs to the legacy (v2) section because the public share APIs only exist in v2. Removed the section from the live-preview page, added a dedicated v2 page with Python/TypeScript examples, and updated the docs nav so users can still find it.

<sup>Written for commit ae252748ea796e5cee17f78a6164b1b217d7824b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

