### PR TITLE
Magnus/2fa guide

### DIFF
--- a/docs/cloud/guides/2fa.mdx
+++ b/docs/cloud/guides/2fa.mdx
@@ -1,0 +1,292 @@
+---
+title: 2FA
+description: "Best practices for handling two-factor authentication in automated browser sessions."
+icon: shield-halved
+---
+
+Sites with 2FA block automated logins. Here are five approaches — pick the one that fits your setup.
+
+| Approach | Best for | Complexity |
+|---|---|---|
+| [Profiles (login once)](#1-profiles--login-once-reuse-cookies) | Sites with long-lived cookies | Lowest |
+| [Human in the loop](#2-human-in-the-loop) | One-off tasks, complex auth flows | Low |
+| [Agent Mail](#3-agent-mail) | Email-based 2FA, end-client automation | Medium |
+| [TOTP secret in prompt](#4-totp-secret-in-prompt) | Authenticator app 2FA (Google Authenticator, Authy) | Medium |
+| [1Password integration](#5-1password-integration) | Teams already using 1Password | Medium |
+
+---
+
+## 1. Profiles — login once, reuse cookies
+
+Login manually once (or let the agent do it), then save the browser state as a profile. Future sessions reuse the cookies — no 2FA prompt as long as the cookies are valid.
+
+<CodeGroup>
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+
+# Create a profile and a session
+profile = await client.profiles.create(name="my-account")
+session = await client.sessions.create(profile_id=profile.id)
+print(f"Live view: {session.live_url}")
+
+# Option A: human logs in via live view
+input("Log in and complete 2FA in the live view, then press Enter...")
+
+# Option B: let the agent log in
+# await client.run("Log in to example.com with user@example.com / password123", session_id=session.id)
+
+# Stop the session — this saves cookies to the profile
+await client.sessions.stop(session.id)
+
+# Next time: reuse the profile, no 2FA needed
+session = await client.sessions.create(profile_id=profile.id)
+result = await client.run("Go to example.com/dashboard and get my balance", session_id=session.id)
+print(result.output)
+await client.sessions.stop(session.id)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+import * as readline from "readline";
+
+const client = new BrowserUse();
+
+// Create a profile and a session
+const profile = await client.profiles.create({ name: "my-account" });
+const session = await client.sessions.create({ profileId: profile.id });
+console.log(`Live view: ${session.liveUrl}`);
+
+// Option A: human logs in via live view
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+await new Promise((resolve) => rl.question("Log in and complete 2FA in the live view, then press Enter...", resolve));
+rl.close();
+
+// Option B: let the agent log in
+// await client.run("Log in to example.com with user@example.com / password123", { sessionId: session.id });
+
+// Stop the session — this saves cookies to the profile
+await client.sessions.stop(session.id);
+
+// Next time: reuse the profile, no 2FA needed
+const newSession = await client.sessions.create({ profileId: profile.id });
+const result = await client.run("Go to example.com/dashboard and get my balance", { sessionId: newSession.id });
+console.log(result.output);
+await client.sessions.stop(newSession.id);
+```
+</CodeGroup>
+
+<Warning>
+  Cookies expire. Some sites stay logged in for months, others expire daily. If your sessions start hitting login pages again, re-authenticate and save the profile.
+</Warning>
+
+<Tip>
+  Always call `sessions.stop()` after you're done — profile state is only saved when the session ends cleanly.
+</Tip>
+
+---
+
+## 2. Human in the loop
+
+Let the agent navigate to the login page, then a human takes over to complete 2FA via the live browser view. The agent continues after.
+
+<CodeGroup>
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+session = await client.sessions.create()
+print(f"Live view: {session.live_url}")
+
+# Agent navigates to login
+result = await client.run(
+    "Go to example.com/login and enter username user@example.com and password mypassword, then stop before 2FA",
+    session_id=session.id,
+)
+
+# Human completes 2FA in the live view
+input("Complete 2FA in the live view, then press Enter...")
+
+# Agent continues
+result = await client.run(
+    "You are now logged in. Go to the dashboard and export the monthly report",
+    session_id=session.id,
+)
+print(result.output)
+await client.sessions.stop(session.id)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+import * as readline from "readline";
+
+const client = new BrowserUse();
+const session = await client.sessions.create();
+console.log(`Live view: ${session.liveUrl}`);
+
+// Agent navigates to login
+await client.run(
+  "Go to example.com/login and enter username user@example.com and password mypassword, then stop before 2FA",
+  { sessionId: session.id },
+);
+
+// Human completes 2FA in the live view
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+await new Promise((resolve) => rl.question("Complete 2FA in the live view, then press Enter...", resolve));
+rl.close();
+
+// Agent continues
+const result = await client.run(
+  "You are now logged in. Go to the dashboard and export the monthly report",
+  { sessionId: session.id },
+);
+console.log(result.output);
+await client.sessions.stop(session.id);
+```
+</CodeGroup>
+
+See [Human in the loop](/cloud/agent/human-in-the-loop) for more patterns.
+
+---
+
+## 3. Agent Mail
+
+When 2FA sends a code via email, the agent can read it automatically using Agent Mail — a built-in email inbox for each session.
+
+Agent Mail is **enabled by default** (`agentmail=True`). Each session gets a unique email address (`session.agentmail_email`). The agent can send and receive emails during the task.
+
+<CodeGroup>
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+
+result = await client.run(
+    """
+    1. Go to example.com/signup
+    2. Sign up with the agent's email address (use the email available to you)
+    3. Check your email inbox for the verification code
+    4. Enter the code on the website
+    5. Complete the registration
+    """,
+    agentmail=True,  # default, shown for clarity
+)
+print(result.output)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+
+const client = new BrowserUse();
+
+const result = await client.run(
+  `1. Go to example.com/signup
+   2. Sign up with the agent's email address (use the email available to you)
+   3. Check your email inbox for the verification code
+   4. Enter the code on the website
+   5. Complete the registration`,
+  { agentmail: true }, // default, shown for clarity
+);
+console.log(result.output);
+```
+</CodeGroup>
+
+### For end-client automation
+
+If you're automating on behalf of your users and they need to receive 2FA codes:
+
+1. **Email forwarding:** Have your client set up an email forwarding rule — forward all emails from the service (e.g., `noreply@bank.com`) to a dedicated inbox (a Gmail address or an Agent Mail address).
+2. **Give the agent access:** The agent reads the forwarded 2FA code from that inbox during the task.
+
+This way, your client's real email stays private — the agent only sees the forwarded verification emails.
+
+### Connect external email via Composio
+
+You can also give the agent access to an existing Gmail account using [Composio](https://composio.dev) in the Browser Use dashboard. Once connected, the agent can read emails directly from that account to retrieve 2FA codes.
+
+---
+
+## 4. TOTP secret in prompt
+
+If the site uses an authenticator app (Google Authenticator, Authy, etc.), you can pass the TOTP secret to the agent. Our agent can execute Python code, so it uses the `pyotp` library to generate fresh 6-digit codes on the fly.
+
+When you set up 2FA on a site, instead of only scanning the QR code, also copy the **secret key** (usually shown as "manual entry" or "can't scan the QR code?"). This is a long base32 string like `JBSWY3DPEHPK3PXP`.
+
+<CodeGroup>
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+
+# The TOTP secret from your authenticator setup — NOT the 6-digit code
+totp_secret = "JBSWY3DPEHPK3PXP"
+
+result = await client.run(
+    f"""
+    Log into example.com with username user@example.com and password mypassword.
+    When prompted for a 2FA code, generate one using pyotp:
+
+    import pyotp
+    totp = pyotp.TOTP("{totp_secret}")
+    code = totp.now()
+
+    Enter the generated code.
+    """,
+)
+print(result.output)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+
+const client = new BrowserUse();
+
+// The TOTP secret from your authenticator setup — NOT the 6-digit code
+const totpSecret = "JBSWY3DPEHPK3PXP";
+
+const result = await client.run(
+  `Log into example.com with username user@example.com and password mypassword.
+   When prompted for a 2FA code, generate one using pyotp:
+
+   import pyotp
+   totp = pyotp.TOTP("${totpSecret}")
+   code = totp.now()
+
+   Enter the generated code.`,
+);
+console.log(result.output);
+```
+</CodeGroup>
+
+This works because the Browser Use agent can execute Python code as part of its task. The agent runs `pyotp.TOTP(secret).now()` to generate a time-based 6-digit code, then types it into the 2FA field.
+
+### Where to find TOTP secrets
+
+- **1Password**: Edit item → One-Time Password → Show secret
+- **Google Authenticator**: During setup, click "Can't scan it?" to see the key
+- **Authy**: Export via desktop app settings
+- **Most sites**: Look for "manual entry" or "setup key" during 2FA enrollment
+
+---
+
+## 5. 1Password integration
+
+If you use 1Password, connect it to Browser Use and the agent will auto-fill credentials and TOTP codes without ever seeing them.
+
+See [1Password & 2FA](/cloud/guides/1password) for setup instructions.
+
+---
+
+## Which approach should I use?
+
+<AccordionGroup>
+  <Accordion title="I'm automating my own accounts">
+    Start with **Profiles** — log in once, reuse cookies. If cookies expire frequently, add **TOTP secret in prompt** or **1Password** for fully automated re-login.
+  </Accordion>
+  <Accordion title="I'm building a product for end-users">
+    Use **Profiles** with one profile per user. For initial login, use **Human in the loop** — your user logs in once via the live view, then the agent reuses the session. For email 2FA, set up **Agent Mail** with email forwarding from your user.
+  </Accordion>
+  <Accordion title="I need to handle email verification codes">
+    Use **Agent Mail** (enabled by default). For end-client scenarios, have them forward 2FA emails to a dedicated inbox.
+  </Accordion>
+  <Accordion title="I need fully autonomous 2FA without any human">
+    Use **TOTP secret in prompt** (the agent generates codes via pyotp) or **1Password** (auto-fills credentials and TOTP). Both work without human intervention.
+  </Accordion>
+</AccordionGroup>

--- a/docs/cloud/guides/2fa.mdx
+++ b/docs/cloud/guides/2fa.mdx
@@ -4,7 +4,7 @@ description: "Best practices for handling two-factor authentication in automated
 icon: shield-halved
 ---
 
-Sites with 2FA block automated logins. Here are five approaches — pick the one that fits your setup.
+Sites with 2FA block automated logins. Here are four approaches — pick the one that fits your setup.
 
 | Approach | Best for | Complexity |
 |---|---|---|
@@ -12,7 +12,6 @@ Sites with 2FA block automated logins. Here are five approaches — pick the one
 | [Human in the loop](#2-human-in-the-loop) | One-off tasks, complex auth flows | Low |
 | [Agent Mail](#3-agent-mail) | Email-based 2FA, end-client automation | Medium |
 | [TOTP secret in prompt](#4-totp-secret-in-prompt) | Authenticator app 2FA (Google Authenticator, Authy) | Medium |
-| [1Password integration](#5-1password-integration) | Teams already using 1Password | Medium |
 
 ---
 
@@ -266,19 +265,11 @@ This works because the Browser Use agent can execute Python code as part of its 
 
 ---
 
-## 5. 1Password integration
-
-If you use 1Password, connect it to Browser Use and the agent will auto-fill credentials and TOTP codes without ever seeing them.
-
-See [1Password & 2FA](/cloud/guides/1password) for setup instructions.
-
----
-
 ## Which approach should I use?
 
 <AccordionGroup>
   <Accordion title="I'm automating my own accounts">
-    Start with **Profiles** — log in once, reuse cookies. If cookies expire frequently, add **TOTP secret in prompt** or **1Password** for fully automated re-login.
+    Start with **Profiles** — log in once, reuse cookies. If cookies expire frequently, add **TOTP secret in prompt** for fully automated re-login.
   </Accordion>
   <Accordion title="I'm building a product for end-users">
     Use **Profiles** with one profile per user. For initial login, use **Human in the loop** — your user logs in once via the live view, then the agent reuses the session. For email 2FA, set up **Agent Mail** with email forwarding from your user.
@@ -287,6 +278,6 @@ See [1Password & 2FA](/cloud/guides/1password) for setup instructions.
     Use **Agent Mail** (enabled by default). For end-client scenarios, have them forward 2FA emails to a dedicated inbox.
   </Accordion>
   <Accordion title="I need fully autonomous 2FA without any human">
-    Use **TOTP secret in prompt** (the agent generates codes via pyotp) or **1Password** (auto-fills credentials and TOTP). Both work without human intervention.
+    Use **TOTP secret in prompt** — the agent generates codes via pyotp, no human intervention needed.
   </Accordion>
 </AccordionGroup>

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -890,6 +890,126 @@ const result = await client.run("Check my LinkedIn messages", {
 ```
 
 
+# 2FA
+Source: https://docs.browser-use.com/cloud/guides/2fa
+
+Sites with 2FA block automated logins. Here are five approaches — pick the one that fits your setup.
+
+| Approach | Best for | Complexity |
+|---|---|---|
+| Profiles (login once) | Sites with long-lived cookies | Lowest |
+| Human in the loop | One-off tasks, complex auth flows | Low |
+| Agent Mail | Email-based 2FA, end-client automation | Medium |
+| TOTP secret in prompt | Authenticator app 2FA (Google Authenticator, Authy) | Medium |
+| 1Password integration | Teams already using 1Password | Medium |
+
+## 1. Profiles — login once, reuse cookies
+
+Login manually once (or let the agent do it), then save the browser state as a profile. Future sessions reuse the cookies — no 2FA prompt as long as the cookies are valid.
+
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+
+profile = await client.profiles.create(name="my-account")
+session = await client.sessions.create(profile_id=profile.id)
+print(f"Live view: {session.live_url}")
+
+input("Log in and complete 2FA in the live view, then press Enter...")
+
+await client.sessions.stop(session.id)
+
+# Next time: reuse the profile, no 2FA needed
+session = await client.sessions.create(profile_id=profile.id)
+result = await client.run("Go to example.com/dashboard and get my balance", session_id=session.id)
+print(result.output)
+await client.sessions.stop(session.id)
+```
+
+Cookies expire. Some sites stay logged in for months, others expire daily. Always call `sessions.stop()` — profile state is only saved when the session ends cleanly.
+
+## 2. Human in the loop
+
+Let the agent navigate to the login page, then a human takes over to complete 2FA via the live browser view.
+
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+session = await client.sessions.create()
+
+result = await client.run(
+    "Go to example.com/login and enter username user@example.com and password mypassword, then stop before 2FA",
+    session_id=session.id,
+)
+
+input("Complete 2FA in the live view, then press Enter...")
+
+result = await client.run(
+    "You are now logged in. Go to the dashboard and export the monthly report",
+    session_id=session.id,
+)
+print(result.output)
+await client.sessions.stop(session.id)
+```
+
+## 3. Agent Mail
+
+When 2FA sends a code via email, the agent can read it automatically using Agent Mail — a built-in email inbox for each session. Enabled by default (`agentmail=True`).
+
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+
+result = await client.run(
+    """
+    1. Go to example.com/signup
+    2. Sign up with the agent's email address (use the email available to you)
+    3. Check your email inbox for the verification code
+    4. Enter the code on the website
+    5. Complete the registration
+    """,
+    agentmail=True,  # default
+)
+print(result.output)
+```
+
+For end-client automation: have your client forward 2FA emails from the service (e.g., `noreply@bank.com`) to a dedicated inbox. The agent reads the forwarded code during the task. You can also connect Gmail via Composio in the dashboard.
+
+## 4. TOTP secret in prompt
+
+If the site uses an authenticator app, pass the TOTP secret to the agent. The agent uses pyotp to generate fresh 6-digit codes.
+
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+totp_secret = "JBSWY3DPEHPK3PXP"  # from authenticator setup, NOT the 6-digit code
+
+result = await client.run(
+    f"""
+    Log into example.com with username user@example.com and password mypassword.
+    When prompted for a 2FA code, generate one using pyotp:
+
+    import pyotp
+    totp = pyotp.TOTP("{totp_secret}")
+    code = totp.now()
+
+    Enter the generated code.
+    """,
+)
+print(result.output)
+```
+
+Where to find TOTP secrets: 1Password (Edit item → One-Time Password → Show secret), Google Authenticator (click "Can't scan it?"), Authy (desktop export), or "manual entry" during 2FA setup.
+
+## 5. 1Password integration
+
+Connect 1Password to Browser Use and the agent auto-fills credentials and TOTP codes without ever seeing them. See the 1Password & 2FA guide for setup.
+
+
 # OpenClaw
 Source: https://docs.browser-use.com/cloud/tutorials/integrations/openclaw
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -893,7 +893,7 @@ const result = await client.run("Check my LinkedIn messages", {
 # 2FA
 Source: https://docs.browser-use.com/cloud/guides/2fa
 
-Sites with 2FA block automated logins. Here are five approaches — pick the one that fits your setup.
+Sites with 2FA block automated logins. Here are four approaches — pick the one that fits your setup.
 
 | Approach | Best for | Complexity |
 |---|---|---|
@@ -901,7 +901,6 @@ Sites with 2FA block automated logins. Here are five approaches — pick the one
 | Human in the loop | One-off tasks, complex auth flows | Low |
 | Agent Mail | Email-based 2FA, end-client automation | Medium |
 | TOTP secret in prompt | Authenticator app 2FA (Google Authenticator, Authy) | Medium |
-| 1Password integration | Teams already using 1Password | Medium |
 
 ## 1. Profiles — login once, reuse cookies
 
@@ -1004,10 +1003,6 @@ print(result.output)
 ```
 
 Where to find TOTP secrets: 1Password (Edit item → One-Time Password → Show secret), Google Authenticator (click "Can't scan it?"), Authy (desktop export), or "manual entry" during 2FA setup.
-
-## 5. 1Password integration
-
-Connect 1Password to Browser Use and the agent auto-fills credentials and TOTP codes without ever seeing them. See the 1Password & 2FA guide for setup.
 
 
 # OpenClaw

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -67,7 +67,7 @@ console.log(result.output);
 ## Authentication
 - [Profiles](https://docs.browser-use.com/cloud/guides/authentication): Persistent browser state — cookies, localStorage, saved passwords. Login once, reuse across sessions.
 - [Sync local and cloud cookies](https://docs.browser-use.com/cloud/guides/profile-sync): Sync your local browser cookies to the cloud — instantly authenticate without managing credentials.
-- [2FA](https://docs.browser-use.com/cloud/guides/2fa): Best practices for two-factor authentication — profiles, human-in-the-loop, Agent Mail, TOTP via pyotp, and 1Password.
+- [2FA](https://docs.browser-use.com/cloud/guides/2fa): Best practices for two-factor authentication — profiles, human-in-the-loop, Agent Mail, and TOTP via pyotp.
 
 ## Integrations
 - [OpenClaw](https://docs.browser-use.com/cloud/tutorials/integrations/openclaw): Give OpenClaw agents browser automation with Browser Use — via CDP or the CLI skill.

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -67,6 +67,7 @@ console.log(result.output);
 ## Authentication
 - [Profiles](https://docs.browser-use.com/cloud/guides/authentication): Persistent browser state — cookies, localStorage, saved passwords. Login once, reuse across sessions.
 - [Sync local and cloud cookies](https://docs.browser-use.com/cloud/guides/profile-sync): Sync your local browser cookies to the cloud — instantly authenticate without managing credentials.
+- [2FA](https://docs.browser-use.com/cloud/guides/2fa): Best practices for two-factor authentication — profiles, human-in-the-loop, Agent Mail, TOTP via pyotp, and 1Password.
 
 ## Integrations
 - [OpenClaw](https://docs.browser-use.com/cloud/tutorials/integrations/openclaw): Give OpenClaw agents browser automation with Browser Use — via CDP or the CLI skill.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -85,7 +85,8 @@
                         "icon": "key",
                         "pages": [
                           "cloud/guides/authentication",
-                          "cloud/guides/profile-sync"
+                          "cloud/guides/profile-sync",
+                          "cloud/guides/2fa"
                         ]
                       }
                     ]

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -893,7 +893,7 @@ const result = await client.run("Check my LinkedIn messages", {
 # 2FA
 Source: https://docs.browser-use.com/cloud/guides/2fa
 
-Sites with 2FA block automated logins. Here are five approaches — pick the one that fits your setup.
+Sites with 2FA block automated logins. Here are four approaches — pick the one that fits your setup.
 
 | Approach | Best for | Complexity |
 |---|---|---|
@@ -901,7 +901,6 @@ Sites with 2FA block automated logins. Here are five approaches — pick the one
 | Human in the loop | One-off tasks, complex auth flows | Low |
 | Agent Mail | Email-based 2FA, end-client automation | Medium |
 | TOTP secret in prompt | Authenticator app 2FA (Google Authenticator, Authy) | Medium |
-| 1Password integration | Teams already using 1Password | Medium |
 
 ## 1. Profiles — login once, reuse cookies
 
@@ -1031,10 +1030,6 @@ print(result.output)
 ```
 
 Where to find TOTP secrets: 1Password (Edit item → One-Time Password → Show secret), Google Authenticator (click "Can't scan it?"), Authy (desktop export), or "manual entry" during 2FA setup.
-
-## 5. 1Password integration
-
-Connect 1Password to Browser Use and the agent auto-fills credentials and TOTP codes without ever seeing them. See the 1Password & 2FA guide for setup.
 
 
 # OpenClaw

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -890,6 +890,153 @@ const result = await client.run("Check my LinkedIn messages", {
 ```
 
 
+# 2FA
+Source: https://docs.browser-use.com/cloud/guides/2fa
+
+Sites with 2FA block automated logins. Here are five approaches — pick the one that fits your setup.
+
+| Approach | Best for | Complexity |
+|---|---|---|
+| Profiles (login once) | Sites with long-lived cookies | Lowest |
+| Human in the loop | One-off tasks, complex auth flows | Low |
+| Agent Mail | Email-based 2FA, end-client automation | Medium |
+| TOTP secret in prompt | Authenticator app 2FA (Google Authenticator, Authy) | Medium |
+| 1Password integration | Teams already using 1Password | Medium |
+
+## 1. Profiles — login once, reuse cookies
+
+Login manually once (or let the agent do it), then save the browser state as a profile. Future sessions reuse the cookies — no 2FA prompt as long as the cookies are valid.
+
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+
+# Create a profile and a session
+profile = await client.profiles.create(name="my-account")
+session = await client.sessions.create(profile_id=profile.id)
+print(f"Live view: {session.live_url}")
+
+# Option A: human logs in via live view
+input("Log in and complete 2FA in the live view, then press Enter...")
+
+# Option B: let the agent log in
+# await client.run("Log in to example.com with user@example.com / password123", session_id=session.id)
+
+# Stop the session — this saves cookies to the profile
+await client.sessions.stop(session.id)
+
+# Next time: reuse the profile, no 2FA needed
+session = await client.sessions.create(profile_id=profile.id)
+result = await client.run("Go to example.com/dashboard and get my balance", session_id=session.id)
+print(result.output)
+await client.sessions.stop(session.id)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+import * as readline from "readline";
+
+const client = new BrowserUse();
+
+const profile = await client.profiles.create({ name: "my-account" });
+const session = await client.sessions.create({ profileId: profile.id });
+console.log(`Live view: ${session.liveUrl}`);
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+await new Promise((resolve) => rl.question("Log in and complete 2FA in the live view, then press Enter...", resolve));
+rl.close();
+
+await client.sessions.stop(session.id);
+
+const newSession = await client.sessions.create({ profileId: profile.id });
+const result = await client.run("Go to example.com/dashboard and get my balance", { sessionId: newSession.id });
+console.log(result.output);
+await client.sessions.stop(newSession.id);
+```
+
+Cookies expire. Some sites stay logged in for months, others expire daily. Always call `sessions.stop()` — profile state is only saved when the session ends cleanly.
+
+## 2. Human in the loop
+
+Let the agent navigate to the login page, then a human takes over to complete 2FA via the live browser view.
+
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+session = await client.sessions.create()
+
+result = await client.run(
+    "Go to example.com/login and enter username user@example.com and password mypassword, then stop before 2FA",
+    session_id=session.id,
+)
+
+input("Complete 2FA in the live view, then press Enter...")
+
+result = await client.run(
+    "You are now logged in. Go to the dashboard and export the monthly report",
+    session_id=session.id,
+)
+print(result.output)
+await client.sessions.stop(session.id)
+```
+
+## 3. Agent Mail
+
+When 2FA sends a code via email, the agent can read it automatically using Agent Mail — a built-in email inbox for each session. Enabled by default (`agentmail=True`).
+
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+
+result = await client.run(
+    """
+    1. Go to example.com/signup
+    2. Sign up with the agent's email address (use the email available to you)
+    3. Check your email inbox for the verification code
+    4. Enter the code on the website
+    5. Complete the registration
+    """,
+    agentmail=True,  # default
+)
+print(result.output)
+```
+
+For end-client automation: have your client forward 2FA emails from the service (e.g., `noreply@bank.com`) to a dedicated inbox. The agent reads the forwarded code during the task. You can also connect Gmail via Composio in the dashboard.
+
+## 4. TOTP secret in prompt
+
+If the site uses an authenticator app, pass the TOTP secret to the agent. The agent uses pyotp to generate fresh 6-digit codes.
+
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+totp_secret = "JBSWY3DPEHPK3PXP"  # from authenticator setup, NOT the 6-digit code
+
+result = await client.run(
+    f"""
+    Log into example.com with username user@example.com and password mypassword.
+    When prompted for a 2FA code, generate one using pyotp:
+
+    import pyotp
+    totp = pyotp.TOTP("{totp_secret}")
+    code = totp.now()
+
+    Enter the generated code.
+    """,
+)
+print(result.output)
+```
+
+Where to find TOTP secrets: 1Password (Edit item → One-Time Password → Show secret), Google Authenticator (click "Can't scan it?"), Authy (desktop export), or "manual entry" during 2FA setup.
+
+## 5. 1Password integration
+
+Connect 1Password to Browser Use and the agent auto-fills credentials and TOTP codes without ever seeing them. See the 1Password & 2FA guide for setup.
+
+
 # OpenClaw
 Source: https://docs.browser-use.com/cloud/tutorials/integrations/openclaw
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -67,7 +67,7 @@ console.log(result.output);
 ## Authentication
 - [Profiles](https://docs.browser-use.com/cloud/guides/authentication): Persistent browser state — cookies, localStorage, saved passwords. Login once, reuse across sessions.
 - [Sync local and cloud cookies](https://docs.browser-use.com/cloud/guides/profile-sync): Sync your local browser cookies to the cloud — instantly authenticate without managing credentials.
-- [2FA](https://docs.browser-use.com/cloud/guides/2fa): Best practices for two-factor authentication — profiles, human-in-the-loop, Agent Mail, TOTP via pyotp, and 1Password.
+- [2FA](https://docs.browser-use.com/cloud/guides/2fa): Best practices for two-factor authentication — profiles, human-in-the-loop, Agent Mail, and TOTP via pyotp.
 
 ## Integrations
 - [OpenClaw](https://docs.browser-use.com/cloud/tutorials/integrations/openclaw): Give OpenClaw agents browser automation with Browser Use — via CDP or the CLI skill.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -67,6 +67,7 @@ console.log(result.output);
 ## Authentication
 - [Profiles](https://docs.browser-use.com/cloud/guides/authentication): Persistent browser state — cookies, localStorage, saved passwords. Login once, reuse across sessions.
 - [Sync local and cloud cookies](https://docs.browser-use.com/cloud/guides/profile-sync): Sync your local browser cookies to the cloud — instantly authenticate without managing credentials.
+- [2FA](https://docs.browser-use.com/cloud/guides/2fa): Best practices for two-factor authentication — profiles, human-in-the-loop, Agent Mail, TOTP via pyotp, and 1Password.
 
 ## Integrations
 - [OpenClaw](https://docs.browser-use.com/cloud/tutorials/integrations/openclaw): Give OpenClaw agents browser automation with Browser Use — via CDP or the CLI skill.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a 2FA best practices guide for automated browser sessions with clear Python/TypeScript examples. Integrates the guide into the docs sidebar and LLM export indexes so it’s easy to find and use.

- **New Features**
  - New page: docs/cloud/guides/2fa.mdx covering Profiles, Human-in-the-loop, Agent Mail, and TOTP via pyotp, with concise code samples.
  - Added to sidebar under Authentication (docs/docs.json).
  - Linked in authentication indexes and full exports (docs/cloud/llms.txt, docs/llms.txt, docs/cloud/llms-full.txt, docs/llms-full.txt).

<sup>Written for commit 84c1ba82077312f72c7bb12ad7b43941a086cd09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

