### PR TITLE
Add Agent vs Browser comparison table and SDK callouts

### DIFF
--- a/docs/cloud/agent/quickstart.mdx
+++ b/docs/cloud/agent/quickstart.mdx
@@ -4,7 +4,7 @@ description: "Easiest way to automate the web. Tell this agent in natural langua
 icon: rocket
 ---
 
-The SDK is a thin wrapper around the [API v3 Reference](/cloud/api-reference).
+The SDK is a thin wrapper around the [API v3 Reference](/cloud/api-reference). Every endpoint in the API reference is available as an SDK method — `client.sessions`, `client.browsers`, `client.profiles`, `client.workspaces`, and `client.billing`.
 
 `client.run()` creates a session, polls every 2 seconds until completion (up to 4 hours), and returns the result. It accepts all parameters from the [Create Session](/cloud/api-v3/sessions/create-session) endpoint. The result is a [Session object](/cloud/api-v3/sessions/get-session) — use `result.output` for the agent's response.
 
@@ -42,3 +42,19 @@ curl -X POST https://api.browser-use.com/api/v3/sessions \
 - **1,000+ integrations** — Gmail, Calendar, Notion, and more
 
 The best SOTA browser agent — see our [online Mind2Web benchmark](https://browser-use.com/posts/online-mind2web-benchmark).
+
+## Agent vs Browser
+
+| | `client.run()` | `client.browsers.create()` |
+|---|---|---|
+| **What it does** | Run an AI agent task | Just give me a browser |
+| **Best for** | Most users | [Playwright / Puppeteer / Selenium](/cloud/browser/playwright-puppeteer-selenium) |
+| proxy | ✓ | ✓ |
+| custom_proxy | ✓ | ✓ |
+| profile_id | ✓ | ✓ |
+| recording | ✓ | ✓ |
+| workspace_id | ✓ | — |
+| keep_alive | ✓ | — |
+| screen size | — | ✓ |
+| timeout | — | ✓ |
+| task / model | ✓ | — |

--- a/docs/cloud/browser/playwright-puppeteer-selenium.mdx
+++ b/docs/cloud/browser/playwright-puppeteer-selenium.mdx
@@ -4,6 +4,10 @@ description: "Connect your automation framework to Browser Use's stealth infrast
 icon: code
 ---
 
+<Tip>
+  Prefer the SDK? See the [Agent docs](/cloud/agent/quickstart) — the SDK has all API endpoints available as methods, including `client.browsers.create()`.
+</Tip>
+
 ## Option 1: WebSocket URL (no SDK)
 
 Connect with a single URL. All configuration is passed as query parameters.

--- a/docs/cloud/browser/stealth.mdx
+++ b/docs/cloud/browser/stealth.mdx
@@ -17,7 +17,3 @@ Every cloud browser session runs in a hardened Chromium fork with stealth enable
 ## Residential proxies
 
 Residential proxies are enabled by default across 195+ countries. This makes browser sessions appear as real users from the target geography. See [Proxies](/cloud/browser/proxies) for details on geo-targeting and custom proxy configuration.
-
-## No setup required
-
-Stealth is always on — every `client.run()` call and every session created via the API uses the hardened browser automatically. There are no flags to enable or parameters to set.


### PR DESCRIPTION
## Summary
- Add Agent vs Browser comparison table to agent/quickstart showing param differences between `client.run()` and `browsers.create()`
- Note that SDK exposes all API endpoints as methods (sessions, browsers, profiles, workspaces, billing)
- Remove redundant "No setup required" section from stealth docs
- Add "Prefer the SDK?" tip to Playwright/Puppeteer/Selenium page linking to agent docs

## Test plan
- [ ] Verify table renders correctly in Mintlify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Agent vs Browser comparison table to the agent quickstart and clarifies that the SDK exposes all API endpoints. Also cleans up redundant content and adds an SDK tip to the Playwright/Puppeteer/Selenium page.

- New Features
  - Added comparison table showing param differences between `client.run()` and `client.browsers.create()`.
  - Noted that all API endpoints are available as SDK methods (`client.sessions`, `client.browsers`, `client.profiles`, `client.workspaces`, `client.billing`).
  - Added “Prefer the SDK?” tip linking to agent docs on the Playwright/Puppeteer/Selenium page.

- Refactors
  - Removed redundant “No setup required” section from the stealth page.

<sup>Written for commit 78c80dd743e435f85cd9aca19c6675b71b4f0a31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

