### PR TITLE
Move SDK callout to API reference page

### DIFF
--- a/docs/cloud/api-reference.mdx
+++ b/docs/cloud/api-reference.mdx
@@ -45,7 +45,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ---
 
-Prefer the SDK? See the [Agent docs](/cloud/agent/quickstart).
+Prefer the SDK? See the [Agent docs](/cloud/agent/quickstart) — the SDK has all API endpoints available as methods, including `client.browsers.create()`.
 
 <CodeGroup>
 ```bash Python

--- a/docs/cloud/browser/playwright-puppeteer-selenium.mdx
+++ b/docs/cloud/browser/playwright-puppeteer-selenium.mdx
@@ -4,10 +4,6 @@ description: "Connect your automation framework to Browser Use's stealth infrast
 icon: code
 ---
 
-<Tip>
-  Prefer the SDK? See the [Agent docs](/cloud/agent/quickstart) — the SDK has all API endpoints available as methods, including `client.browsers.create()`.
-</Tip>
-
 ## Option 1: WebSocket URL (no SDK)
 
 Connect with a single URL. All configuration is passed as query parameters.


### PR DESCRIPTION
## Summary
- Update API reference page SDK callout to mention all endpoints are available as SDK methods
- Remove misplaced SDK tip from Playwright/Puppeteer/Selenium page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the SDK callout to the API reference and removed the misplaced tip from the Playwright/Puppeteer/Selenium page. The API reference now clearly states the SDK exposes all endpoints as methods (e.g., `client.browsers.create()`).

<sup>Written for commit 45bfc4bb8d80c439115512e5cb69cdea190d3966. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

