### PR TITLE
Fix docs audit: wrong auth header, broken links, updated report

### DIFF
--- a/docs-audit-report.md
+++ b/docs-audit-report.md
@@ -1,183 +1,261 @@
-# Browser Use Cloud SDK Documentation — Full Audit Report
+# Browser Use Docs Audit Report
 
-**Date**: 2026-03-29
-**Audited by**: 6 parallel agents testing every section, API endpoint, and LLM readability
+**Date:** 2026-03-30
+**Method:** 14 autonomous agents testing docs from different personas, code snippets, API types, links, llms.txt, and e2e flows.
+**Previous audit:** 2026-03-29 (6 agents, 47 issues). This audit is more comprehensive.
 
 ---
 
 ## Executive Summary
 
-- **All API endpoints work** — zero failures across 76+ API calls
-- **Core DX is good** — 3-line quickstart, clean SDK, $0.04 for a real task
-- **47 issues found** across docs, API spec, and LLM readability
-- **Top 3 systemic problems**: no REST/curl examples, undocumented session lifecycle, v2/v3 import confusion
+| Area | Score | Status |
+|------|-------|--------|
+| **Overall Docs Quality** | **6.2/10** | Good foundation, significant gaps |
+| **Code Snippets (Python)** | **9.5/10** | 49/49 syntax pass, 1 SDK publish issue |
+| **Code Snippets (TypeScript)** | **7.7/10** | 34/44 pass, 4 SDK type bugs, 3 doc bugs |
+| **API Reference** | **5/10** | Wrong auth header (critical), many missing descriptions |
+| **llms.txt** | **7.5/10** | Good structure, needs less marketing, more params |
+| **Broken Links** | **3 found** | 1 internal, 2 external (dead GitHub repos) |
+| **Chat UI Example** | **4/10** | BLOCKER: published SDK missing asyncIterator |
 
 ---
 
-## CRITICAL Issues (fix immediately)
+## BLOCKERS (Fix Before Anything Else)
 
-### 1. `maxCostUsd` defaults to $20 — UNDOCUMENTED
-Every session defaults to a $20 cost cap. A developer could accidentally spend $20 on a single task without knowing. Must be documented prominently.
+### 1. Published npm SDK (v3.3.1) missing `Symbol.asyncIterator`
+- **Impact:** `for await (const msg of run)` throws "run is not async iterable"
+- **Affects:** Chat UI example, streaming docs, every persona that tried streaming
+- **Root cause:** Local source has it (`helpers.ts:102`), but published dist is an older build (207 lines vs 451)
+- **Fix:** Republish npm package from current source
+- **Found by:** Chat UI tester, Automation persona, Embedder persona
 
-### 2. POST /sessions returns 201, OpenAPI spec says 200
-Code generators and SDK validation will break. Fix the spec.
+### 2. Published PyPI SDK (v3.3.1) missing v3 resources
+- **Impact:** `client.browsers`, `client.profiles`, `client.billing` don't exist on published package
+- **Affects:** Proxies docs, Playwright integration, profile/auth docs
+- **Root cause:** Local source has all 5 resources, published package only has `sessions` + `workspaces`
+- **Fix:** Republish PyPI package from current source
+- **Found by:** Python snippets tester
 
-### 3. Python streaming example has a bug
-`sessions.create("task")` should be `sessions.create(task="task")` — string positional arg doesn't match the API.
-
-### 4. Secrets page has two conflicting formats
-- Example 1: `{"github.com": "username:password123"}` (domain-keyed)
-- Example 2: `{"username": "user@company.com", "password": "password123"}` (field-keyed)
-Which is correct? Both? Completely confusing.
-
-### 5. n8n integration references deprecated v2 endpoints
-Uses `/api/v2/tasks` — must be updated to v3 sessions API.
-
----
-
-## HIGH Issues
-
-### Documentation Gaps
-
-| # | Issue | Location |
-|---|-------|----------|
-| 6 | No REST/curl examples anywhere — every page is SDK-only | All pages |
-| 7 | No v3 parameter reference table (run() params scattered across pages) | Agent section |
-| 8 | No v3 model/pricing table (bu-mini, bu-max — no costs, no tradeoffs) | Missing entirely |
-| 9 | No session lifecycle documentation (statuses, timeouts, transitions) | Missing entirely |
-| 10 | No error handling examples anywhere | Missing entirely |
-| 11 | Auth header `X-Browser-Use-API-Key` never mentioned in docs (only in OpenAPI spec) | API reference, all pages |
-| 12 | Agent introduction is near-duplicate of quickstart — adds nothing new | agent/quickstart.mdx |
-| 13 | `agentmailEmail` field in every session response — never documented | Missing |
-| 14 | Browser stop REST endpoint undocumented (SDK has it, REST doesn't) | browser docs |
-| 15 | Stealth page rated 5/10 — core value prop reads like bullet-point teaser | browser/stealth.mdx |
-| 16 | FAQ has 4 broken anchor links | faq.mdx |
-| 17 | Webhooks doc doesn't explain where to get the signing secret | webhooks.mdx |
-
-### API Spec Issues
-
-| # | Issue | Location |
-|---|-------|----------|
-| 18 | RunTaskRequest: zero field descriptions (task, model, sessionId, etc.) | v3.json |
-| 19 | SessionResponse: zero field descriptions | v3.json |
-| 20 | GET /workspaces/{id}/size response schema is empty `{}` | v3.json |
-| 21 | 401 error responses not documented in spec | v3.json |
-| 22 | Three different pagination styles across endpoints | v3.json |
-| 23 | Messages pagination: `hasMore` is misleading (means "older messages exist", not "newer") | v3.json |
-| 24 | Session files tagged as "Files" not "Sessions" — splits sidebar | v3.json |
-
-### Code Issues
-
-| # | Issue | Location |
-|---|-------|----------|
-| 25 | TypeScript profiles example has duplicate `const profile` declaration | authentication.mdx |
-| 26 | CDP URL comment says `ws://` but API returns `https://` | playwright.mdx |
-| 27 | `str(session.id)` vs `session.id` inconsistency across pages | Multiple |
-| 28 | `output_schema` (Python) vs `schema` (TypeScript) naming not explained | structured-output.mdx |
+### 3. `api-reference.mdx` uses wrong auth header
+- **Impact:** Every curl example on the hand-written API reference page fails
+- **Current (wrong):** `Authorization: Bearer bu_your_key_here`
+- **Correct:** `X-Browser-Use-API-Key: bu_your_key_here`
+- **Note:** Auto-generated Mintlify API pages are correct; only the hand-written overview is wrong
+- **Found by:** API types checker
 
 ---
 
-## MEDIUM Issues
+## Code Snippet Audit
 
-| # | Issue | Location |
-|---|-------|----------|
-| 29 | MCP Server missing VS Code and Cline client configs | mcp-server.mdx |
-| 30 | Chat UI uses v2 import for profiles — may be outdated | chat-ui.mdx |
-| 31 | Chat UI says "streaming" but implementation is polling | chat-ui.mdx |
-| 32 | Playwright/Puppeteer under Authentication grouping in llms.txt | llms.txt |
-| 33 | Structured output example uses LinkedIn (requires auth) — bad test example | structured-output.mdx |
-| 34 | No mention of message types (browser_action, completion_result, etc.) | streaming.mdx |
-| 35 | `screenshotUrl` in messages — undocumented but valuable for UIs | streaming.mdx |
-| 36 | Profile sync pipes remote script to shell — no security note | profile-sync.mdx |
-| 37 | 1Password URL points to EU domain only (`my.1password.eu`) | 1password.mdx |
-| 38 | No mention of recording cost or URL expiration | live-preview.mdx |
-| 39 | No connection limits documented for concurrent browsers | playwright.mdx |
-| 40 | Vibecoding page is essentially empty (just a link) | vibecoding.mdx |
-| 41 | OpenClaw integration is very long relative to importance in llms-full.txt | llms-full.txt |
-| 42 | `DELETE /sessions` is soft delete — still accessible after | API behavior |
+### Python (49 snippets tested)
+- **49/49 syntax pass** (100%)
+- **9/11 live tests pass** (2 failures were test setup issues, not doc bugs)
+- **1 warning:** `browsers.create(custom_proxy=...)` sends snake_case key via `**extra` instead of camelCase `customProxy`. Need to add `custom_proxy` as explicit parameter.
+
+### TypeScript (44 snippets tested)
+- **34/44 pass** (77%)
+- **4 SDK type bugs:** `browsers.create()` requires `timeout`, `allowResizing`, `enableRecording` as required fields (they have API defaults, should be optional in types)
+- **3 doc bugs (wrong property names):**
+  - `legacy/agent.mdx`: `upload.presignedUrl` → should be `upload.url`
+  - `legacy/agent.mdx`: `output.presignedUrl` → should be `output.downloadUrl`
+  - `legacy/public-share.mdx`: `share.url` → should be `share.shareUrl`
+- **1 null-safety issue:** `streaming.mdx`: `run.result.output` → should be `run.result!.output` or `run.result?.output`
+- **2 expected failures:** External deps (playwright, puppeteer-core) not installed
 
 ---
 
-## LOW Issues
+## Broken Links
 
-| # | Issue | Location |
-|---|-------|----------|
-| 43 | Title "Introduction Stealth" reads awkwardly | stealth.mdx |
-| 44 | `POST /sessions` requires `{}` body even when empty | API behavior |
-| 45 | Double redirects (e.g., `/examples` → tips → agent) | docs.json |
-| 46 | FAQ uses redirect-based `/cloud/pricing` links | faq.mdx |
-| 47 | n8n doc too thin to be useful | n8n.mdx |
+| Type | File | Link | Issue |
+|------|------|------|-------|
+| Internal | `cloud/browser/proxies.mdx:7` | `/cloud/api-v3/browsers/create-browser` | 404 — correct: `/cloud/api-v3/browsers/create-browser-session` |
+| External | `open-source/browser-use-cli.mdx:274` | `github.com/browser-use/profile-use` | Repo doesn't exist |
+| External | `open-source/customize/integrations/mcp-server.mdx:240` | `github.com/browser-use/browser-use/tree/main/examples/mcp` | Directory doesn't exist |
 
 ---
 
-## LLM Readability (llms.txt / llms-full.txt)
+## API Reference Discrepancies
 
-### What's good
-- Grouped sections matching nav structure
-- Install commands + API key link at top
-- Benchmark links for positioning
-
-### What's missing
-- No v3 parameter reference table (highest-value addition)
-- No error handling patterns
-- No sub-agent integration pattern (top ICP use case)
-- Benchmark numbers not inlined (LLMs can't click links)
-- Missing keywords: "web scraping", "headless browser", "data extraction API"
-- No competitor differentiation (vs Browserbase, Playwright, Selenium)
-- `<CodeGroup>`, `<Note>` Mintlify tags remain as noise in plain text
-
-### Recommendations
-1. Add v3 parameter table with all run() options
-2. Add "Using Browser Use as a Sub-Agent" section (10-line pattern)
-3. Inline benchmark scores instead of just linking
-4. Add "Why Browser Use" section with differentiators
-5. Trim OpenClaw details and duplicate API key sections to save tokens
+| # | Severity | Issue |
+|---|----------|-------|
+| 1 | **Critical** | Auth header wrong in `api-reference.mdx` (see Blockers) |
+| 2 | Should fix | `RunTaskRequest` — 13 fields have no description in OpenAPI spec |
+| 3 | Should fix | `SessionResponse` — all fields missing descriptions (titles are just camelCase names) |
+| 4 | Should fix | `GET /workspaces/{id}/size` — response schema is `{}` (empty) |
+| 5 | Should fix | Default `maxCostUsd` of $20 is undocumented |
+| 6 | Nice to have | `totalInputTokens`/`totalOutputTokens` meaning unclear |
+| 7 | Nice to have | `agentmailEmail` returned by default but not explained |
+| 8 | Nice to have | `output` field typed as "any" in spec but rendered as "object" in docs |
 
 ---
 
-## Test Results
+## Persona Scorecard
 
-### Sub-agent Integration Test
-- **27 API calls** for workspace + task + download flow
-- **62 seconds** end-to-end
-- **$0.04** total cost
-- **Zero errors**
-- Agent correctly extracted data and saved structured JSON to workspace
-- Recording returned valid MP4 URL
-- Live URL appeared within 6 seconds
+### Persona 1: AI Automation Startup ("just run tasks fast")
+| Metric | Score |
+|--------|-------|
+| Intuitiveness | 7/10 |
+| Time-to-value | 8/10 |
+| Completeness | 5/10 |
 
-### API Endpoint Test (all v3)
-- **All 22 endpoints tested** — all work
-- **Profiles**: create, list, search, get, update, delete — all work
-- **Workspaces**: create, upload, list files, download, size, delete — all work
-- **Browsers**: create, list, get, stop — all work
-- **Sessions**: create, get, messages, files, stop, delete — all work
-- **Billing**: account info works
+**Journey:** 4 pages to first successful task. `client.run()` is genuinely simple.
+**Friction:** Two quickstart pages confuse; streaming broken; no pricing/cost info; no error handling examples.
+**Key ask:** Consolidate quickstarts, add pricing section, fix streaming.
+
+### Persona 2: Enterprise User
+| Metric | Score |
+|--------|-------|
+| Security docs | 4/10 |
+| Enterprise readiness | 3/10 |
+| Clarity | 6/10 |
+
+**Gaps (critical for enterprise):**
+- No compliance page (SOC 2, GDPR, data residency)
+- No data retention/deletion policy
+- No API key scoping, rotation, or RBAC
+- No audit logging
+- No SLA documentation
+- `curl | sh` profile sync is a red flag
+- Auth story fragmented across 4 pages with no unifying guide
+
+### Persona 3: Sub-agent Embedder (live browser in app)
+| Metric | Score |
+|--------|-------|
+| Embed docs | 6/10 |
+| Streaming docs | 3/10 |
+| Overall flow | 5/10 |
+
+**Friction:** Must read 4 pages to assemble the embed pattern. `liveUrl` is null from simple `run()` — not documented. Streaming broken in published SDK.
+**Key ask:** Add "Embed in Your App" recipe page showing full flow in one place.
+
+### Persona 4: QA Tester
+| Metric | Score |
+|--------|-------|
+| QA docs | 4/10 |
+| Playwright integration | 8/10 |
+| Clarity | 6/10 |
+
+**Friction:** No dedicated QA/testing guide. No CI/CD examples. No screenshot example on Playwright page. No parallel session guidance.
+**Key ask:** Add a "Testing & QA" guide page with pytest/Jest fixtures, CI/CD patterns, visual regression.
+
+### Persona 5: Data Extraction at Scale
+| Metric | Score |
+|--------|-------|
+| Extraction docs | 4/10 |
+| Structured output | 6/10 |
+| Proxy docs | 4/10 |
+
+**Friction:** No dedicated extraction guide. No concurrency/parallel execution docs. No pagination guidance. No cost estimation. No complex schema examples.
+**Key ask:** Add "Data Extraction at Scale" guide with parallel patterns, pagination, proxy rotation.
 
 ---
 
-## Priority Action Items
+## llms.txt Evaluation
 
-### P0 (This week)
-1. Document `maxCostUsd` default of $20 with a warning
-2. Fix OpenAPI spec: POST /sessions → 201
-3. Fix Python streaming bug
-4. Fix secrets page format confusion
-5. Update n8n to v3
+**Score: 7.5/10**
 
-### P1 (Next sprint)
-6. Add curl/REST examples to quickstart + key pages
-7. Add v3 parameter reference table
-8. Add session lifecycle documentation
-9. Add field descriptions to OpenAPI spec (RunTaskRequest, SessionResponse)
-10. Fix FAQ broken anchor links
-11. Expand stealth page significantly
+**What's good:**
+- Strong structure, clear hierarchy
+- Inline code for quick start (most llms.txt files don't do this)
+- v3 callout prevents outdated code generation
+- Pointer to llms-full.txt
 
-### P2 (Backlog)
-12. Add error handling examples
-13. Add sub-agent integration pattern
-14. Add model/pricing table
-15. Standardize pagination in API
-16. Document agentmailEmail
-17. Add VS Code/Cline to MCP server
-18. Inline benchmark scores in llms.txt
+**What to improve:**
+1. Blockquote is too marketing-heavy ("most SOTA", "most scalable") — LLMs need facts, not persuasion
+2. Duplicate GitHub link (lines 5 and 8)
+3. No `## Optional` section for legacy/v2 content (per llmstxt.org spec)
+4. Top-level links are unstructured — should be under `## Resources`
+5. No size hint for llms-full.txt (~60KB)
+6. Links point to HTML pages, not `.md` variants (if Mintlify supports them)
+7. Missing key parameters list for `client.run()`
+
+**llms.txt navigation test (can AI build from it alone?):**
+- llms.txt navigability: **8/10** — great sitemap, but not enough to write code beyond basics
+- llms-full.txt completeness: **7/10** — good but has zod v4 omission and wrong `client.profiles` examples for TS
+
+---
+
+## Chat UI Example
+
+**Score: 4/10**
+
+**BLOCKER:** Published SDK doesn't have `Symbol.asyncIterator`, so `npm run build` fails with:
+```
+Type 'SessionRun<string>' must have a '[Symbol.asyncIterator]()' method
+```
+
+**Other issues:**
+- Docs page has ZERO setup commands (no `git clone`, `npm install`, `npm run dev`)
+- It's a conceptual guide, not a tutorial — setup instructions only exist in the GitHub repo README
+- Should at minimum include quick-start commands on the docs page
+
+---
+
+## File Upload/Download
+
+**Score: Docs 6/10, Functionality 8/10**
+
+**What works:** All file types upload/download correctly. Round-trip integrity confirmed. Agent can read uploaded files and write new ones.
+
+**What's missing from docs:**
+- File size limits
+- Supported file types (SDK supports 20+ MIME types, undocumented)
+- `prefix` parameter for organizing files
+- `delete_file()` method
+- `size()` endpoint
+- Workspace lifecycle/persistence
+- Agent leaves cache artifacts in workspace (undocumented)
+
+---
+
+## Profile System
+
+**Score: Docs 7/10, API 8/10, SDK 9/10**
+
+**Key issue:** Main profiles doc is `authentication.mdx` at URL `/guides/authentication` under sidebar group "Authentication". A user searching for "profiles" won't find it easily.
+
+**Missing:**
+- No explanation of what a profile actually stores
+- `user_id` field is undocumented
+- No curl/raw API examples
+- Warning about `sessions.stop()` saving profile state is buried at bottom
+
+---
+
+## Top 10 Recommendations (Priority Order)
+
+### Must Fix Now
+1. **Republish npm package** — include `Symbol.asyncIterator` in v3 dist
+2. **Republish PyPI package** — include `browsers`, `profiles`, `billing` resources in v3
+3. **Fix auth header in `api-reference.mdx`** — change `Authorization: Bearer` to `X-Browser-Use-API-Key`
+4. **Fix 3 broken links** (proxies internal link, 2 dead GitHub repos)
+
+### Should Fix Soon
+5. **Fix TS doc bugs** — wrong property names in legacy docs (`presignedUrl` → `url`/`downloadUrl`, `share.url` → `share.shareUrl`)
+6. **Fix SDK types** — make `CreateBrowserSessionRequest` fields with defaults optional; add `custom_proxy` as explicit param to Python `browsers.create()`
+7. **Add setup commands to chat-ui tutorial page** (clone, install, env, run)
+
+### Should Add (New Content)
+8. **"Embed in Your App" recipe page** — single page showing full embed flow
+9. **"Data Extraction at Scale" guide** — parallel patterns, pagination, complex schemas
+10. **"Testing & QA" guide** — pytest/Jest fixtures, CI/CD, screenshots, parallel sessions
+
+### Nice to Have
+- Consolidate two quickstart pages into one
+- Add OpenAPI field descriptions for RunTaskRequest and SessionResponse
+- Add `## Optional` section to llms.txt for legacy content
+- Rewrite llms.txt blockquote to be factual, not marketing
+- Add pricing/cost section to docs
+- Add error handling examples
+- Document `maxCostUsd` default of $20
+- Document workspace lifecycle and file size limits
+- Rename `authentication.mdx` → `profiles.mdx` (or add "Profiles" to sidebar title)
+- Add unified "Authentication Architecture" page for enterprise users
+- Add compliance/security page for enterprise evaluation
+- Document concurrency limits and parallel execution patterns
+- Add zod v4 requirement note to structured output docs
+
+---
+
+*Report generated by 14 autonomous agents testing docs from different angles.*
+*Full path: `/Users/magnus/.superset/worktrees/sdk/magnus/citrine-function/docs-audit-report.md`*

--- a/docs/cloud/api-reference.mdx
+++ b/docs/cloud/api-reference.mdx
@@ -7,10 +7,10 @@ mode: wide
 
 ## Authentication
 
-All requests require an API key in the `Authorization` header:
+All requests require an API key in the `X-Browser-Use-API-Key` header:
 
 ```
-Authorization: Bearer bu_your_key_here
+X-Browser-Use-API-Key: bu_your_key_here
 ```
 
 Get a key at [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1). Keys start with `bu_`.
@@ -26,13 +26,13 @@ https://api.browser-use.com/api/v3
 ```bash curl
 # Create a session
 curl -X POST https://api.browser-use.com/api/v3/sessions \
-  -H "Authorization: Bearer bu_your_key_here" \
+  -H "X-Browser-Use-API-Key: bu_your_key_here" \
   -H "Content-Type: application/json" \
   -d '{"task": "Find the top 3 trending repos on GitHub today"}'
 
 # Get session result (replace SESSION_ID)
 curl https://api.browser-use.com/api/v3/sessions/SESSION_ID \
-  -H "Authorization: Bearer bu_your_key_here"
+  -H "X-Browser-Use-API-Key: bu_your_key_here"
 ```
 
 ## Environment variable

--- a/docs/cloud/browser/proxies.mdx
+++ b/docs/cloud/browser/proxies.mdx
@@ -4,7 +4,7 @@ description: "Residential proxies in 195+ countries. On by default."
 icon: globe
 ---
 
-A US residential proxy is active by default on every browser. To route through a different country, set `proxy_country_code`. See the [API reference](/cloud/api-v3/browsers/create-browser) for all supported country codes.
+A US residential proxy is active by default on every browser. To route through a different country, set `proxy_country_code`. See the [API reference](/cloud/api-v3/browsers/create-browser-session) for all supported country codes.
 
 <CodeGroup>
 ```python Python

--- a/docs/open-source/browser-use-cli.mdx
+++ b/docs/open-source/browser-use-cli.mdx
@@ -271,7 +271,7 @@ browser-use open https://abc.trycloudflare.com
 
 ## Profile Management
 
-The `profile` subcommand delegates to the [profile-use](https://github.com/browser-use/profile-use) Go binary, which syncs local browser cookies to Browser-Use cloud.
+The `profile` subcommand delegates to the [profile-use](https://github.com/browser-use/browser-use-cli) Go binary, which syncs local browser cookies to Browser-Use cloud.
 
 The binary is managed at `~/.browser-use/bin/profile-use` and auto-downloaded on first use.
 

--- a/docs/open-source/customize/integrations/mcp-server.mdx
+++ b/docs/open-source/customize/integrations/mcp-server.mdx
@@ -237,6 +237,6 @@ uvx --from 'browser-use[cli]' browser-use --mcp
 
 ## Next Steps
 
-- Explore the [examples directory](https://github.com/browser-use/browser-use/tree/main/examples/mcp) for more usage patterns
+- Explore the [examples directory](https://github.com/browser-use/browser-use/tree/main/examples) for more usage patterns
 - Check out [MCP documentation](https://modelcontextprotocol.io/) to learn more about the protocol
 - Join our [Discord](https://link.browser-use.com/discord) for support and discussions


### PR DESCRIPTION
- Fix api-reference.mdx: Authorization: Bearer → X-Browser-Use-API-Key
- Fix proxies.mdx: internal link to correct /create-browser-session path
- Fix browser-use-cli.mdx: dead profile-use repo → browser-use-cli
- Fix mcp-server.mdx: dead examples/mcp link → examples
- Update audit report with 14-agent comprehensive results

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Cloud API docs to use the correct auth header and repairs three broken links; also updates the docs audit report with results from a 14-agent run.

- **Bug Fixes**
  - `api-reference.mdx`: switch auth header to `X-Browser-Use-API-Key` in text and curl examples.
  - `proxies.mdx`: fix internal link to `/cloud/api-v3/browsers/create-browser-session`.
  - `browser-use-cli.mdx`: update dead `profile-use` link to the `browser-use-cli` repo.
  - `mcp-server.mdx`: point examples link to `/examples` instead of non-existent `/examples/mcp`.

<sup>Written for commit ea40d7358a0b3a2b9a124fd31b467354df0dc70c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

