### PR TITLE
Fix table wording: sessions.create in run() description

### DIFF
--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -52,7 +52,7 @@ console.log(result.output);
 
 `client.sessions.create()` creates an AI agent session. `client.run()` wraps `sessions.create()` and polls until done. `client.browsers.create()` gives you a raw browser for [Playwright / Puppeteer / Selenium](/cloud/browser/playwright-puppeteer-selenium).
 
-| | `client.sessions.create()` / `client.run()` (wraps create and polls until done) | `client.browsers.create()` |
+| | `client.sessions.create()` / `client.run()` (wraps sessions.create and polls until done) | `client.browsers.create()` |
 |---|---|---|
 | **What it does** | Run an AI agent task | Just give me a browser |
 | task | ✓ | — |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrected the quickstart table to state that `client.run()` wraps `client.sessions.create()` and polls until done. Resolved a merge conflict in `docs/cloud/quickstart.mdx`.

<sup>Written for commit 932b0580af5b886f3ceb42cea26c572b36277bc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

