### PR TITLE
Fix table wording: sessions.create first, run as wrapper

### DIFF
--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -50,11 +50,11 @@ console.log(result.output);
 
 ## Agent vs Browser
 
-`client.run()` / `client.sessions.create()` run an AI agent task. `run()` is a wrapper around `sessions.create()` that polls until the task is done and returns the result. `client.browsers.create()` gives you a raw browser for [Playwright / Puppeteer / Selenium](/cloud/browser/playwright-puppeteer-selenium).
+`client.sessions.create()` creates an AI agent session. `client.run()` wraps `sessions.create()` and polls until done. `client.browsers.create()` gives you a raw browser for [Playwright / Puppeteer / Selenium](/cloud/browser/playwright-puppeteer-selenium).
 
-| | `client.run()` / `client.sessions.create()` | `client.browsers.create()` |
+| | `client.sessions.create()` / `client.run()` (wraps create and polls until done) | `client.browsers.create()` |
 |---|---|---|
-| **What it does** | Run an AI agent task (run polls until done) | Just give me a browser |
+| **What it does** | Run an AI agent task | Just give me a browser |
 | task | ✓ | — |
 | model | ✓ | — |
 | proxy | ✓ | ✓ |


### PR DESCRIPTION
## Summary
- Put `client.sessions.create()` first in the table header
- `client.run()` shown second with "(wraps create and polls until done)"
- Move polling explanation from "What it does" row into the column title

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the Agent vs Browser quickstart by listing `client.sessions.create()` first and moving the polling explanation to the column title. Simplifies the "What it does" row and makes it clear that `client.run()` wraps `sessions.create()`.

<sup>Written for commit 63ee5e397b2df38f25d5a938808ecf9c13edeebb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

