### PR TITLE
Fix docs audit issues: redirect bug, enable_recording param, llms.txt…

### DIFF
--- a/browser-use-python/src/browser_use_sdk/v3/client.py
+++ b/browser-use-python/src/browser_use_sdk/v3/client.py
@@ -54,6 +54,7 @@ class BrowserUse:
         profile_id: str | None = ...,
         proxy_country_code: str | None = ...,
         workspace_id: str | None = ...,
+        enable_recording: bool | None = ...,
         **extra: Any,
     ) -> SessionResult[T]: ...
 
@@ -70,6 +71,7 @@ class BrowserUse:
         profile_id: str | None = ...,
         proxy_country_code: str | None = ...,
         workspace_id: str | None = ...,
+        enable_recording: bool | None = ...,
         **extra: Any,
     ) -> SessionResult[T]: ...
 
@@ -85,6 +87,7 @@ class BrowserUse:
         profile_id: str | None = ...,
         proxy_country_code: str | None = ...,
         workspace_id: str | None = ...,
+        enable_recording: bool | None = ...,
         **extra: Any,
     ) -> SessionResult[str]: ...
 
@@ -101,6 +104,7 @@ class BrowserUse:
         profile_id: str | None = None,
         proxy_country_code: str | None = None,
         workspace_id: str | None = None,
+        enable_recording: bool | None = None,
         **extra: Any,
     ) -> Any:
         """Run a task and block until complete. Returns a SessionResult."""
@@ -123,6 +127,7 @@ class BrowserUse:
             proxy_country_code=proxy_country_code,
             output_schema=schema_dict,
             workspace_id=workspace_id,
+            enable_recording=enable_recording,
             **extra,
         )
         return _poll_output(self.sessions, str(data.id), resolved_schema)
@@ -140,6 +145,7 @@ class BrowserUse:
         profile_id: str | None = None,
         proxy_country_code: str | None = None,
         workspace_id: str | None = None,
+        enable_recording: bool | None = None,
         **extra: Any,
     ) -> SessionStream[Any]:
         """Run a task and yield messages as they happen.
@@ -169,6 +175,7 @@ class BrowserUse:
             proxy_country_code=proxy_country_code,
             output_schema=schema_dict,
             workspace_id=workspace_id,
+            enable_recording=enable_recording,
             **extra,
         )
         return SessionStream(data, self.sessions, resolved_schema)
@@ -220,6 +227,7 @@ class AsyncBrowserUse:
         profile_id: str | None = ...,
         proxy_country_code: str | None = ...,
         workspace_id: str | None = ...,
+        enable_recording: bool | None = ...,
         **extra: Any,
     ) -> AsyncSessionRun[T]: ...
 
@@ -236,6 +244,7 @@ class AsyncBrowserUse:
         profile_id: str | None = ...,
         proxy_country_code: str | None = ...,
         workspace_id: str | None = ...,
+        enable_recording: bool | None = ...,
         **extra: Any,
     ) -> AsyncSessionRun[T]: ...
 
@@ -251,6 +260,7 @@ class AsyncBrowserUse:
         profile_id: str | None = ...,
         proxy_country_code: str | None = ...,
         workspace_id: str | None = ...,
+        enable_recording: bool | None = ...,
         **extra: Any,
     ) -> AsyncSessionRun[str]: ...
 
@@ -267,6 +277,7 @@ class AsyncBrowserUse:
         profile_id: str | None = None,
         proxy_country_code: str | None = None,
         workspace_id: str | None = None,
+        enable_recording: bool | None = None,
         **extra: Any,
     ) -> AsyncSessionRun[Any]:
         """Run a task. Await the result for a SessionResult."""
@@ -291,6 +302,7 @@ class AsyncBrowserUse:
                 proxy_country_code=proxy_country_code,
                 output_schema=schema_dict,
                 workspace_id=workspace_id,
+                enable_recording=enable_recording,
                 **extra,
             )
 

--- a/browser-use-python/src/browser_use_sdk/v3/resources/sessions.py
+++ b/browser-use-python/src/browser_use_sdk/v3/resources/sessions.py
@@ -36,6 +36,7 @@ class Sessions:
         output_schema: dict[str, Any] | None = None,
         workspace_id: str | None = None,
         enable_scheduled_tasks: bool | None = None,
+        enable_recording: bool | None = None,
         **extra: Any,
     ) -> SessionResponse:
         """Create a session and optionally dispatch a task."""
@@ -60,6 +61,8 @@ class Sessions:
             body["workspaceId"] = workspace_id
         if enable_scheduled_tasks is not None:
             body["enableScheduledTasks"] = enable_scheduled_tasks
+        if enable_recording is not None:
+            body["enableRecording"] = enable_recording
         body.update(extra)
         return SessionResponse.model_validate(
             self._http.request("POST", "/sessions", json=body)
@@ -207,6 +210,7 @@ class AsyncSessions:
         output_schema: dict[str, Any] | None = None,
         workspace_id: str | None = None,
         enable_scheduled_tasks: bool | None = None,
+        enable_recording: bool | None = None,
         **extra: Any,
     ) -> SessionResponse:
         """Create a session and optionally dispatch a task."""
@@ -231,6 +235,8 @@ class AsyncSessions:
             body["workspaceId"] = workspace_id
         if enable_scheduled_tasks is not None:
             body["enableScheduledTasks"] = enable_scheduled_tasks
+        if enable_recording is not None:
+            body["enableRecording"] = enable_recording
         body.update(extra)
         return SessionResponse.model_validate(
             await self._http.request("POST", "/sessions", json=body)

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -284,37 +284,23 @@ while (true) {
 Source: https://docs.browser-use.com/cloud/agent/workspaces
 
 
-Workspaces are the recommended way to handle all file operations — uploading input files and downloading results. Prefer workspaces over session-level file uploads.
+Workspaces give your agent persistent file storage. Two patterns cover almost every use case:
 
-See your workspace IDs at [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=workspaces).
+1. **You upload a file** → agent reads it
+2. **Agent creates a file** → you download it
 
 ## Upload a file
 
-Upload a file to a workspace, then tell the agent to use it.
-
 ```python Python
-import httpx
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 workspace = await client.workspaces.create(name="my-workspace")
 
-# Get a presigned upload URL
-upload = await client.workspaces.upload_files(
-    workspace.id,
-    files=[{"name": "people.csv", "contentType": "text/csv", "size": 45}],
-)
+# Upload
+await client.workspaces.upload(workspace.id, "people.csv")
 
-# Upload the file
-with open("people.csv", "rb") as f:
-    async with httpx.AsyncClient() as http:
-        await http.put(
-            upload.files[0].upload_url,
-            content=f.read(),
-            headers={"Content-Type": "text/csv", "Content-Length": "45"},
-        )
-
-# Tell the agent to use it
+# Agent can now read it
 result = await client.run(
     "Read people.csv and tell me who works at Google",
     workspace_id=workspace.id,
@@ -323,24 +309,14 @@ print(result.output)
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
-import { readFileSync } from "fs";
 
 const client = new BrowserUse();
 const workspace = await client.workspaces.create({ name: "my-workspace" });
 
-// Get a presigned upload URL
-const upload = await client.workspaces.uploadFiles(workspace.id, {
-  files: [{ name: "people.csv", contentType: "text/csv", size: 45 }],
-});
+// Upload
+await client.workspaces.upload(workspace.id, "people.csv");
 
-// Upload the file
-await fetch(upload.files[0].uploadUrl, {
-  method: "PUT",
-  headers: { "Content-Type": "text/csv", "Content-Length": "45" },
-  body: readFileSync("people.csv"),
-});
-
-// Tell the agent to use it
+// Agent can now read it
 const result = await client.run(
   "Read people.csv and tell me who works at Google",
   { workspaceId: workspace.id },
@@ -348,53 +324,56 @@ const result = await client.run(
 console.log(result.output);
 ```
 
-## Download files
-
-Run a task that saves files to a workspace, then download them.
+You can upload multiple files at once:
 
 ```python Python
-import httpx
+await client.workspaces.upload(workspace.id, "data.csv", "config.json", "image.png")
+```
+```typescript TypeScript
+await client.workspaces.upload(workspace.id, "data.csv", "config.json", "image.png");
+```
+
+## Download files
+
+```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 workspace = await client.workspaces.create(name="my-workspace")
 
-# Agent saves files to the workspace
+# Agent creates a file
 result = await client.run(
     "Go to Hacker News and save the top 3 posts as posts.json",
     workspace_id=workspace.id,
 )
 
-# List and download files
-files = await client.workspaces.files(workspace.id, include_urls=True)
-for f in files.files:
-    print(f"{f.path} ({f.size} bytes)")
+# Download a single file
+await client.workspaces.download(workspace.id, "posts.json", to="./posts.json")
 
-    async with httpx.AsyncClient() as http:
-        resp = await http.get(f.url)
-        with open(f.path, "wb") as out:
-            out.write(resp.content)
+# Or download everything
+paths = await client.workspaces.download_all(workspace.id, to="./output")
+for p in paths:
+    print(f"Downloaded: {p}")
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
-import { writeFileSync } from "fs";
 
 const client = new BrowserUse();
 const workspace = await client.workspaces.create({ name: "my-workspace" });
 
-// Agent saves files to the workspace
+// Agent creates a file
 const result = await client.run(
   "Go to Hacker News and save the top 3 posts as posts.json",
   { workspaceId: workspace.id },
 );
 
-// List and download files
-const files = await client.workspaces.files(workspace.id, { includeUrls: true });
-for (const f of files.files) {
-  console.log(`${f.path} (${f.size} bytes)`);
+// Download a single file
+await client.workspaces.download(workspace.id, "posts.json", { to: "./posts.json" });
 
-  const resp = await fetch(f.url);
-  writeFileSync(f.path, Buffer.from(await resp.arrayBuffer()));
+// Or download everything
+const paths = await client.workspaces.downloadAll(workspace.id, { to: "./output" });
+for (const p of paths) {
+  console.log(`Downloaded: ${p}`);
 }
 ```
 
@@ -412,6 +391,8 @@ const updated = await client.workspaces.update(workspaceId, { name: "renamed" })
 const workspaces = await client.workspaces.list();
 await client.workspaces.delete(workspaceId);
 ```
+
+You can also manage workspaces from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=workspaces).
 
   Deleting a workspace permanently removes all its files. This cannot be undone.
 
@@ -686,18 +667,111 @@ for (const url of urls) {
 
   Recording URLs are presigned and **expire after 1 hour**. Download or serve the recording promptly. If you need to access it later, save the MP4 to your own storage.
 
-## Public share links
 
-Generate a public URL that anyone can open to watch the entire agent session — no API key needed. Useful for sharing with teammates, stakeholders, or embedding in dashboards.
+
+# Playwright, Puppeteer, Selenium
+Source: https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium
+
+
+## Option 1: WebSocket URL (no SDK)
+
+Connect with a single URL. All configuration is passed as query parameters.
+
+### Playwright
 
 ```python Python
-share = await client.sessions.create_share(session.id)
-print(share.url)
+from playwright.async_api import async_playwright
+
+WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us"
+
+async with async_playwright() as p:
+    browser = await p.chromium.connect_over_cdp(WSS_URL)
+    page = browser.contexts[0].pages[0]
+    await page.goto("https://example.com")
+    print(await page.title())
+    await browser.close()
+# Browser is automatically stopped when the WebSocket disconnects
 ```
 ```typescript TypeScript
-const share = await client.sessions.createShare(session.id);
-console.log(share.url);
+import { chromium } from "playwright";
+
+const WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us";
+
+const browser = await chromium.connectOverCDP(WSS_URL);
+const page = browser.contexts()[0].pages()[0];
+await page.goto("https://example.com");
+console.log(await page.title());
+await browser.close();
+// Browser is automatically stopped when the WebSocket disconnects
 ```
+
+### Puppeteer
+
+```typescript
+import puppeteer from "puppeteer-core";
+
+const WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us";
+
+const browser = await puppeteer.connect({ browserWSEndpoint: WSS_URL });
+const [page] = await browser.pages();
+await page.goto("https://example.com");
+console.log(await page.title());
+await browser.close();
+```
+
+### Selenium
+
+```python
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+browser = await client.browsers.create()
+
+options = Options()
+options.debugger_address = browser.cdp_url.replace("ws://", "").replace("/devtools/browser/", "")
+driver = webdriver.Chrome(options=options)
+driver.get("https://example.com")
+print(driver.title)
+driver.quit()
+
+await client.browsers.stop(browser.id)
+```
+
+## Query parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `apiKey` | `string` | **Required.** Your Browser Use API key. |
+| `proxyCountryCode` | `string` | Proxy country code (e.g. `us`, `de`, `jp`). 195+ countries. |
+| `profileId` | `string` | Load a saved browser profile (cookies, localStorage). |
+| `timeout` | `int` | Session timeout in minutes. Max: 240 (4 hours). |
+| `browserScreenWidth` | `int` | Browser width in pixels. |
+| `browserScreenHeight` | `int` | Browser height in pixels. |
+
+## Option 2: SDK
+
+Create a browser via the SDK, get a `cdp_url`, connect with your framework.
+
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+browser = await client.browsers.create(proxy_country_code="us")
+print(browser.cdp_url)   # ws://...
+print(browser.live_url)  # debug view
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+
+const client = new BrowserUse();
+const browser = await client.browsers.create({ proxyCountryCode: "us" });
+console.log(browser.cdpUrl);
+console.log(browser.liveUrl);
+```
+
+  Always stop browser sessions when done. Sessions left running will continue to incur charges until the timeout expires.
 
 
 # Profiles
@@ -812,111 +886,6 @@ const result = await client.run("Check my LinkedIn messages", {
   sessionId: session.id,
 });
 ```
-
-
-# Playwright, Puppeteer, Selenium
-Source: https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium
-
-
-## Option 1: WebSocket URL (no SDK)
-
-Connect with a single URL. All configuration is passed as query parameters.
-
-### Playwright
-
-```python Python
-from playwright.async_api import async_playwright
-
-WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us"
-
-async with async_playwright() as p:
-    browser = await p.chromium.connect_over_cdp(WSS_URL)
-    page = browser.contexts[0].pages[0]
-    await page.goto("https://example.com")
-    print(await page.title())
-    await browser.close()
-# Browser is automatically stopped when the WebSocket disconnects
-```
-```typescript TypeScript
-import { chromium } from "playwright";
-
-const WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us";
-
-const browser = await chromium.connectOverCDP(WSS_URL);
-const page = browser.contexts()[0].pages()[0];
-await page.goto("https://example.com");
-console.log(await page.title());
-await browser.close();
-// Browser is automatically stopped when the WebSocket disconnects
-```
-
-### Puppeteer
-
-```typescript
-import puppeteer from "puppeteer-core";
-
-const WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us";
-
-const browser = await puppeteer.connect({ browserWSEndpoint: WSS_URL });
-const [page] = await browser.pages();
-await page.goto("https://example.com");
-console.log(await page.title());
-await browser.close();
-```
-
-### Selenium
-
-```python
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-from browser_use_sdk.v3 import AsyncBrowserUse
-
-client = AsyncBrowserUse()
-browser = await client.browsers.create()
-
-options = Options()
-options.debugger_address = browser.cdp_url.replace("ws://", "").replace("/devtools/browser/", "")
-driver = webdriver.Chrome(options=options)
-driver.get("https://example.com")
-print(driver.title)
-driver.quit()
-
-await client.browsers.stop(browser.id)
-```
-
-## Query parameters
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `apiKey` | `string` | **Required.** Your Browser Use API key. |
-| `proxyCountryCode` | `string` | Proxy country code (e.g. `us`, `de`, `jp`). 195+ countries. |
-| `profileId` | `string` | Load a saved browser profile (cookies, localStorage). |
-| `timeout` | `int` | Session timeout in minutes. Max: 240 (4 hours). |
-| `browserScreenWidth` | `int` | Browser width in pixels. |
-| `browserScreenHeight` | `int` | Browser height in pixels. |
-
-## Option 2: SDK
-
-Create a browser via the SDK, get a `cdp_url`, connect with your framework.
-
-```python Python
-from browser_use_sdk.v3 import AsyncBrowserUse
-
-client = AsyncBrowserUse()
-browser = await client.browsers.create(proxy_country_code="us")
-print(browser.cdp_url)   # ws://...
-print(browser.live_url)  # debug view
-```
-```typescript TypeScript
-import { BrowserUse } from "browser-use-sdk/v3";
-
-const client = new BrowserUse();
-const browser = await client.browsers.create({ proxyCountryCode: "us" });
-console.log(browser.cdpUrl);
-console.log(browser.liveUrl);
-```
-
-  Always stop browser sessions when done. Sessions left running will continue to incur charges until the timeout expires.
 
 
 # OpenClaw
@@ -1718,6 +1687,22 @@ console.log(run.result?.output);  // final result after iteration
 | `skill_ids` | `list[str]` | Skills the agent can use during the task. |
 | `op_vault_id` | `str` | 1Password vault ID for auto-fill credentials and 2FA. |
 | `metadata` | `dict[str, str]` | Custom metadata attached to the task. |
+
+
+# Public share links (v2)
+Source: https://docs.browser-use.com/cloud/legacy/public-share
+
+
+Generate a public URL that anyone can open to watch the entire agent session — no API key needed. Useful for sharing with teammates, stakeholders, or embedding in dashboards.
+
+```python Python
+share = await client.sessions.create_share(session.id)
+print(share.url)
+```
+```typescript TypeScript
+const share = await client.sessions.createShare(session.id);
+console.log(share.url);
+```
 
 
 # Skills

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -13,6 +13,8 @@
 - Agent benchmark (online Mind2Web): https://browser-use.com/posts/online-mind2web-benchmark
 - Blog: https://browser-use.com/posts
 
+**Use v3** (`from browser_use_sdk.v3 import AsyncBrowserUse` / `import { BrowserUse } from "browser-use-sdk/v3"`). v2 is legacy.
+
 Install (check if already installed and update to latest):
 - Python: `pip install --upgrade browser-use-sdk`
 - TypeScript: `npm install browser-use-sdk@latest`
@@ -32,20 +34,18 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 - [Structured output](https://docs.browser-use.com/cloud/agent/structured-output): Get validated, typed data back from agent tasks.
 - [Follow-up tasks](https://docs.browser-use.com/cloud/agent/follow-up-tasks): Run multiple tasks in the same browser session.
 - [Live messages](https://docs.browser-use.com/cloud/agent/streaming): Stream the agent's messages in real time to build custom UIs or monitor progress.
-- [Workspaces & files](https://docs.browser-use.com/cloud/agent/workspaces): Persistent file storage across sessions. Upload input files, download results, and share data across tasks.
+- [Workspaces & files](https://docs.browser-use.com/cloud/agent/workspaces): Upload files for the agent, download files the agent creates.
 - [Human in the loop](https://docs.browser-use.com/cloud/agent/human-in-the-loop): Let a human interact with the live browser while the agent is running. Useful for approvals, payments, complex auth flows, or reviewing agent work before continuing.
 
 ## Browser
 - [Introduction Stealth](https://docs.browser-use.com/cloud/browser/stealth): Best stealth on the planet. We fork Chromium to give agents access to all websites.
 - [Proxies](https://docs.browser-use.com/cloud/browser/proxies): Residential proxies in 195+ countries. On by default.
 - [Live preview & recording](https://docs.browser-use.com/cloud/browser/live-preview): Watch the agent's browser in real time. Embed it in your app.
+- [Playwright, Puppeteer, Selenium](https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium): Connect your automation framework to Browser Use's stealth infrastructure via CDP.
 
 ## Authentication
 - [Profiles](https://docs.browser-use.com/cloud/guides/authentication): Persistent browser state — cookies, localStorage, saved passwords. Login once, reuse across sessions.
 - [Sync local and cloud cookies](https://docs.browser-use.com/cloud/guides/profile-sync): Sync your local browser cookies to the cloud — instantly authenticate without managing credentials.
-- [Playwright, Puppeteer, Selenium](https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium): Connect your automation framework to Browser Use's stealth infrastructure via CDP.
-
-## More
 
 ## Integrations
 - [OpenClaw](https://docs.browser-use.com/cloud/tutorials/integrations/openclaw): Give OpenClaw agents browser automation with Browser Use — via CDP or the CLI skill.
@@ -59,6 +59,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Legacy (v2)
 - [Agent (v2)](https://docs.browser-use.com/cloud/legacy/agent): V2 agent models and file handling.
+- [Public share links (v2)](https://docs.browser-use.com/cloud/legacy/public-share): Generate shareable URLs for agent sessions using the v2 API.
 - [Skills](https://docs.browser-use.com/cloud/legacy/skills): Turn any website into a deterministic API endpoint. Create once, call repeatedly.
 - [1Password & 2FA](https://docs.browser-use.com/cloud/guides/1password): Auto-fill passwords and TOTP codes from 1Password during agent tasks.
 - [Secrets](https://docs.browser-use.com/cloud/guides/secrets): Pass domain-scoped credentials to the agent securely.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -79,6 +79,7 @@
                       "cloud/browser/stealth",
                       "cloud/browser/proxies",
                       "cloud/browser/live-preview",
+                      "cloud/browser/playwright-puppeteer-selenium",
                       {
                         "group": "Authentication",
                         "icon": "key",
@@ -86,8 +87,7 @@
                           "cloud/guides/authentication",
                           "cloud/guides/profile-sync"
                         ]
-                      },
-                      "cloud/browser/playwright-puppeteer-selenium"
+                      }
                     ]
                   }
                 ]
@@ -109,10 +109,10 @@
                     "group": "Tutorials",
                     "icon": "graduation-cap",
                     "pages": [
-                      "cloud/tutorials/chat-ui"
+                      "cloud/tutorials/chat-ui",
+                      "cloud/faq"
                     ]
                   },
-                  "cloud/faq",
                   {
                     "group": "Legacy (v2)",
                     "icon": "box-archive",
@@ -513,7 +513,7 @@
     {"source": "/concepts/profile", "destination": "/cloud/guides/authentication"},
     {"source": "/concepts/file", "destination": "/cloud/agent/quickstart"},
     {"source": "/concepts/browser", "destination": "/cloud/browser/playwright-puppeteer-selenium"},
-    {"source": "/usage/structured-output", "destination": "/cloud/agent/quickstart"},
+    {"source": "/usage/structured-output", "destination": "/cloud/agent/structured-output"},
     {"source": "/usage/streaming-response", "destination": "/cloud/agent/quickstart"},
     {"source": "/usage/streaming", "destination": "/cloud/agent/quickstart"},
     {"source": "/usage/mcp-server", "destination": "/cloud/guides/mcp-server"},

--- a/docs/generate-llms-txt.sh
+++ b/docs/generate-llms-txt.sh
@@ -209,6 +209,8 @@ cat > "$CLOUD_INDEX" << 'HEADER'
 - Agent benchmark (online Mind2Web): https://browser-use.com/posts/online-mind2web-benchmark
 - Blog: https://browser-use.com/posts
 
+**Use v3** (`from browser_use_sdk.v3 import AsyncBrowserUse` / `import { BrowserUse } from "browser-use-sdk/v3"`). v2 is legacy.
+
 Install (check if already installed and update to latest):
 - Python: `pip install --upgrade browser-use-sdk`
 - TypeScript: `npm install browser-use-sdk@latest`

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -284,37 +284,23 @@ while (true) {
 Source: https://docs.browser-use.com/cloud/agent/workspaces
 
 
-Workspaces are the recommended way to handle all file operations — uploading input files and downloading results. Prefer workspaces over session-level file uploads.
+Workspaces give your agent persistent file storage. Two patterns cover almost every use case:
 
-See your workspace IDs at [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=workspaces).
+1. **You upload a file** → agent reads it
+2. **Agent creates a file** → you download it
 
 ## Upload a file
 
-Upload a file to a workspace, then tell the agent to use it.
-
 ```python Python
-import httpx
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 workspace = await client.workspaces.create(name="my-workspace")
 
-# Get a presigned upload URL
-upload = await client.workspaces.upload_files(
-    workspace.id,
-    files=[{"name": "people.csv", "contentType": "text/csv", "size": 45}],
-)
+# Upload
+await client.workspaces.upload(workspace.id, "people.csv")
 
-# Upload the file
-with open("people.csv", "rb") as f:
-    async with httpx.AsyncClient() as http:
-        await http.put(
-            upload.files[0].upload_url,
-            content=f.read(),
-            headers={"Content-Type": "text/csv", "Content-Length": "45"},
-        )
-
-# Tell the agent to use it
+# Agent can now read it
 result = await client.run(
     "Read people.csv and tell me who works at Google",
     workspace_id=workspace.id,
@@ -323,24 +309,14 @@ print(result.output)
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
-import { readFileSync } from "fs";
 
 const client = new BrowserUse();
 const workspace = await client.workspaces.create({ name: "my-workspace" });
 
-// Get a presigned upload URL
-const upload = await client.workspaces.uploadFiles(workspace.id, {
-  files: [{ name: "people.csv", contentType: "text/csv", size: 45 }],
-});
+// Upload
+await client.workspaces.upload(workspace.id, "people.csv");
 
-// Upload the file
-await fetch(upload.files[0].uploadUrl, {
-  method: "PUT",
-  headers: { "Content-Type": "text/csv", "Content-Length": "45" },
-  body: readFileSync("people.csv"),
-});
-
-// Tell the agent to use it
+// Agent can now read it
 const result = await client.run(
   "Read people.csv and tell me who works at Google",
   { workspaceId: workspace.id },
@@ -348,53 +324,56 @@ const result = await client.run(
 console.log(result.output);
 ```
 
-## Download files
-
-Run a task that saves files to a workspace, then download them.
+You can upload multiple files at once:
 
 ```python Python
-import httpx
+await client.workspaces.upload(workspace.id, "data.csv", "config.json", "image.png")
+```
+```typescript TypeScript
+await client.workspaces.upload(workspace.id, "data.csv", "config.json", "image.png");
+```
+
+## Download files
+
+```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 workspace = await client.workspaces.create(name="my-workspace")
 
-# Agent saves files to the workspace
+# Agent creates a file
 result = await client.run(
     "Go to Hacker News and save the top 3 posts as posts.json",
     workspace_id=workspace.id,
 )
 
-# List and download files
-files = await client.workspaces.files(workspace.id, include_urls=True)
-for f in files.files:
-    print(f"{f.path} ({f.size} bytes)")
+# Download a single file
+await client.workspaces.download(workspace.id, "posts.json", to="./posts.json")
 
-    async with httpx.AsyncClient() as http:
-        resp = await http.get(f.url)
-        with open(f.path, "wb") as out:
-            out.write(resp.content)
+# Or download everything
+paths = await client.workspaces.download_all(workspace.id, to="./output")
+for p in paths:
+    print(f"Downloaded: {p}")
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
-import { writeFileSync } from "fs";
 
 const client = new BrowserUse();
 const workspace = await client.workspaces.create({ name: "my-workspace" });
 
-// Agent saves files to the workspace
+// Agent creates a file
 const result = await client.run(
   "Go to Hacker News and save the top 3 posts as posts.json",
   { workspaceId: workspace.id },
 );
 
-// List and download files
-const files = await client.workspaces.files(workspace.id, { includeUrls: true });
-for (const f of files.files) {
-  console.log(`${f.path} (${f.size} bytes)`);
+// Download a single file
+await client.workspaces.download(workspace.id, "posts.json", { to: "./posts.json" });
 
-  const resp = await fetch(f.url);
-  writeFileSync(f.path, Buffer.from(await resp.arrayBuffer()));
+// Or download everything
+const paths = await client.workspaces.downloadAll(workspace.id, { to: "./output" });
+for (const p of paths) {
+  console.log(`Downloaded: ${p}`);
 }
 ```
 
@@ -412,6 +391,8 @@ const updated = await client.workspaces.update(workspaceId, { name: "renamed" })
 const workspaces = await client.workspaces.list();
 await client.workspaces.delete(workspaceId);
 ```
+
+You can also manage workspaces from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=workspaces).
 
   Deleting a workspace permanently removes all its files. This cannot be undone.
 
@@ -686,18 +667,111 @@ for (const url of urls) {
 
   Recording URLs are presigned and **expire after 1 hour**. Download or serve the recording promptly. If you need to access it later, save the MP4 to your own storage.
 
-## Public share links
 
-Generate a public URL that anyone can open to watch the entire agent session — no API key needed. Useful for sharing with teammates, stakeholders, or embedding in dashboards.
+
+# Playwright, Puppeteer, Selenium
+Source: https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium
+
+
+## Option 1: WebSocket URL (no SDK)
+
+Connect with a single URL. All configuration is passed as query parameters.
+
+### Playwright
 
 ```python Python
-share = await client.sessions.create_share(session.id)
-print(share.url)
+from playwright.async_api import async_playwright
+
+WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us"
+
+async with async_playwright() as p:
+    browser = await p.chromium.connect_over_cdp(WSS_URL)
+    page = browser.contexts[0].pages[0]
+    await page.goto("https://example.com")
+    print(await page.title())
+    await browser.close()
+# Browser is automatically stopped when the WebSocket disconnects
 ```
 ```typescript TypeScript
-const share = await client.sessions.createShare(session.id);
-console.log(share.url);
+import { chromium } from "playwright";
+
+const WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us";
+
+const browser = await chromium.connectOverCDP(WSS_URL);
+const page = browser.contexts()[0].pages()[0];
+await page.goto("https://example.com");
+console.log(await page.title());
+await browser.close();
+// Browser is automatically stopped when the WebSocket disconnects
 ```
+
+### Puppeteer
+
+```typescript
+import puppeteer from "puppeteer-core";
+
+const WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us";
+
+const browser = await puppeteer.connect({ browserWSEndpoint: WSS_URL });
+const [page] = await browser.pages();
+await page.goto("https://example.com");
+console.log(await page.title());
+await browser.close();
+```
+
+### Selenium
+
+```python
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+browser = await client.browsers.create()
+
+options = Options()
+options.debugger_address = browser.cdp_url.replace("ws://", "").replace("/devtools/browser/", "")
+driver = webdriver.Chrome(options=options)
+driver.get("https://example.com")
+print(driver.title)
+driver.quit()
+
+await client.browsers.stop(browser.id)
+```
+
+## Query parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `apiKey` | `string` | **Required.** Your Browser Use API key. |
+| `proxyCountryCode` | `string` | Proxy country code (e.g. `us`, `de`, `jp`). 195+ countries. |
+| `profileId` | `string` | Load a saved browser profile (cookies, localStorage). |
+| `timeout` | `int` | Session timeout in minutes. Max: 240 (4 hours). |
+| `browserScreenWidth` | `int` | Browser width in pixels. |
+| `browserScreenHeight` | `int` | Browser height in pixels. |
+
+## Option 2: SDK
+
+Create a browser via the SDK, get a `cdp_url`, connect with your framework.
+
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+browser = await client.browsers.create(proxy_country_code="us")
+print(browser.cdp_url)   # ws://...
+print(browser.live_url)  # debug view
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+
+const client = new BrowserUse();
+const browser = await client.browsers.create({ proxyCountryCode: "us" });
+console.log(browser.cdpUrl);
+console.log(browser.liveUrl);
+```
+
+  Always stop browser sessions when done. Sessions left running will continue to incur charges until the timeout expires.
 
 
 # Profiles
@@ -812,111 +886,6 @@ const result = await client.run("Check my LinkedIn messages", {
   sessionId: session.id,
 });
 ```
-
-
-# Playwright, Puppeteer, Selenium
-Source: https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium
-
-
-## Option 1: WebSocket URL (no SDK)
-
-Connect with a single URL. All configuration is passed as query parameters.
-
-### Playwright
-
-```python Python
-from playwright.async_api import async_playwright
-
-WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us"
-
-async with async_playwright() as p:
-    browser = await p.chromium.connect_over_cdp(WSS_URL)
-    page = browser.contexts[0].pages[0]
-    await page.goto("https://example.com")
-    print(await page.title())
-    await browser.close()
-# Browser is automatically stopped when the WebSocket disconnects
-```
-```typescript TypeScript
-import { chromium } from "playwright";
-
-const WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us";
-
-const browser = await chromium.connectOverCDP(WSS_URL);
-const page = browser.contexts()[0].pages()[0];
-await page.goto("https://example.com");
-console.log(await page.title());
-await browser.close();
-// Browser is automatically stopped when the WebSocket disconnects
-```
-
-### Puppeteer
-
-```typescript
-import puppeteer from "puppeteer-core";
-
-const WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us";
-
-const browser = await puppeteer.connect({ browserWSEndpoint: WSS_URL });
-const [page] = await browser.pages();
-await page.goto("https://example.com");
-console.log(await page.title());
-await browser.close();
-```
-
-### Selenium
-
-```python
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-from browser_use_sdk.v3 import AsyncBrowserUse
-
-client = AsyncBrowserUse()
-browser = await client.browsers.create()
-
-options = Options()
-options.debugger_address = browser.cdp_url.replace("ws://", "").replace("/devtools/browser/", "")
-driver = webdriver.Chrome(options=options)
-driver.get("https://example.com")
-print(driver.title)
-driver.quit()
-
-await client.browsers.stop(browser.id)
-```
-
-## Query parameters
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `apiKey` | `string` | **Required.** Your Browser Use API key. |
-| `proxyCountryCode` | `string` | Proxy country code (e.g. `us`, `de`, `jp`). 195+ countries. |
-| `profileId` | `string` | Load a saved browser profile (cookies, localStorage). |
-| `timeout` | `int` | Session timeout in minutes. Max: 240 (4 hours). |
-| `browserScreenWidth` | `int` | Browser width in pixels. |
-| `browserScreenHeight` | `int` | Browser height in pixels. |
-
-## Option 2: SDK
-
-Create a browser via the SDK, get a `cdp_url`, connect with your framework.
-
-```python Python
-from browser_use_sdk.v3 import AsyncBrowserUse
-
-client = AsyncBrowserUse()
-browser = await client.browsers.create(proxy_country_code="us")
-print(browser.cdp_url)   # ws://...
-print(browser.live_url)  # debug view
-```
-```typescript TypeScript
-import { BrowserUse } from "browser-use-sdk/v3";
-
-const client = new BrowserUse();
-const browser = await client.browsers.create({ proxyCountryCode: "us" });
-console.log(browser.cdpUrl);
-console.log(browser.liveUrl);
-```
-
-  Always stop browser sessions when done. Sessions left running will continue to incur charges until the timeout expires.
 
 
 # OpenClaw
@@ -1718,6 +1687,22 @@ console.log(run.result?.output);  // final result after iteration
 | `skill_ids` | `list[str]` | Skills the agent can use during the task. |
 | `op_vault_id` | `str` | 1Password vault ID for auto-fill credentials and 2FA. |
 | `metadata` | `dict[str, str]` | Custom metadata attached to the task. |
+
+
+# Public share links (v2)
+Source: https://docs.browser-use.com/cloud/legacy/public-share
+
+
+Generate a public URL that anyone can open to watch the entire agent session — no API key needed. Useful for sharing with teammates, stakeholders, or embedding in dashboards.
+
+```python Python
+share = await client.sessions.create_share(session.id)
+print(share.url)
+```
+```typescript TypeScript
+const share = await client.sessions.createShare(session.id);
+console.log(share.url);
+```
 
 
 # Skills

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -13,6 +13,8 @@
 - Agent benchmark (online Mind2Web): https://browser-use.com/posts/online-mind2web-benchmark
 - Blog: https://browser-use.com/posts
 
+**Use v3** (`from browser_use_sdk.v3 import AsyncBrowserUse` / `import { BrowserUse } from "browser-use-sdk/v3"`). v2 is legacy.
+
 Install (check if already installed and update to latest):
 - Python: `pip install --upgrade browser-use-sdk`
 - TypeScript: `npm install browser-use-sdk@latest`
@@ -32,20 +34,18 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 - [Structured output](https://docs.browser-use.com/cloud/agent/structured-output): Get validated, typed data back from agent tasks.
 - [Follow-up tasks](https://docs.browser-use.com/cloud/agent/follow-up-tasks): Run multiple tasks in the same browser session.
 - [Live messages](https://docs.browser-use.com/cloud/agent/streaming): Stream the agent's messages in real time to build custom UIs or monitor progress.
-- [Workspaces & files](https://docs.browser-use.com/cloud/agent/workspaces): Persistent file storage across sessions. Upload input files, download results, and share data across tasks.
+- [Workspaces & files](https://docs.browser-use.com/cloud/agent/workspaces): Upload files for the agent, download files the agent creates.
 - [Human in the loop](https://docs.browser-use.com/cloud/agent/human-in-the-loop): Let a human interact with the live browser while the agent is running. Useful for approvals, payments, complex auth flows, or reviewing agent work before continuing.
 
 ## Browser
 - [Introduction Stealth](https://docs.browser-use.com/cloud/browser/stealth): Best stealth on the planet. We fork Chromium to give agents access to all websites.
 - [Proxies](https://docs.browser-use.com/cloud/browser/proxies): Residential proxies in 195+ countries. On by default.
 - [Live preview & recording](https://docs.browser-use.com/cloud/browser/live-preview): Watch the agent's browser in real time. Embed it in your app.
+- [Playwright, Puppeteer, Selenium](https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium): Connect your automation framework to Browser Use's stealth infrastructure via CDP.
 
 ## Authentication
 - [Profiles](https://docs.browser-use.com/cloud/guides/authentication): Persistent browser state — cookies, localStorage, saved passwords. Login once, reuse across sessions.
 - [Sync local and cloud cookies](https://docs.browser-use.com/cloud/guides/profile-sync): Sync your local browser cookies to the cloud — instantly authenticate without managing credentials.
-- [Playwright, Puppeteer, Selenium](https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium): Connect your automation framework to Browser Use's stealth infrastructure via CDP.
-
-## More
 
 ## Integrations
 - [OpenClaw](https://docs.browser-use.com/cloud/tutorials/integrations/openclaw): Give OpenClaw agents browser automation with Browser Use — via CDP or the CLI skill.
@@ -59,6 +59,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Legacy (v2)
 - [Agent (v2)](https://docs.browser-use.com/cloud/legacy/agent): V2 agent models and file handling.
+- [Public share links (v2)](https://docs.browser-use.com/cloud/legacy/public-share): Generate shareable URLs for agent sessions using the v2 API.
 - [Skills](https://docs.browser-use.com/cloud/legacy/skills): Turn any website into a deterministic API endpoint. Create once, call repeatedly.
 - [1Password & 2FA](https://docs.browser-use.com/cloud/guides/1password): Auto-fill passwords and TOTP codes from 1Password during agent tasks.
 - [Secrets](https://docs.browser-use.com/cloud/guides/secrets): Pass domain-scoped credentials to the agent securely.


### PR DESCRIPTION
… nav

- Fix redirect: /usage/structured-output now points to /cloud/agent/structured-output instead of /cloud/agent/quickstart
- Add enable_recording as explicit named parameter in Python v3 SDK (run, stream, sessions.create) so snake_case is correctly mapped to camelCase enableRecording in the API request body
- Add v3 version statement to llms.txt header
- Move Playwright page before Authentication sub-group in docs.json so it appears under Browser (not Authentication) in llms.txt
- Move FAQ into Tutorials group to eliminate orphaned ## More header in llms.txt
- Regenerate llms.txt and llms-full.txt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix redirect for Structured Output docs and add explicit `enable_recording` support in the v3 Python SDK. Updates LLM docs and navigation to emphasize v3 and correct page placement.

- **Bug Fixes**
  - Redirect: `/usage/structured-output` → `/cloud/agent/structured-output`.
  - Python v3 SDK: add `enable_recording` to `run()`, `stream()`, and `sessions.create()` (sync + async) in `browser_use_sdk.v3`; sent to the API as `enableRecording`.

- **Docs**
  - Add v3 usage note to `llms.txt`; mark v2 as legacy.
  - Move Playwright page under Browser and FAQ into Tutorials in `docs.json`.
  - Regenerate `llms.txt` and `llms-full.txt` (cloud and root) to reflect nav and wording updates.

<sup>Written for commit 5aec3bfaee86f105d0f619c445413efff3781816. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

