### PR TITLE
Sync v3 API tag ordering across all spec copies

### DIFF
--- a/docs/openapi/v3.json
+++ b/docs/openapi/v3.json
@@ -3625,10 +3625,10 @@
             "name": "Sessions"
         },
         {
-            "name": "Profiles"
+            "name": "Browsers"
         },
         {
-            "name": "Browsers"
+            "name": "Profiles"
         },
         {
             "name": "Workspaces"

--- a/snapshots/v3.json
+++ b/snapshots/v3.json
@@ -3625,10 +3625,10 @@
             "name": "Sessions"
         },
         {
-            "name": "Profiles"
+            "name": "Browsers"
         },
         {
-            "name": "Browsers"
+            "name": "Profiles"
         },
         {
             "name": "Workspaces"


### PR DESCRIPTION
## Summary
- Swaps Browsers and Profiles in `snapshots/v3.json` and `docs/openapi/v3.json` to match the correct ordering in `docs/cloud/openapi/v3.json`
- All three copies now consistently use: Sessions, Browsers, Profiles, Workspaces, Files, Billing

## Test plan
- [ ] Verify Mintlify docs sidebar shows correct API endpoint ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the v3 API tag order across all OpenAPI specs so endpoint groups appear consistently in docs. Swaps Profiles and Browsers in `docs/openapi/v3.json` and `snapshots/v3.json` to match `docs/cloud/openapi/v3.json`: Sessions, Browsers, Profiles, Workspaces, Files, Billing.

<sup>Written for commit db3e44bf2e3abd1324eb56e01ebb3e0624d366ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

