### PR TITLE
Add CTA to vibecoding page

### DIFF
--- a/docs/cloud/vibecoding.mdx
+++ b/docs/cloud/vibecoding.mdx
@@ -4,4 +4,8 @@ description: "Complete Cloud SDK reference for AI coding agents."
 icon: brain
 ---
 
-[docs.browser-use.com/cloud/llms.txt](https://docs.browser-use.com/cloud/llms.txt)
+Copy this link and paste it into your coding agent (Cursor, Claude Code, Windsurf, etc.) — it contains all the context needed to build with Browser Use.
+
+```
+https://docs.browser-use.com/cloud/llms.txt
+```


### PR DESCRIPTION
## Summary
- Replace bare link with a simple call to action: copy the llms.txt URL and paste it into your coding agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the plain link on the vibecoding page with a clear CTA instructing users to copy and paste https://docs.browser-use.com/cloud/llms.txt into their coding agent (Cursor, Claude Code, Windsurf, etc.). This clarifies the setup step and improves onboarding.

<sup>Written for commit fb5688752ebd895b2b4d91e0b99fedbf372a08c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

