### PR TITLE
Fix docs R2: auth header, legacy property names

### DIFF
--- a/docs/cloud/agent/quickstart.mdx
+++ b/docs/cloud/agent/quickstart.mdx
@@ -25,7 +25,7 @@ console.log(result.output);
 ```
 ```bash curl
 curl -X POST https://api.browser-use.com/api/v3/sessions \
-  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "X-Browser-Use-API-Key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"task": "List the top 20 posts on Hacker News today with their points"}'
 ```

--- a/docs/cloud/legacy/agent.mdx
+++ b/docs/cloud/legacy/agent.mdx
@@ -73,8 +73,8 @@ const upload = await client.files.sessionUrl(session.id, {
   sizeBytes: 1024,
 });
 
-await fetch(upload.presignedUrl, {
-  method: "PUT",
+await fetch(upload.url, {
+  method: "POST",
   body: readFileSync("input.pdf"),
   headers: { "Content-Type": "application/pdf" },
 });
@@ -100,7 +100,7 @@ for file in result.output_files:
 const result = await client.tasks.get(taskId);
 for (const file of result.outputFiles) {
   const output = await client.files.taskOutput(taskId, file.id);
-  console.log(output.presignedUrl);
+  console.log(output.downloadUrl);
 }
 ```
 </CodeGroup>

--- a/docs/cloud/legacy/public-share.mdx
+++ b/docs/cloud/legacy/public-share.mdx
@@ -9,10 +9,10 @@ Generate a public URL that anyone can open to watch the entire agent session —
 <CodeGroup>
 ```python Python
 share = await client.sessions.create_share(session.id)
-print(share.url)
+print(share.share_url)
 ```
 ```typescript TypeScript
 const share = await client.sessions.createShare(session.id);
-console.log(share.url);
+console.log(share.shareUrl);
 ```
 </CodeGroup>

--- a/docs/open-source/browser-use-cli.mdx
+++ b/docs/open-source/browser-use-cli.mdx
@@ -271,7 +271,7 @@ browser-use open https://abc.trycloudflare.com
 
 ## Profile Management
 
-The `profile` subcommand delegates to the [profile-use](https://github.com/browser-use/browser-use-cli) Go binary, which syncs local browser cookies to Browser-Use cloud.
+The `profile` subcommand syncs local browser cookies to Browser-Use cloud.
 
 The binary is managed at `~/.browser-use/bin/profile-use` and auto-downloaded on first use.
 


### PR DESCRIPTION
## Summary
- **Fix auth header** in `agent/quickstart.mdx` curl example: `Authorization: Bearer` → `X-Browser-Use-API-Key`
- **Fix legacy/agent.mdx**: `upload.presignedUrl` → `upload.url`, method `PUT` → `POST`; `output.presignedUrl` → `output.downloadUrl`
- **Fix legacy/public-share.mdx**: `share.url` → `share.shareUrl` (both Python and TS)

All `Authorization: Bearer` instances now removed from MDX sources (only remain in generated `llms-full.txt` which will regenerate).

## Still needs input
- `profile.sh` URL is 404 — need correct URL or removal
- `browser-use-cli` GitHub repo is 404 — need correct repo URL

## Test plan
- [ ] Verify curl examples work with `X-Browser-Use-API-Key`
- [ ] Verify legacy file upload/download/share snippets compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix docs to use the `X-Browser-Use-API-Key` header, align legacy examples with the current API, and remove a dead CLI repo link. Curl and code samples now work as written; CLI docs clarify that `profile` is built-in.

- **Bug Fixes**
  - In `docs/cloud/agent/quickstart.mdx`, replace `Authorization: Bearer` with `X-Browser-Use-API-Key`.
  - In `docs/cloud/legacy/agent.mdx`, change `upload.presignedUrl` → `upload.url` with `POST`, and `output.presignedUrl` → `output.downloadUrl`.
  - In `docs/cloud/legacy/public-share.mdx`, change `share.url` → `share.shareUrl` (TS) and `share.share_url` (Python).
  - In `docs/open-source/browser-use-cli.mdx`, remove the dead repo link and state the `profile` subcommand syncs cookies and is part of the CLI.

<sup>Written for commit 37ed7385afb2d4f488e2a907998f5a683d58317c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

