### PR TITLE
Remove hCaptcha, DataDome, CAPTCHA solving, and CDP note from stealth docs

### DIFF
--- a/docs/cloud/browser/stealth.mdx
+++ b/docs/cloud/browser/stealth.mdx
@@ -11,7 +11,6 @@ See [how we perform in the hardest stealth benchmark](https://browser-use.com/po
 Every cloud browser session runs in a hardened Chromium fork with stealth enabled by default — no configuration needed.
 
 - **Anti-detect browser fingerprinting** — Canvas, WebGL, fonts, navigator, and other browser fingerprints are randomized per session to appear as a real user. Passes CreepJS, BrowserLeaks, and other fingerprint detectors.
-- **Automatic CAPTCHA solving** — reCAPTCHA and Cloudflare Turnstile are solved transparently. The agent does not need to take any action.
 - **Ad and cookie banner blocking** — Banners are dismissed automatically so the agent sees clean pages and executes faster.
 - **Cloudflare / anti-bot bypass** — Works on sites protected by Cloudflare, PerimeterX, and other bot detection services.
 

--- a/docs/cloud/browser/stealth.mdx
+++ b/docs/cloud/browser/stealth.mdx
@@ -11,9 +11,9 @@ See [how we perform in the hardest stealth benchmark](https://browser-use.com/po
 Every cloud browser session runs in a hardened Chromium fork with stealth enabled by default — no configuration needed.
 
 - **Anti-detect browser fingerprinting** — Canvas, WebGL, fonts, navigator, and other browser fingerprints are randomized per session to appear as a real user. Passes CreepJS, BrowserLeaks, and other fingerprint detectors.
-- **Automatic CAPTCHA solving** — reCAPTCHA, hCaptcha, and Cloudflare Turnstile are solved transparently. The agent does not need to take any action.
+- **Automatic CAPTCHA solving** — reCAPTCHA and Cloudflare Turnstile are solved transparently. The agent does not need to take any action.
 - **Ad and cookie banner blocking** — Banners are dismissed automatically so the agent sees clean pages and executes faster.
-- **Cloudflare / anti-bot bypass** — Works on sites protected by Cloudflare, DataDome, PerimeterX, and other bot detection services.
+- **Cloudflare / anti-bot bypass** — Works on sites protected by Cloudflare, PerimeterX, and other bot detection services.
 
 ## Residential proxies
 
@@ -22,7 +22,3 @@ Residential proxies are enabled by default across 195+ countries. This makes bro
 ## No setup required
 
 Stealth is always on — every `client.run()` call and every session created via the API uses the hardened browser automatically. There are no flags to enable or parameters to set.
-
-<Note>
-  Need to connect your own automation framework? See [Playwright, Puppeteer, Selenium](/cloud/browser/playwright-puppeteer-selenium) to use Browser Use's stealth infrastructure via CDP.
-</Note>

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -509,7 +509,6 @@ See [how we perform in the hardest stealth benchmark](https://browser-use.com/po
 Every cloud browser session runs in a hardened Chromium fork with stealth enabled by default — no configuration needed.
 
 - **Anti-detect browser fingerprinting** — Canvas, WebGL, fonts, navigator, and other browser fingerprints are randomized per session to appear as a real user. Passes CreepJS, BrowserLeaks, and other fingerprint detectors.
-- **Automatic CAPTCHA solving** — reCAPTCHA and Cloudflare Turnstile are solved transparently. The agent does not need to take any action.
 - **Ad and cookie banner blocking** — Banners are dismissed automatically so the agent sees clean pages and executes faster.
 - **Cloudflare / anti-bot bypass** — Works on sites protected by Cloudflare, PerimeterX, and other bot detection services.
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -509,9 +509,9 @@ See [how we perform in the hardest stealth benchmark](https://browser-use.com/po
 Every cloud browser session runs in a hardened Chromium fork with stealth enabled by default — no configuration needed.
 
 - **Anti-detect browser fingerprinting** — Canvas, WebGL, fonts, navigator, and other browser fingerprints are randomized per session to appear as a real user. Passes CreepJS, BrowserLeaks, and other fingerprint detectors.
-- **Automatic CAPTCHA solving** — reCAPTCHA, hCaptcha, and Cloudflare Turnstile are solved transparently. The agent does not need to take any action.
+- **Automatic CAPTCHA solving** — reCAPTCHA and Cloudflare Turnstile are solved transparently. The agent does not need to take any action.
 - **Ad and cookie banner blocking** — Banners are dismissed automatically so the agent sees clean pages and executes faster.
-- **Cloudflare / anti-bot bypass** — Works on sites protected by Cloudflare, DataDome, PerimeterX, and other bot detection services.
+- **Cloudflare / anti-bot bypass** — Works on sites protected by Cloudflare, PerimeterX, and other bot detection services.
 
 ## Residential proxies
 
@@ -520,8 +520,6 @@ Residential proxies are enabled by default across 195+ countries. This makes bro
 ## No setup required
 
 Stealth is always on — every `client.run()` call and every session created via the API uses the hardened browser automatically. There are no flags to enable or parameters to set.
-
-  Need to connect your own automation framework? See [Playwright, Puppeteer, Selenium](https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium) to use Browser Use's stealth infrastructure via CDP.
 
 
 # Proxies

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -509,7 +509,6 @@ See [how we perform in the hardest stealth benchmark](https://browser-use.com/po
 Every cloud browser session runs in a hardened Chromium fork with stealth enabled by default — no configuration needed.
 
 - **Anti-detect browser fingerprinting** — Canvas, WebGL, fonts, navigator, and other browser fingerprints are randomized per session to appear as a real user. Passes CreepJS, BrowserLeaks, and other fingerprint detectors.
-- **Automatic CAPTCHA solving** — reCAPTCHA and Cloudflare Turnstile are solved transparently. The agent does not need to take any action.
 - **Ad and cookie banner blocking** — Banners are dismissed automatically so the agent sees clean pages and executes faster.
 - **Cloudflare / anti-bot bypass** — Works on sites protected by Cloudflare, PerimeterX, and other bot detection services.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -509,9 +509,9 @@ See [how we perform in the hardest stealth benchmark](https://browser-use.com/po
 Every cloud browser session runs in a hardened Chromium fork with stealth enabled by default — no configuration needed.
 
 - **Anti-detect browser fingerprinting** — Canvas, WebGL, fonts, navigator, and other browser fingerprints are randomized per session to appear as a real user. Passes CreepJS, BrowserLeaks, and other fingerprint detectors.
-- **Automatic CAPTCHA solving** — reCAPTCHA, hCaptcha, and Cloudflare Turnstile are solved transparently. The agent does not need to take any action.
+- **Automatic CAPTCHA solving** — reCAPTCHA and Cloudflare Turnstile are solved transparently. The agent does not need to take any action.
 - **Ad and cookie banner blocking** — Banners are dismissed automatically so the agent sees clean pages and executes faster.
-- **Cloudflare / anti-bot bypass** — Works on sites protected by Cloudflare, DataDome, PerimeterX, and other bot detection services.
+- **Cloudflare / anti-bot bypass** — Works on sites protected by Cloudflare, PerimeterX, and other bot detection services.
 
 ## Residential proxies
 
@@ -520,8 +520,6 @@ Residential proxies are enabled by default across 195+ countries. This makes bro
 ## No setup required
 
 Stealth is always on — every `client.run()` call and every session created via the API uses the hardened browser automatically. There are no flags to enable or parameters to set.
-
-  Need to connect your own automation framework? See [Playwright, Puppeteer, Selenium](https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium) to use Browser Use's stealth infrastructure via CDP.
 
 
 # Proxies


### PR DESCRIPTION
## Summary
- Remove hCaptcha and DataDome mentions from stealth docs
- Remove the entire CAPTCHA solving bullet point
- Remove the Playwright/Puppeteer/Selenium CDP note

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unsupported claims from stealth docs by deleting hCaptcha/DataDome mentions, the automatic CAPTCHA solving line, and the Playwright/Puppeteer/Selenium CDP note. This clarifies current capabilities.

- **Refactors**
  - Removed the CAPTCHA solving bullet (reCAPTCHA, hCaptcha, Turnstile).
  - Updated the anti-bot line to drop DataDome.
  - Deleted the CDP note linking to Playwright/Puppeteer/Selenium.

<sup>Written for commit 49425d651060214304ee1755b825aec6f2be805e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

