### PR TITLE
Add browsers.create examples to live preview & recording docs

### DIFF
--- a/docs/cloud/browser/live-preview.mdx
+++ b/docs/cloud/browser/live-preview.mdx
@@ -29,6 +29,19 @@ console.log(session.liveUrl);
 ```
 </CodeGroup>
 
+`liveUrl` is also returned when creating a standalone browser session:
+
+<CodeGroup>
+```python Python
+browser = await client.browsers.create()
+print(browser.live_url)
+```
+```typescript TypeScript
+const browser = await client.browsers.create();
+console.log(browser.liveUrl);
+```
+</CodeGroup>
+
 ## Embed live browser into your app
 
 Useful for human interaction or to see live what's happening.
@@ -89,6 +102,23 @@ const urls = await client.sessions.waitForRecording(result.id);
 for (const url of urls) {
   console.log(url); // presigned MP4 download URL
 }
+```
+</CodeGroup>
+
+For standalone browser sessions, pass `enable_recording` when creating the browser and retrieve the URL after stopping it:
+
+<CodeGroup>
+```python Python
+browser = await client.browsers.create(enable_recording=True)
+# ... use the browser via CDP ...
+stopped = await client.browsers.stop(browser.id)
+print(stopped.recording_url)  # presigned MP4 download URL
+```
+```typescript TypeScript
+const browser = await client.browsers.create({ enableRecording: true });
+// ... use the browser via CDP ...
+const stopped = await client.browsers.stop(browser.id);
+console.log(stopped.recordingUrl); // presigned MP4 download URL
 ```
 </CodeGroup>
 

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -50,8 +50,6 @@ console.log(result.output);
 
 ## Agent vs Browser
 
-`client.sessions.create()` creates an AI agent session. `client.run()` wraps `sessions.create()` and polls until done. `client.browsers.create()` gives you a raw browser for [Playwright / Puppeteer / Selenium](/cloud/browser/playwright-puppeteer-selenium).
-
 | | `client.sessions.create()` / `client.run()` (wraps create and polls until done) | `client.browsers.create()` |
 |---|---|---|
 | **What it does** | Run an AI agent task | Just give me a browser |


### PR DESCRIPTION
## Summary
- Added `browsers.create` example for `liveUrl` in the live preview section
- Added `browsers.create` with `enableRecording` example in the recording section, showing how to retrieve the recording URL after stopping the browser

## Test plan
- [ ] Verify Mintlify renders the new CodeGroup blocks correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `browsers.create` examples to live preview and recording docs for standalone browser sessions. Shows how to read `liveUrl` on create and retrieve a presigned `recordingUrl` after stop in Python and TypeScript, and removes a redundant paragraph above the “Agent vs Browser” table in Quickstart.

<sup>Written for commit 1725fac37b051785f4ba07b0a4aaaa4914452232. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

