### PR TITLE
Fix docs audit: broken examples, SDK bugs, copy-paste errors

### DIFF
--- a/browser-use-node/src/v3/resources/profiles.ts
+++ b/browser-use-node/src/v3/resources/profiles.ts
@@ -7,6 +7,7 @@ type ProfileCreateRequest = components["schemas"]["ProfileCreateRequest"];
 type ProfileUpdateRequest = components["schemas"]["ProfileUpdateRequest"];
 
 export interface ProfileListParams {
+  query?: string;
   page?: number;
   page_size?: number;
 }

--- a/browser-use-node/src/v3/resources/sessions.ts
+++ b/browser-use-node/src/v3/resources/sessions.ts
@@ -36,7 +36,7 @@ export class Sessions {
 
   /** Create a session and optionally dispatch a task. */
   create(body?: CreateSessionBody): Promise<SessionResponse> {
-    return this.http.post<SessionResponse>("/sessions", body);
+    return this.http.post<SessionResponse>("/sessions", body ?? {});
   }
 
   /** List sessions for the authenticated project. */

--- a/browser-use-python/src/browser_use_sdk/v3/resources/profiles.py
+++ b/browser-use-python/src/browser_use_sdk/v3/resources/profiles.py
@@ -37,6 +37,7 @@ class Profiles:
     def list(
         self,
         *,
+        query: str | None = None,
         page: int | None = None,
         page_size: int | None = None,
     ) -> ProfileListResponse:
@@ -45,7 +46,7 @@ class Profiles:
             self._http.request(
                 "GET",
                 "/profiles",
-                params={"page": page, "page_size": page_size},
+                params={"query": query, "page": page, "page_size": page_size},
             )
         )
 
@@ -104,6 +105,7 @@ class AsyncProfiles:
     async def list(
         self,
         *,
+        query: str | None = None,
         page: int | None = None,
         page_size: int | None = None,
     ) -> ProfileListResponse:
@@ -112,7 +114,7 @@ class AsyncProfiles:
             await self._http.request(
                 "GET",
                 "/profiles",
-                params={"page": page, "page_size": page_size},
+                params={"query": query, "page": page, "page_size": page_size},
             )
         )
 

--- a/docs/cloud/agent/human-in-the-loop.mdx
+++ b/docs/cloud/agent/human-in-the-loop.mdx
@@ -33,7 +33,7 @@ result = await client.run(
 )
 print(result.output)
 
-# 3. Human opens live_url and picks a flight
+# 3. Human opens live_url and picks a product
 input("Press Enter after you've selected a product in the live view...")
 
 # 4. Agent continues where the human left off
@@ -63,7 +63,7 @@ const searchResult = await client.run(
 );
 console.log(searchResult.output);
 
-// 3. Human opens liveUrl and picks a flight
+// 3. Human opens liveUrl and picks a product
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 await new Promise((resolve) =>
   rl.question("Press Enter after you've selected a product in the live view...", resolve),

--- a/docs/cloud/agent/workspaces.mdx
+++ b/docs/cloud/agent/workspaces.mdx
@@ -109,13 +109,18 @@ for (const p of paths) {
 ```python Python
 workspace = await client.workspaces.get(workspace_id)
 updated = await client.workspaces.update(workspace_id, name="renamed")
-workspaces = await client.workspaces.list()
+response = await client.workspaces.list()
+for w in response.items:
+    print(w.id, w.name)
 await client.workspaces.delete(workspace_id)
 ```
 ```typescript TypeScript
 const workspace = await client.workspaces.get(workspaceId);
 const updated = await client.workspaces.update(workspaceId, { name: "renamed" });
-const workspaces = await client.workspaces.list();
+const response = await client.workspaces.list();
+for (const w of response.items) {
+  console.log(w.id, w.name);
+}
 await client.workspaces.delete(workspaceId);
 ```
 </CodeGroup>

--- a/docs/cloud/guides/authentication.mdx
+++ b/docs/cloud/guides/authentication.mdx
@@ -41,13 +41,13 @@ View your profile IDs at [cloud.browser-use.com/settings](https://cloud.browser-
 profile = await client.profiles.create(name="work-account")
 
 # List all
-profiles = await client.profiles.list()
-for p in profiles:
+response = await client.profiles.list()
+for p in response.items:
     print(p.id, p.name)
 
 # Search by name
-results = await client.profiles.list(query="user-id-1")
-profile = results[0]  # first match
+response = await client.profiles.list(query="user-id-1")
+profile = response.items[0]  # first match
 
 # Get one by ID
 profile = await client.profiles.get(profile_id)
@@ -63,14 +63,14 @@ await client.profiles.delete(profile_id)
 const profile = await client.profiles.create({ name: "work-account" });
 
 // List all
-const profiles = await client.profiles.list();
-for (const p of profiles) {
+const response = await client.profiles.list();
+for (const p of response.items) {
   console.log(p.id, p.name);
 }
 
 // Search by name
 const results = await client.profiles.list({ query: "user-id-1" });
-const found = results[0]; // first match
+const found = results.items[0]; // first match
 
 // Get one by ID
 const fetched = await client.profiles.get(profileId);

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -382,13 +382,18 @@ for (const p of paths) {
 ```python Python
 workspace = await client.workspaces.get(workspace_id)
 updated = await client.workspaces.update(workspace_id, name="renamed")
-workspaces = await client.workspaces.list()
+response = await client.workspaces.list()
+for w in response.items:
+    print(w.id, w.name)
 await client.workspaces.delete(workspace_id)
 ```
 ```typescript TypeScript
 const workspace = await client.workspaces.get(workspaceId);
 const updated = await client.workspaces.update(workspaceId, { name: "renamed" });
-const workspaces = await client.workspaces.list();
+const response = await client.workspaces.list();
+for (const w of response.items) {
+  console.log(w.id, w.name);
+}
 await client.workspaces.delete(workspaceId);
 ```
 
@@ -429,7 +434,7 @@ result = await client.run(
 )
 print(result.output)
 
-# 3. Human opens live_url and picks a flight
+# 3. Human opens live_url and picks a product
 input("Press Enter after you've selected a product in the live view...")
 
 # 4. Agent continues where the human left off
@@ -459,7 +464,7 @@ const searchResult = await client.run(
 );
 console.log(searchResult.output);
 
-// 3. Human opens liveUrl and picks a flight
+// 3. Human opens liveUrl and picks a product
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 await new Promise((resolve) =>
   rl.question("Press Enter after you've selected a product in the live view...", resolve),
@@ -809,13 +814,13 @@ View your profile IDs at [cloud.browser-use.com/settings](https://cloud.browser-
 profile = await client.profiles.create(name="work-account")
 
 # List all
-profiles = await client.profiles.list()
-for p in profiles:
+response = await client.profiles.list()
+for p in response.items:
     print(p.id, p.name)
 
 # Search by name
-results = await client.profiles.list(query="user-id-1")
-profile = results[0]  # first match
+response = await client.profiles.list(query="user-id-1")
+profile = response.items[0]  # first match
 
 # Get one by ID
 profile = await client.profiles.get(profile_id)
@@ -831,14 +836,14 @@ await client.profiles.delete(profile_id)
 const profile = await client.profiles.create({ name: "work-account" });
 
 // List all
-const profiles = await client.profiles.list();
-for (const p of profiles) {
+const response = await client.profiles.list();
+for (const p of response.items) {
   console.log(p.id, p.name);
 }
 
 // Search by name
 const results = await client.profiles.list({ query: "user-id-1" });
-const found = results[0]; // first match
+const found = results.items[0]; // first match
 
 // Get one by ID
 const fetched = await client.profiles.get(profileId);
@@ -1326,11 +1331,12 @@ All SDK calls live in a single file: `src/lib/api.ts`.
 ```typescript api.ts
 import { BrowserUse } from "browser-use-sdk/v3";
 
-const apiKey = process.env.NEXT_PUBLIC_BROWSER_USE_API_KEY ?? "";
+// Server-only — no NEXT_PUBLIC_ prefix, never exposed to the browser
+const apiKey = process.env.BROWSER_USE_API_KEY ?? "";
 export const client = new BrowserUse({ apiKey });
 ```
 
-  `NEXT_PUBLIC_` exposes the key to the browser. In production, move SDK calls to server actions or API routes.
+  The API key uses `BROWSER_USE_API_KEY` (no `NEXT_PUBLIC_` prefix) so it stays server-side. All SDK calls go through server actions — never call the SDK directly from client components.
 
 ---
 

--- a/docs/cloud/tutorials/chat-ui.mdx
+++ b/docs/cloud/tutorials/chat-ui.mdx
@@ -22,24 +22,29 @@ All SDK calls live in a single file: `src/lib/api.ts`.
 ```typescript api.ts
 import { BrowserUse } from "browser-use-sdk/v3";
 
-const apiKey = process.env.NEXT_PUBLIC_BROWSER_USE_API_KEY ?? "";
+// Server-only — no NEXT_PUBLIC_ prefix, never exposed to the browser
+const apiKey = process.env.BROWSER_USE_API_KEY ?? "";
 export const client = new BrowserUse({ apiKey });
 ```
 
-<Warning>
-  `NEXT_PUBLIC_` exposes the key to the browser. In production, move SDK calls to server actions or API routes.
-</Warning>
+<Note>
+  The API key uses `BROWSER_USE_API_KEY` (no `NEXT_PUBLIC_` prefix) so it stays server-side. All SDK calls go through [server actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations) — never call the SDK directly from client components.
+</Note>
 
 ---
 
 ## 1. Create a session
 
-```typescript api.ts
+```typescript actions.ts
+"use server";
+import { client } from "./api";
+
 export async function createSession() {
-  return client.sessions.create({
+  const session = await client.sessions.create({
     keepAlive: true,
     enableRecording: true,
   });
+  return { id: session.id, liveUrl: session.liveUrl, status: session.status };
 }
 ```
 
@@ -125,7 +130,7 @@ useEffect(() => {
 
 ## 5. Stop a task
 
-```typescript api.ts
+```typescript actions.ts
 export async function stopTask(id: string) {
   await client.sessions.stop(id, { strategy: "task" });
 }

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -382,13 +382,18 @@ for (const p of paths) {
 ```python Python
 workspace = await client.workspaces.get(workspace_id)
 updated = await client.workspaces.update(workspace_id, name="renamed")
-workspaces = await client.workspaces.list()
+response = await client.workspaces.list()
+for w in response.items:
+    print(w.id, w.name)
 await client.workspaces.delete(workspace_id)
 ```
 ```typescript TypeScript
 const workspace = await client.workspaces.get(workspaceId);
 const updated = await client.workspaces.update(workspaceId, { name: "renamed" });
-const workspaces = await client.workspaces.list();
+const response = await client.workspaces.list();
+for (const w of response.items) {
+  console.log(w.id, w.name);
+}
 await client.workspaces.delete(workspaceId);
 ```
 
@@ -429,7 +434,7 @@ result = await client.run(
 )
 print(result.output)
 
-# 3. Human opens live_url and picks a flight
+# 3. Human opens live_url and picks a product
 input("Press Enter after you've selected a product in the live view...")
 
 # 4. Agent continues where the human left off
@@ -459,7 +464,7 @@ const searchResult = await client.run(
 );
 console.log(searchResult.output);
 
-// 3. Human opens liveUrl and picks a flight
+// 3. Human opens liveUrl and picks a product
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 await new Promise((resolve) =>
   rl.question("Press Enter after you've selected a product in the live view...", resolve),
@@ -809,13 +814,13 @@ View your profile IDs at [cloud.browser-use.com/settings](https://cloud.browser-
 profile = await client.profiles.create(name="work-account")
 
 # List all
-profiles = await client.profiles.list()
-for p in profiles:
+response = await client.profiles.list()
+for p in response.items:
     print(p.id, p.name)
 
 # Search by name
-results = await client.profiles.list(query="user-id-1")
-profile = results[0]  # first match
+response = await client.profiles.list(query="user-id-1")
+profile = response.items[0]  # first match
 
 # Get one by ID
 profile = await client.profiles.get(profile_id)
@@ -831,14 +836,14 @@ await client.profiles.delete(profile_id)
 const profile = await client.profiles.create({ name: "work-account" });
 
 // List all
-const profiles = await client.profiles.list();
-for (const p of profiles) {
+const response = await client.profiles.list();
+for (const p of response.items) {
   console.log(p.id, p.name);
 }
 
 // Search by name
 const results = await client.profiles.list({ query: "user-id-1" });
-const found = results[0]; // first match
+const found = results.items[0]; // first match
 
 // Get one by ID
 const fetched = await client.profiles.get(profileId);
@@ -1326,11 +1331,12 @@ All SDK calls live in a single file: `src/lib/api.ts`.
 ```typescript api.ts
 import { BrowserUse } from "browser-use-sdk/v3";
 
-const apiKey = process.env.NEXT_PUBLIC_BROWSER_USE_API_KEY ?? "";
+// Server-only — no NEXT_PUBLIC_ prefix, never exposed to the browser
+const apiKey = process.env.BROWSER_USE_API_KEY ?? "";
 export const client = new BrowserUse({ apiKey });
 ```
 
-  `NEXT_PUBLIC_` exposes the key to the browser. In production, move SDK calls to server actions or API routes.
+  The API key uses `BROWSER_USE_API_KEY` (no `NEXT_PUBLIC_` prefix) so it stays server-side. All SDK calls go through server actions — never call the SDK directly from client components.
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix `profiles.list()` and `workspaces.list()` doc examples — they returned paginated response objects (`ProfileListResponse`/`WorkspaceListResponse` with `.items`), not plain lists. All iteration/indexing examples were silently broken.
- Add missing `query` param to `profiles.list()` in both TS and Python v3 SDKs (already supported by API and v2 SDK, was omitted from v3).
- Fix TS `sessions.create()` no-args bug — passing `undefined` body meant no `Content-Type` header and no JSON body, causing API 422. Now defaults to `{}`.
- Fix chat-ui tutorial to match actual repo: `BROWSER_USE_API_KEY` (not `NEXT_PUBLIC_`), server actions pattern (not client-side SDK).
- Fix "picks a flight" → "picks a product" copy-paste error in human-in-the-loop docs.
- Sync all fixes to `llms-full.txt` (cloud + root copies).

### How `query` param works
The OpenAPI v3 spec defines `query` as an optional string on `GET /profiles`. The backend filters server-side across **all** profiles (not just the current page). `pageSize`/`pageNumber` paginate the filtered results. Both HTTP clients strip `None`/`undefined` params automatically, so omitting `query` is identical to the old behavior — zero edge cases.

### How `sessions.create()` fix works
`body ?? {}` ensures the HTTP client always gets a defined object. The `Content-Type: application/json` header is set (line 44 of `http.ts` checks `body !== undefined`), and `JSON.stringify({})` sends `"{}"`. `CreateSessionBody` is `Partial<RunTaskRequest>` so `{}` is valid — creates an idle session. No edge cases: explicit `undefined` also coalesces to `{}`.

## Test plan
- [x] `npx tsc --noEmit` passes (TS SDK)
- [ ] Run `task test` to verify no regressions
- [ ] Verify `profiles.list(query="...")` returns filtered results against live API
- [ ] Verify `sessions.create()` with no args returns a valid idle session (TS SDK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SDK inconsistencies and updates docs so examples run as written. Adds `query` to `profiles.list()` in v3 TS and Python SDK and makes `sessions.create()` send `{}` when called without args.

- **Bug Fixes**
  - TS (`browser-use-sdk/v3`): `profiles.list()` accepts `query`; `sessions.create()` posts `{}` when body is undefined (sets `Content-Type: application/json`).
  - Python (`browser_use_sdk/v3`): `profiles.list()` supports `query`.
  - Docs: `profiles.list()`/`workspaces.list()` examples use `.items`; chat-ui tutorial uses `BROWSER_USE_API_KEY` and server actions; “flight” → “product”; synced in `llms-full.txt` (cloud + root).

<sup>Written for commit 0fc4c91f816fa41b51b8f86305794fad3f0b8d4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

