### PR TITLE
Fix round 2 docs audit: n8n, webhooks, llms.txt, cross-linking

### DIFF
--- a/docs/cloud/agent/follow-up-tasks.mdx
+++ b/docs/cloud/agent/follow-up-tasks.mdx
@@ -44,3 +44,9 @@ const result2 = await client.run("Extract the customer reviews", {
 await client.sessions.stop(session.id);
 ```
 </CodeGroup>
+
+`sessions.create()` returns a `live_url` you can embed to watch each task execute — see [Live preview](/cloud/browser/live-preview). To stream messages as each task runs, use `client.run()` with `for await` — see [Live messages](/cloud/agent/streaming).
+
+<Note>
+  Sessions time out after 15 minutes of inactivity by default. The maximum session duration is 4 hours.
+</Note>

--- a/docs/cloud/agent/streaming.mdx
+++ b/docs/cloud/agent/streaming.mdx
@@ -96,3 +96,8 @@ while (true) {
 }
 ```
 </CodeGroup>
+
+## Related
+
+- [Live preview & recording](/cloud/browser/live-preview) — embed the browser alongside your message stream
+- [Follow-up tasks](/cloud/agent/follow-up-tasks) — chain multiple tasks in one session while streaming each

--- a/docs/cloud/agent/structured-output.mdx
+++ b/docs/cloud/agent/structured-output.mdx
@@ -6,6 +6,10 @@ icon: table
 
 Pass a Pydantic model (Python) or Zod schema (TypeScript) — `result.output` is automatically validated and converted to the typed object.
 
+<Note>
+  TypeScript requires **Zod v4** (`npm install zod@4`). Zod v3 is not compatible.
+</Note>
+
 <CodeGroup>
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse

--- a/docs/cloud/browser/live-preview.mdx
+++ b/docs/cloud/browser/live-preview.mdx
@@ -96,3 +96,8 @@ for (const url of urls) {
   Recording URLs are presigned and **expire after 1 hour**. Download or serve the recording promptly. If you need to access it later, save the MP4 to your own storage.
 </Warning>
 
+## Related
+
+- [Live messages](/cloud/agent/streaming) — stream the agent's messages alongside the live browser view
+- [Follow-up tasks](/cloud/agent/follow-up-tasks) — chain tasks in one session while watching live
+

--- a/docs/cloud/browser/playwright-puppeteer-selenium.mdx
+++ b/docs/cloud/browser/playwright-puppeteer-selenium.mdx
@@ -4,6 +4,8 @@ description: "Connect your automation framework to Browser Use's stealth infrast
 icon: code
 ---
 
+Every session runs in a [hardened Chromium fork](/cloud/browser/stealth) with stealth, anti-fingerprinting, and [residential proxies](/cloud/browser/proxies) enabled by default — no configuration needed.
+
 ## Option 1: WebSocket URL (no SDK)
 
 Connect with a single URL. All configuration is passed as query parameters.
@@ -79,7 +81,7 @@ await client.browsers.stop(browser.id)
 | `apiKey` | `string` | **Required.** Your Browser Use API key. |
 | `proxyCountryCode` | `string` | Proxy country code (e.g. `us`, `de`, `jp`). 195+ countries. |
 | `profileId` | `string` | Load a saved browser profile (cookies, localStorage). |
-| `timeout` | `int` | Session timeout in minutes. Max: 240 (4 hours). |
+| `timeout` | `int` | Session timeout in minutes. Default: 15. Max: 240 (4 hours). |
 | `browserScreenWidth` | `int` | Browser width in pixels. |
 | `browserScreenHeight` | `int` | Browser height in pixels. |
 

--- a/docs/cloud/guides/authentication.mdx
+++ b/docs/cloud/guides/authentication.mdx
@@ -11,7 +11,7 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 client = AsyncBrowserUse()
 profile = await client.profiles.create(name="user-id-1")
 # or search existing
-# profile = (await client.profiles.list(query="user-id-1"))[0]
+# profile = (await client.profiles.list(query="user-id-1")).items[0]
 session = await client.sessions.create(profile_id=profile.id)
 result = await client.run("Check browser-use github stars", session_id=session.id)
 print(result.output)
@@ -22,7 +22,7 @@ import { BrowserUse } from "browser-use-sdk/v3";
 const client = new BrowserUse();
 const profile = await client.profiles.create({ name: "user-id-1" });
 // or search existing
-// const profile = (await client.profiles.list({ query: "user-id-1" }))[0];
+// const profile = (await client.profiles.list({ query: "user-id-1" })).items[0];
 const session = await client.sessions.create({ profileId: profile.id });
 const result = await client.run("Check browser-use github stars", {
   sessionId: session.id,

--- a/docs/cloud/guides/webhooks.mdx
+++ b/docs/cloud/guides/webhooks.mdx
@@ -9,7 +9,7 @@ Set up webhooks at [cloud.browser-use.com/settings?tab=webhooks](https://cloud.b
 
 | Event | When |
 |-------|------|
-| `agent.task.status_update` | Task status changes (`started`, `finished`, or `stopped`) |
+| `agent.task.status_update` | Task status changes (`running`, `idle`, or `stopped`) |
 | `test` | Webhook test ping |
 
 ## Payload
@@ -21,7 +21,7 @@ Set up webhooks at [cloud.browser-use.com/settings?tab=webhooks](https://cloud.b
   "payload": {
     "task_id": "task_abc123",
     "session_id": "session_xyz",
-    "status": "finished",
+    "status": "idle",
     "metadata": {}
   }
 }

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -786,7 +786,7 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 client = AsyncBrowserUse()
 profile = await client.profiles.create(name="user-id-1")
 # or search existing
-# profile = (await client.profiles.list(query="user-id-1"))[0]
+# profile = (await client.profiles.list(query="user-id-1")).items[0]
 session = await client.sessions.create(profile_id=profile.id)
 result = await client.run("Check browser-use github stars", session_id=session.id)
 print(result.output)
@@ -797,7 +797,7 @@ import { BrowserUse } from "browser-use-sdk/v3";
 const client = new BrowserUse();
 const profile = await client.profiles.create({ name: "user-id-1" });
 // or search existing
-// const profile = (await client.profiles.list({ query: "user-id-1" }))[0];
+// const profile = (await client.profiles.list({ query: "user-id-1" })).items[0];
 const session = await client.sessions.create({ profileId: profile.id });
 const result = await client.run("Check browser-use github stars", {
   sessionId: session.id,
@@ -1076,7 +1076,7 @@ Set up webhooks at [cloud.browser-use.com/settings?tab=webhooks](https://cloud.b
 
 | Event | When |
 |-------|------|
-| `agent.task.status_update` | Task status changes (`started`, `finished`, or `stopped`) |
+| `agent.task.status_update` | Task status changes (`running`, `idle`, or `stopped`) |
 | `test` | Webhook test ping |
 
 ## Payload
@@ -1088,7 +1088,7 @@ Set up webhooks at [cloud.browser-use.com/settings?tab=webhooks](https://cloud.b
   "payload": {
     "task_id": "task_abc123",
     "session_id": "session_xyz",
-    "status": "finished",
+    "status": "idle",
     "metadata": {}
   }
 }
@@ -1299,14 +1299,7 @@ The final response contains `output` with the agent's result.
 
 ## Event-driven alternative
 
-Instead of polling, use [Webhooks](https://docs.browser-use.com/cloud/guides/webhooks) to receive a callback when the session completes. Add a Webhook trigger node in n8n and pass your webhook URL in the session creation body:
-
-```json
-{
-  "task": "Find the top 3 trending repos on GitHub today",
-  "webhook_url": "https://your-n8n-instance.com/webhook/browser-use"
-}
-```
+Instead of polling, use [Webhooks](https://docs.browser-use.com/cloud/guides/webhooks) to receive a callback when the session completes. Configure your webhook endpoint in the [dashboard](https://cloud.browser-use.com/settings?tab=webhooks), then add a **Webhook** trigger node in n8n to receive `agent.task.status_update` events when sessions finish.
 
   This pattern works with any workflow tool that supports HTTP requests — Make, Zapier, Pipedream, or custom orchestrators.
 

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -24,6 +24,27 @@ Set API key (starts with `bu_`):
 export BROWSER_USE_API_KEY=bu_your_key_here
 ```
 
+For the full reference with all code examples inline, fetch: https://docs.browser-use.com/cloud/llms-full.txt
+
+## Quick start
+
+`client.run()` is a high-level wrapper: it creates a session, polls every 2s until completion (up to 4 hours), and returns the result. The SDK also exposes every endpoint from the [API v3 Reference](https://docs.browser-use.com/cloud/api-reference) directly (e.g. `client.sessions.create()`, `client.sessions.get()`, `client.profiles.list()`). The pages below show common patterns; see the API reference for the full surface.
+
+```python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+result = await client.run("Go to example.com and get the page title")
+print(result.output)
+```
+
+```typescript
+import { BrowserUse } from "browser-use-sdk/v3";
+
+const client = new BrowserUse();
+const result = await client.run("Go to example.com and get the page title");
+console.log(result.output);
+```
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.

--- a/docs/cloud/tutorials/chat-ui.mdx
+++ b/docs/cloud/tutorials/chat-ui.mdx
@@ -28,7 +28,7 @@ export const client = new BrowserUse({ apiKey });
 ```
 
 <Note>
-  The API key uses `BROWSER_USE_API_KEY` (no `NEXT_PUBLIC_` prefix) so it stays server-side. All SDK calls go through [server actions](https://nextjs.org/docs/app/building-your-application/data-fetching/server-actions-and-mutations) — never call the SDK directly from client components.
+  The API key uses `BROWSER_USE_API_KEY` (no `NEXT_PUBLIC_` prefix) so it stays server-side. All SDK calls go through [server actions](https://nextjs.org/docs/app/guides/forms) — never call the SDK directly from client components.
 </Note>
 
 ---

--- a/docs/cloud/tutorials/integrations/n8n.mdx
+++ b/docs/cloud/tutorials/integrations/n8n.mdx
@@ -52,14 +52,7 @@ The final response contains `output` with the agent's result.
 
 ## Event-driven alternative
 
-Instead of polling, use [Webhooks](/cloud/guides/webhooks) to receive a callback when the session completes. Add a Webhook trigger node in n8n and pass your webhook URL in the session creation body:
-
-```json
-{
-  "task": "Find the top 3 trending repos on GitHub today",
-  "webhook_url": "https://your-n8n-instance.com/webhook/browser-use"
-}
-```
+Instead of polling, use [Webhooks](/cloud/guides/webhooks) to receive a callback when the session completes. Configure your webhook endpoint in the [dashboard](https://cloud.browser-use.com/settings?tab=webhooks), then add a **Webhook** trigger node in n8n to receive `agent.task.status_update` events when sessions finish.
 
 <Tip>
   This pattern works with any workflow tool that supports HTTP requests — Make, Zapier, Pipedream, or custom orchestrators.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -786,7 +786,7 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 client = AsyncBrowserUse()
 profile = await client.profiles.create(name="user-id-1")
 # or search existing
-# profile = (await client.profiles.list(query="user-id-1"))[0]
+# profile = (await client.profiles.list(query="user-id-1")).items[0]
 session = await client.sessions.create(profile_id=profile.id)
 result = await client.run("Check browser-use github stars", session_id=session.id)
 print(result.output)
@@ -797,7 +797,7 @@ import { BrowserUse } from "browser-use-sdk/v3";
 const client = new BrowserUse();
 const profile = await client.profiles.create({ name: "user-id-1" });
 // or search existing
-// const profile = (await client.profiles.list({ query: "user-id-1" }))[0];
+// const profile = (await client.profiles.list({ query: "user-id-1" })).items[0];
 const session = await client.sessions.create({ profileId: profile.id });
 const result = await client.run("Check browser-use github stars", {
   sessionId: session.id,
@@ -1076,7 +1076,7 @@ Set up webhooks at [cloud.browser-use.com/settings?tab=webhooks](https://cloud.b
 
 | Event | When |
 |-------|------|
-| `agent.task.status_update` | Task status changes (`started`, `finished`, or `stopped`) |
+| `agent.task.status_update` | Task status changes (`running`, `idle`, or `stopped`) |
 | `test` | Webhook test ping |
 
 ## Payload
@@ -1088,7 +1088,7 @@ Set up webhooks at [cloud.browser-use.com/settings?tab=webhooks](https://cloud.b
   "payload": {
     "task_id": "task_abc123",
     "session_id": "session_xyz",
-    "status": "finished",
+    "status": "idle",
     "metadata": {}
   }
 }
@@ -1299,14 +1299,7 @@ The final response contains `output` with the agent's result.
 
 ## Event-driven alternative
 
-Instead of polling, use [Webhooks](https://docs.browser-use.com/cloud/guides/webhooks) to receive a callback when the session completes. Add a Webhook trigger node in n8n and pass your webhook URL in the session creation body:
-
-```json
-{
-  "task": "Find the top 3 trending repos on GitHub today",
-  "webhook_url": "https://your-n8n-instance.com/webhook/browser-use"
-}
-```
+Instead of polling, use [Webhooks](https://docs.browser-use.com/cloud/guides/webhooks) to receive a callback when the session completes. Configure your webhook endpoint in the [dashboard](https://cloud.browser-use.com/settings?tab=webhooks), then add a **Webhook** trigger node in n8n to receive `agent.task.status_update` events when sessions finish.
 
   This pattern works with any workflow tool that supports HTTP requests — Make, Zapier, Pipedream, or custom orchestrators.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -24,6 +24,27 @@ Set API key (starts with `bu_`):
 export BROWSER_USE_API_KEY=bu_your_key_here
 ```
 
+For the full reference with all code examples inline, fetch: https://docs.browser-use.com/cloud/llms-full.txt
+
+## Quick start
+
+`client.run()` is a high-level wrapper: it creates a session, polls every 2s until completion (up to 4 hours), and returns the result. The SDK also exposes every endpoint from the [API v3 Reference](https://docs.browser-use.com/cloud/api-reference) directly (e.g. `client.sessions.create()`, `client.sessions.get()`, `client.profiles.list()`). The pages below show common patterns; see the API reference for the full surface.
+
+```python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+result = await client.run("Go to example.com and get the page title")
+print(result.output)
+```
+
+```typescript
+import { BrowserUse } from "browser-use-sdk/v3";
+
+const client = new BrowserUse();
+const result = await client.run("Go to example.com and get the page title");
+console.log(result.output);
+```
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.


### PR DESCRIPTION
## Summary
Round 2 of the docs audit. Fixes issues found by 12 test agents after the first PR (#86) was merged.

- **n8n**: Remove fake `webhook_url` param from session creation body — the API has no such field. Webhooks are configured in the dashboard, not per-request.
- **Webhooks**: Fix status `"finished"` → `"idle"` and `"started"` → `"running"` to match v3 `BuAgentSessionStatus` enum.
- **chat-ui.mdx**: Fix broken Next.js link (old server-actions URL → `/docs/app/guides/forms`).
- **authentication.mdx**: Fix remaining profiles.list() comment `[0]` → `.items[0]`.
- **structured-output.mdx**: Add Zod v4 requirement note (Zod v3 crashes with opaque error).
- **llms.txt**: Add inline quick-start code examples (Python + TS), explain that `client.run()` is a wrapper around `sessions.create` + polling, note that SDK exposes all API endpoints, link to llms-full.txt.
- **Cross-linking**: Add "Related" sections connecting live preview ↔ streaming ↔ follow-up tasks.
- **Playwright page**: Add stealth/proxy mention at top, document default timeout (15 min).
- **follow-up-tasks.mdx**: Add session timeout note (15 min idle, 4h max).
- Sync all fixes to both `llms-full.txt` files.

## Test plan
- [x] All changes are docs-only (no SDK code changes)
- [ ] Verify Mintlify preview renders correctly
- [ ] Spot-check cross-links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Round 2 of the docs audit plus small SDK fixes. Aligns docs and SDK with the v3 API, improves quick starts and cross-linking, and fixes webhook statuses, session creation, and profiles search.

- **Bug Fixes**
  - TypeScript SDK: `sessions.create()` now posts `{}` when called with no args to ensure a valid JSON body.
  - Python SDK: add explicit `custom_proxy` param to `sessions.create()`, `run()`, and streaming; maps to `customProxy`.
  - TS + Python SDK: `profiles.list()` now accepts `query`; examples updated to use paginated `.items`.
  - Webhooks/n8n docs: correct statuses to `running`/`idle`; remove non-existent `webhook_url`; point setup to dashboard.
  - Docs: fix broken Next.js link, add `zod@4` note, document 15-minute default session timeout, mention stealth/proxies, add cross-links (live preview ↔ streaming ↔ follow-ups), note `live_url` in follow-ups, add LLM quick starts and link to `llms-full.txt`, and sync fixes across both `llms-full.txt` copies.

- **Migration**
  - TypeScript structured output requires `zod@4`.
  - Update any code using `profiles.list()` or `workspaces.list()` as arrays to read from `.items`.
  - If consuming webhook statuses, expect `running`/`idle` (not `started`/`finished`).

<sup>Written for commit 672a2d80bdf7ffb0d78a8c2ec1d6ea80018ae2bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

