### PR TITLE
Fix docs R2: auth header, legacy property names, dead CLI link

### DIFF
--- a/docs/cloud/agent/quickstart.mdx
+++ b/docs/cloud/agent/quickstart.mdx
@@ -25,7 +25,7 @@ console.log(result.output);
 ```
 ```bash curl
 curl -X POST https://api.browser-use.com/api/v3/sessions \
-  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "X-Browser-Use-API-Key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"task": "List the top 20 posts on Hacker News today with their points"}'
 ```

--- a/docs/cloud/legacy/agent.mdx
+++ b/docs/cloud/legacy/agent.mdx
@@ -56,7 +56,7 @@ upload = await client.files.session_url(
 
 with open("input.pdf", "rb") as f:
     async with httpx.AsyncClient() as http:
-        await http.put(upload.presigned_url, content=f.read(), headers={"Content-Type": "application/pdf"})
+        await http.post(upload.url, content=f.read(), headers={"Content-Type": "application/pdf"})
 
 result = await client.run("Summarize the uploaded PDF", session_id=session.id)
 ```
@@ -94,7 +94,7 @@ const result = await client.run("Summarize the uploaded PDF", { sessionId: sessi
 result = await client.tasks.get(task_id)
 for file in result.output_files:
     output = await client.files.task_output(task_id, file.id)
-    print(output.presigned_url)  # download URL
+    print(output.download_url)  # download URL
 ```
 ```typescript TypeScript
 const result = await client.tasks.get(taskId);

--- a/docs/cloud/legacy/agent.mdx
+++ b/docs/cloud/legacy/agent.mdx
@@ -73,8 +73,8 @@ const upload = await client.files.sessionUrl(session.id, {
   sizeBytes: 1024,
 });
 
-await fetch(upload.presignedUrl, {
-  method: "PUT",
+await fetch(upload.url, {
+  method: "POST",
   body: readFileSync("input.pdf"),
   headers: { "Content-Type": "application/pdf" },
 });
@@ -100,7 +100,7 @@ for file in result.output_files:
 const result = await client.tasks.get(taskId);
 for (const file of result.outputFiles) {
   const output = await client.files.taskOutput(taskId, file.id);
-  console.log(output.presignedUrl);
+  console.log(output.downloadUrl);
 }
 ```
 </CodeGroup>

--- a/docs/cloud/legacy/agent.mdx
+++ b/docs/cloud/legacy/agent.mdx
@@ -37,7 +37,7 @@ Upload images, PDFs, documents, and text files (10 MB max) to sessions, and down
 
 ### Upload a file
 
-Get a presigned URL, then upload via PUT.
+Get a presigned URL, then upload via POST.
 
 <CodeGroup>
 ```python Python

--- a/docs/cloud/legacy/public-share.mdx
+++ b/docs/cloud/legacy/public-share.mdx
@@ -9,10 +9,10 @@ Generate a public URL that anyone can open to watch the entire agent session —
 <CodeGroup>
 ```python Python
 share = await client.sessions.create_share(session.id)
-print(share.url)
+print(share.share_url)
 ```
 ```typescript TypeScript
 const share = await client.sessions.createShare(session.id);
-console.log(share.url);
+console.log(share.shareUrl);
 ```
 </CodeGroup>

--- a/docs/open-source/browser-use-cli.mdx
+++ b/docs/open-source/browser-use-cli.mdx
@@ -271,7 +271,7 @@ browser-use open https://abc.trycloudflare.com
 
 ## Profile Management
 
-The `profile` subcommand delegates to the [profile-use](https://github.com/browser-use/browser-use-cli) Go binary, which syncs local browser cookies to Browser-Use cloud.
+The `profile` subcommand syncs local browser cookies to Browser-Use cloud.
 
 The binary is managed at `~/.browser-use/bin/profile-use` and auto-downloaded on first use.
 


### PR DESCRIPTION
## Summary
- **Fix auth header** in `agent/quickstart.mdx`: `Authorization: Bearer` → `X-Browser-Use-API-Key`
- **Fix legacy/agent.mdx**: `upload.presignedUrl` → `upload.url` (method PUT→POST), `output.presignedUrl` → `output.downloadUrl`
- **Fix legacy/public-share.mdx**: `share.url` → `share.shareUrl` (Python + TS)
- **Fix browser-use-cli.mdx**: remove dead `github.com/browser-use/browser-use-cli` link

## Test plan
- [ ] Verify curl examples work with X-Browser-Use-API-Key
- [ ] Verify legacy snippets compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated R2 docs to match the current API and SDK: fixed the auth header in the quickstart, corrected legacy property names and upload method (TS + Python), and removed a dead CLI link. This ensures copy/paste examples work and reduces confusion.

- **Bug Fixes**
  - Quickstart curl: use header "X-Browser-Use-API-Key" instead of "Authorization: Bearer".
  - Legacy agent: upload is POST (not PUT); TS `upload.presignedUrl`/`output.presignedUrl` → `upload.url`/`output.downloadUrl`; Python `upload.presigned_url`/`output.presigned_url` → `upload.url`/`output.download_url`.
  - Legacy public-share: `share.url` → `share.shareUrl` (TypeScript) and `share.share_url` (Python).
  - CLI docs: removed dead GitHub link; clarified `profile` subcommand is built-in and syncs cookies.

<sup>Written for commit dfeca6d752de46e95023a15934bd286208eafb46. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

