### PR TITLE
Move Agent vs Browser table to quickstart, improve columns

### DIFF
--- a/docs/cloud/agent/quickstart.mdx
+++ b/docs/cloud/agent/quickstart.mdx
@@ -43,18 +43,3 @@ curl -X POST https://api.browser-use.com/api/v3/sessions \
 
 The best SOTA browser agent — see our [online Mind2Web benchmark](https://browser-use.com/posts/online-mind2web-benchmark).
 
-## Agent vs Browser
-
-| | `client.run()` | `client.browsers.create()` |
-|---|---|---|
-| **What it does** | Run an AI agent task | Just give me a browser |
-| **Best for** | Most users | [Playwright / Puppeteer / Selenium](/cloud/browser/playwright-puppeteer-selenium) |
-| proxy | ✓ | ✓ |
-| custom_proxy | ✓ | ✓ |
-| profile_id | ✓ | ✓ |
-| recording | ✓ | ✓ |
-| workspace_id | ✓ | — |
-| keep_alive | ✓ | — |
-| screen size | — | ✓ |
-| timeout | — | ✓ |
-| task / model | ✓ | — |

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -47,3 +47,21 @@ console.log(result.output);
 <Note>
   Want a full working app? See the [Chat UI example](/cloud/tutorials/chat-ui) — a complete Next.js app with live browser preview, streaming messages, authentication, and session management.
 </Note>
+
+## Agent vs Browser
+
+`client.run()` / `client.sessions.create()` run an AI agent task. `run()` is a wrapper around `sessions.create()` that polls until the task is done and returns the result. `client.browsers.create()` gives you a raw browser for [Playwright / Puppeteer / Selenium](/cloud/browser/playwright-puppeteer-selenium).
+
+| | `client.run()` / `client.sessions.create()` | `client.browsers.create()` |
+|---|---|---|
+| **What it does** | Run an AI agent task (run polls until done) | Just give me a browser |
+| task | ✓ | — |
+| model | ✓ | — |
+| proxy | ✓ | ✓ |
+| custom_proxy | ✓ | ✓ |
+| profile_id | ✓ | ✓ |
+| recording | ✓ | ✓ |
+| workspace_id | ✓ | — |
+| keep_alive | ✓ | — |
+| screen size | — | ✓ |
+| timeout | — | ✓ |


### PR DESCRIPTION
## Summary
- Move Agent vs Browser table from agent/quickstart to the main quickstart page
- Show `client.run()` / `client.sessions.create()` together, explain run() is a polling wrapper
- Split task and model into separate rows, move to first position
- Remove "Best for" column

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the Agent vs Browser comparison to the main quickstart and clarifies API usage by pairing `client.run()` with `client.sessions.create()` (with `run()` explained as a polling wrapper). The table now splits task and model into separate first rows, removes the "Best for" column, and tightens column order.

<sup>Written for commit 6959e26f31fd1cd7747600e545cf6bafa04edff2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

