### PR TITLE
Add custom_proxy as explicit param in Python v3 SDK

### DIFF
--- a/browser-use-python/src/browser_use_sdk/v3/client.py
+++ b/browser-use-python/src/browser_use_sdk/v3/client.py
@@ -61,6 +61,7 @@ class BrowserUse:
         proxy_country_code: str | None = ...,
         workspace_id: str | None = ...,
         enable_recording: bool | None = ...,
+        custom_proxy: dict[str, Any] | None = ...,
         **extra: Any,
     ) -> SessionResult[T]: ...
 
@@ -78,6 +79,7 @@ class BrowserUse:
         proxy_country_code: str | None = ...,
         workspace_id: str | None = ...,
         enable_recording: bool | None = ...,
+        custom_proxy: dict[str, Any] | None = ...,
         **extra: Any,
     ) -> SessionResult[T]: ...
 
@@ -94,6 +96,7 @@ class BrowserUse:
         proxy_country_code: str | None = ...,
         workspace_id: str | None = ...,
         enable_recording: bool | None = ...,
+        custom_proxy: dict[str, Any] | None = ...,
         **extra: Any,
     ) -> SessionResult[str]: ...
 
@@ -111,6 +114,7 @@ class BrowserUse:
         proxy_country_code: str | None = None,
         workspace_id: str | None = None,
         enable_recording: bool | None = None,
+        custom_proxy: dict[str, Any] | None = None,
         **extra: Any,
     ) -> Any:
         """Run a task and block until complete. Returns a SessionResult."""
@@ -134,6 +138,7 @@ class BrowserUse:
             output_schema=schema_dict,
             workspace_id=workspace_id,
             enable_recording=enable_recording,
+            custom_proxy=custom_proxy,
             **extra,
         )
         return _poll_output(self.sessions, str(data.id), resolved_schema)
@@ -152,6 +157,7 @@ class BrowserUse:
         proxy_country_code: str | None = None,
         workspace_id: str | None = None,
         enable_recording: bool | None = None,
+        custom_proxy: dict[str, Any] | None = None,
         **extra: Any,
     ) -> SessionStream[Any]:
         """Run a task and yield messages as they happen.
@@ -182,6 +188,7 @@ class BrowserUse:
             output_schema=schema_dict,
             workspace_id=workspace_id,
             enable_recording=enable_recording,
+            custom_proxy=custom_proxy,
             **extra,
         )
         return SessionStream(data, self.sessions, resolved_schema)
@@ -237,6 +244,7 @@ class AsyncBrowserUse:
         proxy_country_code: str | None = ...,
         workspace_id: str | None = ...,
         enable_recording: bool | None = ...,
+        custom_proxy: dict[str, Any] | None = ...,
         **extra: Any,
     ) -> AsyncSessionRun[T]: ...
 
@@ -254,6 +262,7 @@ class AsyncBrowserUse:
         proxy_country_code: str | None = ...,
         workspace_id: str | None = ...,
         enable_recording: bool | None = ...,
+        custom_proxy: dict[str, Any] | None = ...,
         **extra: Any,
     ) -> AsyncSessionRun[T]: ...
 
@@ -270,6 +279,7 @@ class AsyncBrowserUse:
         proxy_country_code: str | None = ...,
         workspace_id: str | None = ...,
         enable_recording: bool | None = ...,
+        custom_proxy: dict[str, Any] | None = ...,
         **extra: Any,
     ) -> AsyncSessionRun[str]: ...
 
@@ -287,6 +297,7 @@ class AsyncBrowserUse:
         proxy_country_code: str | None = None,
         workspace_id: str | None = None,
         enable_recording: bool | None = None,
+        custom_proxy: dict[str, Any] | None = None,
         **extra: Any,
     ) -> AsyncSessionRun[Any]:
         """Run a task. Await the result for a SessionResult."""
@@ -312,6 +323,7 @@ class AsyncBrowserUse:
                 output_schema=schema_dict,
                 workspace_id=workspace_id,
                 enable_recording=enable_recording,
+                custom_proxy=custom_proxy,
                 **extra,
             )
 

--- a/browser-use-python/src/browser_use_sdk/v3/resources/sessions.py
+++ b/browser-use-python/src/browser_use_sdk/v3/resources/sessions.py
@@ -37,6 +37,7 @@ class Sessions:
         workspace_id: str | None = None,
         enable_scheduled_tasks: bool | None = None,
         enable_recording: bool | None = None,
+        custom_proxy: dict[str, Any] | None = None,
         **extra: Any,
     ) -> SessionResponse:
         """Create a session and optionally dispatch a task."""
@@ -63,6 +64,8 @@ class Sessions:
             body["enableScheduledTasks"] = enable_scheduled_tasks
         if enable_recording is not None:
             body["enableRecording"] = enable_recording
+        if custom_proxy is not None:
+            body["customProxy"] = custom_proxy
         body.update(extra)
         return SessionResponse.model_validate(
             self._http.request("POST", "/sessions", json=body)
@@ -211,6 +214,7 @@ class AsyncSessions:
         workspace_id: str | None = None,
         enable_scheduled_tasks: bool | None = None,
         enable_recording: bool | None = None,
+        custom_proxy: dict[str, Any] | None = None,
         **extra: Any,
     ) -> SessionResponse:
         """Create a session and optionally dispatch a task."""
@@ -237,6 +241,8 @@ class AsyncSessions:
             body["enableScheduledTasks"] = enable_scheduled_tasks
         if enable_recording is not None:
             body["enableRecording"] = enable_recording
+        if custom_proxy is not None:
+            body["customProxy"] = custom_proxy
         body.update(extra)
         return SessionResponse.model_validate(
             await self._http.request("POST", "/sessions", json=body)


### PR DESCRIPTION
## Summary
- Add `custom_proxy` as an explicit named parameter on Python v3 `sessions.create()`, `run()`, and `stream()`
- Maps snake_case `custom_proxy` to camelCase `customProxy` in the API request body
- Same pattern as the `enable_recording` fix — previously `custom_proxy` fell through `**extra` as snake_case and was silently ignored by the backend

## Test plan
- [ ] `await client.run("...", custom_proxy={"host": "proxy.example.com", "port": 8080})` sends `customProxy` in request body
- [ ] `task check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `custom_proxy` as a named parameter in the Python v3 SDK for `sessions.create()`, `run()`, and `stream()`. It maps to `customProxy` in the request body so proxy settings are applied instead of being dropped via `**extra`.

- **Bug Fixes**
  - `custom_proxy` is now serialized to `customProxy` for both sync and async `sessions.create()`, `run()`, and `stream()` calls.

<sup>Written for commit 3851457671da7332b8ec5b11cc2a9e263c85b438. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

