### PR TITLE
Fix docs R2: auth header, legacy property names, dead CLI link

### DIFF
--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -44,9 +44,7 @@ console.log(result.output);
 ```
 </CodeGroup>
 
-<Note>
-  Want a full working app? See the [Chat UI example](/cloud/tutorials/chat-ui) — a complete Next.js app with live browser preview, streaming messages, authentication, and session management.
-</Note>
+Want a full working app? Check out the [Chat UI example](/cloud/tutorials/chat-ui).
 
 ## Agent vs Browser
 

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -50,9 +50,10 @@ console.log(result.output);
 
 ## Agent vs Browser
 
-| | `client.sessions.create()` / `client.run()` (wraps sessions.create and polls until done) | `client.browsers.create()` |
+| | **Agent** | **Browser** |
 |---|---|---|
-| **What it does** | Run an AI agent task | Just give me a browser |
+| **Method** | `sessions.create()` / `run()` | `browsers.create()` |
+| **What it does** | AI agent runs your task | Raw browser via CDP |
 | task | ✓ | — |
 | model | ✓ | — |
 | proxy | ✓ | ✓ |


### PR DESCRIPTION
## Summary
- **Fix auth header** in `agent/quickstart.mdx`: `Authorization: Bearer` → `X-Browser-Use-API-Key`
- **Fix legacy/agent.mdx**: `upload.presignedUrl` → `upload.url` (method PUT→POST), `output.presignedUrl` → `output.downloadUrl`
- **Fix legacy/public-share.mdx**: `share.url` → `share.shareUrl` (Python + TS)
- **Fix browser-use-cli.mdx**: remove dead `github.com/browser-use/browser-use-cli` link

## Test plan
- [ ] Verify curl examples work with X-Browser-Use-API-Key
- [ ] Verify legacy snippets compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)