### PR TITLE
Fix docs audit: proxy sentinel, auth header, Partial types, hidden field + R2 fixes

### DIFF
--- a/browser-use-node/src/generated/v3/types.ts
+++ b/browser-use-node/src/generated/v3/types.ts
@@ -103,7 +103,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/sessions/{session_id}/files": {
+    "/browsers": {
         parameters: {
             query?: never;
             header?: never;
@@ -111,43 +111,61 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * List Session Files
-         * @description List files in a session's workspace.
-         *
-         *     Returns paginated file metadata. Pass includeUrls=true to get
-         *     presigned download URLs (60s expiry) inline with each file.
+         * List Browser Sessions
+         * @description Get paginated list of browser sessions with optional status filtering.
          */
-        get: operations["list_session_files_sessions__session_id__files_get"];
+        get: operations["list_browser_sessions_browsers_get"];
         put?: never;
-        post?: never;
+        /**
+         * Create Browser Session
+         * @description Create a new browser session.
+         *
+         *     **Pricing:** Browser sessions are charged per hour with tiered pricing:
+         *     - Pay As You Go users: $0.06/hour
+         *     - Business/Scaleup subscribers: $0.03/hour (50% discount)
+         *
+         *     The full rate is charged upfront when the session starts.
+         *     When you stop the session, any unused time is automatically refunded proportionally.
+         *
+         *     Billing is rounded up to the minute (minimum 1 minute).
+         *     For example, if you stop a session after 30 minutes, you'll be refunded half the charged amount.
+         *
+         *     **Session Limits:**
+         *     - All users: Up to 4 hours per session
+         */
+        post: operations["create_browser_session_browsers_post"];
         delete?: never;
         options?: never;
         head?: never;
         patch?: never;
         trace?: never;
     };
-    "/sessions/{session_id}/files/upload": {
+    "/browsers/{session_id}": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get?: never;
-        put?: never;
         /**
-         * Upload Session Files
-         * @description Get presigned PUT URLs for uploading files to a session's workspace.
-         *
-         *     Files are placed under ``uploads/`` in the session's S3 prefix. After
-         *     receiving the URLs, PUT each file directly to S3 using the returned
-         *     ``uploadUrl`` with the matching ``Content-Type`` header.
+         * Get Browser Session
+         * @description Get detailed browser session information including status and URLs.
          */
-        post: operations["upload_session_files_sessions__session_id__files_upload_post"];
+        get: operations["get_browser_session_browsers__session_id__get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
-        patch?: never;
+        /**
+         * Update Browser Session
+         * @description Stop a browser session.
+         *
+         *     **Refund:** When you stop a session, unused time is automatically refunded.
+         *     If the session ran for less than 1 hour, you'll receive a proportional refund.
+         *     Billing is ceil to the nearest minute (minimum 1 minute).
+         */
+        patch: operations["update_browser_session_browsers__session_id__patch"];
         trace?: never;
     };
     "/profiles": {
@@ -212,91 +230,6 @@ export interface paths {
          * @description Update a browser profile's information.
          */
         patch: operations["update_profile_profiles__profile_id__patch"];
-        trace?: never;
-    };
-    "/billing/account": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Account Billing
-         * @description Get authenticated account information including credit balance and account details.
-         */
-        get: operations["get_account_billing_billing_account_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/browsers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List Browser Sessions
-         * @description Get paginated list of browser sessions with optional status filtering.
-         */
-        get: operations["list_browser_sessions_browsers_get"];
-        put?: never;
-        /**
-         * Create Browser Session
-         * @description Create a new browser session.
-         *
-         *     **Pricing:** Browser sessions are charged per hour with tiered pricing:
-         *     - Pay As You Go users: $0.06/hour
-         *     - Business/Scaleup subscribers: $0.03/hour (50% discount)
-         *
-         *     The full rate is charged upfront when the session starts.
-         *     When you stop the session, any unused time is automatically refunded proportionally.
-         *
-         *     Billing is rounded up to the minute (minimum 1 minute).
-         *     For example, if you stop a session after 30 minutes, you'll be refunded half the charged amount.
-         *
-         *     **Session Limits:**
-         *     - All users: Up to 4 hours per session
-         */
-        post: operations["create_browser_session_browsers_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/browsers/{session_id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Browser Session
-         * @description Get detailed browser session information including status and URLs.
-         */
-        get: operations["get_browser_session_browsers__session_id__get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /**
-         * Update Browser Session
-         * @description Stop a browser session.
-         *
-         *     **Refund:** When you stop a session, unused time is automatically refunded.
-         *     If the session ran for less than 1 hour, you'll receive a proportional refund.
-         *     Billing is ceil to the nearest minute (minimum 1 minute).
-         */
-        patch: operations["update_browser_session_browsers__session_id__patch"];
         trace?: never;
     };
     "/workspaces": {
@@ -409,6 +342,73 @@ export interface paths {
          * @description Get presigned PUT URLs for uploading files to a workspace.
          */
         post: operations["upload_workspace_files_workspaces__workspace_id__files_upload_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sessions/{session_id}/files": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Session Files
+         * @description List files in a session's workspace.
+         *
+         *     Returns paginated file metadata. Pass includeUrls=true to get
+         *     presigned download URLs (60s expiry) inline with each file.
+         */
+        get: operations["list_session_files_sessions__session_id__files_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sessions/{session_id}/files/upload": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Upload Session Files
+         * @description Get presigned PUT URLs for uploading files to a session's workspace.
+         *
+         *     Files are placed under ``uploads/`` in the session's S3 prefix. After
+         *     receiving the URLs, PUT each file directly to S3 using the returned
+         *     ``uploadUrl`` with the matching ``Content-Type`` header.
+         */
+        post: operations["upload_session_files_sessions__session_id__files_upload_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/billing/account": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Account Billing
+         * @description Get authenticated account information including credit balance and account details.
+         */
+        get: operations["get_account_billing_billing_account_get"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -890,6 +890,12 @@ export interface components {
             summary: string;
             /** Screenshoturl */
             screenshotUrl?: string | null;
+            /**
+             * Hidden
+             * @description Whether this message should be hidden from the user in a chat UI.
+             * @default false
+             */
+            hidden: boolean;
             /**
              * Createdat
              * Format: date-time
@@ -1549,15 +1555,102 @@ export interface operations {
             };
         };
     };
-    list_session_files_sessions__session_id__files_get: {
+    list_browser_sessions_browsers_get: {
         parameters: {
             query?: {
-                prefix?: string;
-                limit?: number;
-                cursor?: string | null;
-                includeUrls?: boolean;
-                shallow?: boolean;
+                pageSize?: number;
+                pageNumber?: number;
+                filterBy?: components["schemas"]["BrowserSessionStatus"] | null;
             };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BrowserSessionListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_browser_session_browsers_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateBrowserSessionRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BrowserSessionItemView"];
+                };
+            };
+            /** @description Session timeout limit exceeded (maximum 4 hours) */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionTimeoutLimitExceededError"];
+                };
+            };
+            /** @description Profile not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProfileNotFoundError"];
+                };
+            };
+            /** @description Request validation failed */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationError"];
+                };
+            };
+            /** @description Too many concurrent active sessions */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TooManyConcurrentActiveSessionsError"];
+                };
+            };
+        };
+    };
+    get_browser_session_browsers__session_id__get: {
+        parameters: {
+            query?: never;
             header?: never;
             path: {
                 session_id: string;
@@ -1572,7 +1665,16 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["FileListResponse"];
+                    "application/json": components["schemas"]["BrowserSessionView"];
+                };
+            };
+            /** @description Session not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionNotFoundError"];
                 };
             };
             /** @description Validation Error */
@@ -1586,7 +1688,7 @@ export interface operations {
             };
         };
     };
-    upload_session_files_sessions__session_id__files_upload_post: {
+    update_browser_session_browsers__session_id__patch: {
         parameters: {
             query?: never;
             header?: never;
@@ -1597,7 +1699,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["FileUploadRequest"];
+                "application/json": components["schemas"]["UpdateBrowserSessionRequest"];
             };
         };
         responses: {
@@ -1607,16 +1709,25 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["FileUploadResponse"];
+                    "application/json": components["schemas"]["BrowserSessionView"];
                 };
             };
-            /** @description Validation Error */
+            /** @description Session not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SessionNotFoundError"];
+                };
+            };
+            /** @description Request validation failed */
             422: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
+                    "application/json": components["schemas"]["ValidationError"];
                 };
             };
         };
@@ -1805,221 +1916,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    get_account_billing_billing_account_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AccountView"];
-                };
-            };
-            /** @description Project for a given API key not found! */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AccountNotFoundError"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    list_browser_sessions_browsers_get: {
-        parameters: {
-            query?: {
-                pageSize?: number;
-                pageNumber?: number;
-                filterBy?: components["schemas"]["BrowserSessionStatus"] | null;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["BrowserSessionListResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    create_browser_session_browsers_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreateBrowserSessionRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["BrowserSessionItemView"];
-                };
-            };
-            /** @description Session timeout limit exceeded (maximum 4 hours) */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SessionTimeoutLimitExceededError"];
-                };
-            };
-            /** @description Profile not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ProfileNotFoundError"];
-                };
-            };
-            /** @description Request validation failed */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ValidationError"];
-                };
-            };
-            /** @description Too many concurrent active sessions */
-            429: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TooManyConcurrentActiveSessionsError"];
-                };
-            };
-        };
-    };
-    get_browser_session_browsers__session_id__get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                session_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["BrowserSessionView"];
-                };
-            };
-            /** @description Session not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SessionNotFoundError"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_browser_session_browsers__session_id__patch: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                session_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateBrowserSessionRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["BrowserSessionView"];
-                };
-            };
-            /** @description Session not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SessionNotFoundError"];
-                };
-            };
-            /** @description Request validation failed */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ValidationError"];
                 };
             };
         };
@@ -2309,6 +2205,116 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["FileUploadResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_session_files_sessions__session_id__files_get: {
+        parameters: {
+            query?: {
+                prefix?: string;
+                limit?: number;
+                cursor?: string | null;
+                includeUrls?: boolean;
+                shallow?: boolean;
+            };
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FileListResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    upload_session_files_sessions__session_id__files_upload_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FileUploadRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FileUploadResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_account_billing_billing_account_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccountView"];
+                };
+            };
+            /** @description Project for a given API key not found! */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccountNotFoundError"];
                 };
             };
             /** @description Validation Error */

--- a/browser-use-node/src/v3/resources/browsers.ts
+++ b/browser-use-node/src/v3/resources/browsers.ts
@@ -16,7 +16,7 @@ export class Browsers {
   constructor(private readonly http: HttpClient) {}
 
   /** Create a standalone browser session. */
-  create(body?: CreateBrowserSessionRequest): Promise<BrowserSessionItemView> {
+  create(body?: Partial<CreateBrowserSessionRequest>): Promise<BrowserSessionItemView> {
     return this.http.post<BrowserSessionItemView>("/browsers", body);
   }
 

--- a/browser-use-python/src/browser_use_sdk/_core/__init__.py
+++ b/browser-use-python/src/browser_use_sdk/_core/__init__.py
@@ -1,4 +1,9 @@
 from .errors import BrowserUseError
 from .http import AsyncHttpClient, SyncHttpClient
 
-__all__ = ["BrowserUseError", "SyncHttpClient", "AsyncHttpClient"]
+_UNSET: object = object()
+"""Sentinel for parameters where ``None`` has explicit API meaning (e.g. sending
+JSON ``null`` to disable proxies).  Using ``_UNSET`` as the default lets the SDK
+distinguish "caller didn't pass a value" from "caller explicitly passed ``None``"."""
+
+__all__ = ["BrowserUseError", "SyncHttpClient", "AsyncHttpClient", "_UNSET"]

--- a/browser-use-python/src/browser_use_sdk/generated/v3/models.py
+++ b/browser-use-python/src/browser_use_sdk/generated/v3/models.py
@@ -257,6 +257,11 @@ class MessageResponse(BaseModel):
     screenshot_url: str | None = Field(
         None, alias='screenshotUrl', title='Screenshoturl'
     )
+    hidden: bool | None = Field(
+        False,
+        description='Whether this message should be hidden from the user in a chat UI.',
+        title='Hidden',
+    )
     created_at: AwareDatetime = Field(..., alias='createdAt', title='Createdat')
 
 

--- a/browser-use-python/src/browser_use_sdk/v3/client.py
+++ b/browser-use-python/src/browser_use_sdk/v3/client.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
+from .._core import _UNSET
 from .._core.http import AsyncHttpClient, SyncHttpClient
 from .resources.billing import AsyncBilling, Billing as BillingResource
 from .resources.browsers import AsyncBrowsers, Browsers as BrowsersResource
@@ -111,7 +112,7 @@ class BrowserUse:
         keep_alive: bool | None = None,
         max_cost_usd: float | None = None,
         profile_id: str | None = None,
-        proxy_country_code: str | None = None,
+        proxy_country_code: str | None = _UNSET,  # type: ignore[assignment]
         workspace_id: str | None = None,
         enable_recording: bool | None = None,
         custom_proxy: dict[str, Any] | None = None,
@@ -154,7 +155,7 @@ class BrowserUse:
         keep_alive: bool | None = None,
         max_cost_usd: float | None = None,
         profile_id: str | None = None,
-        proxy_country_code: str | None = None,
+        proxy_country_code: str | None = _UNSET,  # type: ignore[assignment]
         workspace_id: str | None = None,
         enable_recording: bool | None = None,
         custom_proxy: dict[str, Any] | None = None,
@@ -294,7 +295,7 @@ class AsyncBrowserUse:
         keep_alive: bool | None = None,
         max_cost_usd: float | None = None,
         profile_id: str | None = None,
-        proxy_country_code: str | None = None,
+        proxy_country_code: str | None = _UNSET,  # type: ignore[assignment]
         workspace_id: str | None = None,
         enable_recording: bool | None = None,
         custom_proxy: dict[str, Any] | None = None,

--- a/browser-use-python/src/browser_use_sdk/v3/resources/browsers.py
+++ b/browser-use-python/src/browser_use_sdk/v3/resources/browsers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 from uuid import UUID
 
+from ..._core import _UNSET
 from ..._core.http import AsyncHttpClient, SyncHttpClient
 from ...generated.v3.models import (
     BrowserSessionItemView,
@@ -21,7 +22,7 @@ class Browsers:
         self,
         *,
         profile_id: str | None = None,
-        proxy_country_code: str | None = None,
+        proxy_country_code: str | None = _UNSET,  # type: ignore[assignment]
         timeout: int | None = None,
         browser_screen_width: int | None = None,
         browser_screen_height: int | None = None,
@@ -33,7 +34,7 @@ class Browsers:
         body: dict[str, Any] = {}
         if profile_id is not None:
             body["profileId"] = profile_id
-        if proxy_country_code is not None:
+        if proxy_country_code is not _UNSET:
             body["proxyCountryCode"] = proxy_country_code
         if timeout is not None:
             body["timeout"] = timeout
@@ -92,7 +93,7 @@ class AsyncBrowsers:
         self,
         *,
         profile_id: str | None = None,
-        proxy_country_code: str | None = None,
+        proxy_country_code: str | None = _UNSET,  # type: ignore[assignment]
         timeout: int | None = None,
         browser_screen_width: int | None = None,
         browser_screen_height: int | None = None,
@@ -104,7 +105,7 @@ class AsyncBrowsers:
         body: dict[str, Any] = {}
         if profile_id is not None:
             body["profileId"] = profile_id
-        if proxy_country_code is not None:
+        if proxy_country_code is not _UNSET:
             body["proxyCountryCode"] = proxy_country_code
         if timeout is not None:
             body["timeout"] = timeout

--- a/browser-use-python/src/browser_use_sdk/v3/resources/sessions.py
+++ b/browser-use-python/src/browser_use_sdk/v3/resources/sessions.py
@@ -5,6 +5,7 @@ import time
 from typing import Any
 from uuid import UUID
 
+from ..._core import _UNSET
 from ..._core.http import AsyncHttpClient, SyncHttpClient
 from ...generated.v3.models import (
     FileListResponse,
@@ -32,7 +33,7 @@ class Sessions:
         keep_alive: bool | None = None,
         max_cost_usd: float | None = None,
         profile_id: str | None = None,
-        proxy_country_code: str | None = None,
+        proxy_country_code: str | None = _UNSET,  # type: ignore[assignment]
         output_schema: dict[str, Any] | None = None,
         workspace_id: str | None = None,
         enable_scheduled_tasks: bool | None = None,
@@ -54,7 +55,7 @@ class Sessions:
             body["maxCostUsd"] = max_cost_usd
         if profile_id is not None:
             body["profileId"] = profile_id
-        if proxy_country_code is not None:
+        if proxy_country_code is not _UNSET:
             body["proxyCountryCode"] = proxy_country_code
         if output_schema is not None:
             body["outputSchema"] = output_schema
@@ -209,7 +210,7 @@ class AsyncSessions:
         keep_alive: bool | None = None,
         max_cost_usd: float | None = None,
         profile_id: str | None = None,
-        proxy_country_code: str | None = None,
+        proxy_country_code: str | None = _UNSET,  # type: ignore[assignment]
         output_schema: dict[str, Any] | None = None,
         workspace_id: str | None = None,
         enable_scheduled_tasks: bool | None = None,
@@ -231,7 +232,7 @@ class AsyncSessions:
             body["maxCostUsd"] = max_cost_usd
         if profile_id is not None:
             body["profileId"] = profile_id
-        if proxy_country_code is not None:
+        if proxy_country_code is not _UNSET:
             body["proxyCountryCode"] = proxy_country_code
         if output_schema is not None:
             body["outputSchema"] = output_schema

--- a/docs-audit-report.md
+++ b/docs-audit-report.md
@@ -267,7 +267,7 @@ The npm package `browser-use-sdk@3.3.1` does not export features the docs refere
 | Python Snippets | 3.2 min | 26 checked, 1 bug found |
 | TS Snippets | 7.5 min | 28 checked, 10 issues (SDK publishing gap) |
 | API Types Checker | 3.7 min | 12 discrepancies, auth header critical |
-| Link Checker | 7.5 min | 1 broken external link, 6 orphaned pages |
+| Link Checker | 7.5 min | 1 broken external link, 3 orphaned pages |
 | Persona: AI Startup | 2.7 min | Concurrent execution is #1 gap |
 | Persona: Embedder | 2.4 min | CSP and streaming events undocumented |
 | Persona: QA | 2.0 min | No Playwright compat matrix |

--- a/docs-audit-report.md
+++ b/docs-audit-report.md
@@ -1,261 +1,276 @@
 # Browser Use Docs Audit Report
 
 **Date:** 2026-03-30
-**Method:** 14 autonomous agents testing docs from different personas, code snippets, API types, links, llms.txt, and e2e flows.
-**Previous audit:** 2026-03-29 (6 agents, 47 issues). This audit is more comprehensive.
+**Method:** 12 parallel AI agents with different personas and test objectives
+**Scope:** All cloud docs, llms.txt, code snippets, API spec, chat UI example, link integrity
 
 ---
 
 ## Executive Summary
 
-| Area | Score | Status |
-|------|-------|--------|
-| **Overall Docs Quality** | **6.2/10** | Good foundation, significant gaps |
-| **Code Snippets (Python)** | **9.5/10** | 49/49 syntax pass, 1 SDK publish issue |
-| **Code Snippets (TypeScript)** | **7.7/10** | 34/44 pass, 4 SDK type bugs, 3 doc bugs |
-| **API Reference** | **5/10** | Wrong auth header (critical), many missing descriptions |
-| **llms.txt** | **7.5/10** | Good structure, needs less marketing, more params |
-| **Broken Links** | **3 found** | 1 internal, 2 external (dead GitHub repos) |
-| **Chat UI Example** | **4/10** | BLOCKER: published SDK missing asyncIterator |
+| Area | Score | Critical Issues |
+|------|-------|-----------------|
+| **llms.txt** | 7/10 | Marketing-heavy blockquote, missing `## Optional`, Python snippet incomplete |
+| **Python Snippets** | 25/26 pass | `proxy_country_code=None` doesn't disable proxies |
+| **TypeScript Snippets** | 18/28 pass | **Published SDK (v3.3.1) missing browsers, profiles, upload/download, async iterator** |
+| **Chat UI Example** | BROKEN | `npm run build` fails -- `SessionRun` has no `[Symbol.asyncIterator]` in published SDK |
+| **API Spec vs Docs** | 12 discrepancies | **Auth header wrong in cURL examples and llms-full.txt** |
+| **Broken Links** | 1 broken | `github.com/browser-use/browser-use-cli` is 404 |
+| **Persona: AI Startup** | 7.4/10 | No concurrency/parallel docs anywhere |
+| **Persona: Sub-agent Embedder** | 7.2/10 | CSP/iframe guidance missing, streaming events undocumented |
+| **Persona: QA Tester** | 5.5/10 | No Playwright feature compatibility matrix, no migration guide |
+| **Persona: Data Extraction** | 5.8/10 | No "scraping at scale" guide, no rate limits, no parallel examples |
+| **Persona: Enterprise** | 5.1/10 | No security/compliance page at all |
+| **File Upload/Profiles** | 6.3/10 | Undocumented SDK methods, inconsistent patterns, missing `stop()` in examples |
+
+**Overall Docs Intuitiveness Score: 6.2/10**
 
 ---
 
-## BLOCKERS (Fix Before Anything Else)
+## P0: Critical / Blocking Issues
 
-### 1. Published npm SDK (v3.3.1) missing `Symbol.asyncIterator`
-- **Impact:** `for await (const msg of run)` throws "run is not async iterable"
-- **Affects:** Chat UI example, streaming docs, every persona that tried streaming
-- **Root cause:** Local source has it (`helpers.ts:102`), but published dist is an older build (207 lines vs 451)
-- **Fix:** Republish npm package from current source
-- **Found by:** Chat UI tester, Automation persona, Embedder persona
+### 1. Chat UI Example is Broken
+- `npm run build` fails: `SessionRun<string>` has no `[Symbol.asyncIterator]()` in published SDK (v3.2.0)
+- The core streaming feature doesn't work -- users cannot clone and run this
+- Docs show simplified architecture that doesn't match actual code (SSE route handler missing from tutorial)
+- Docs reference `src/lib/session-context.tsx` but actual path is `src/context/session-context.tsx`
 
-### 2. Published PyPI SDK (v3.3.1) missing v3 resources
-- **Impact:** `client.browsers`, `client.profiles`, `client.billing` don't exist on published package
-- **Affects:** Proxies docs, Playwright integration, profile/auth docs
-- **Root cause:** Local source has all 5 resources, published package only has `sessions` + `workspaces`
-- **Fix:** Republish PyPI package from current source
-- **Found by:** Python snippets tester
+### 2. Auth Header Wrong in cURL Examples + llms-full.txt
+- OpenAPI spec: `X-Browser-Use-API-Key` header
+- `agent/quickstart.mdx` cURL: uses `Authorization: Bearer` -- **WRONG**
+- Both `llms-full.txt` files: use `Authorization: Bearer` -- **WRONG**
+- Every LLM consuming llms-full.txt will generate broken API calls
 
-### 3. `api-reference.mdx` uses wrong auth header
-- **Impact:** Every curl example on the hand-written API reference page fails
-- **Current (wrong):** `Authorization: Bearer bu_your_key_here`
-- **Correct:** `X-Browser-Use-API-Key: bu_your_key_here`
-- **Note:** Auto-generated Mintlify API pages are correct; only the hand-written overview is wrong
-- **Found by:** API types checker
+### 3. Published TS SDK Missing Major Features
+The npm package `browser-use-sdk@3.3.1` does not export features the docs reference:
+- `client.browsers` (6 snippets broken)
+- `client.profiles` (2 snippets broken)
+- `workspaces.upload()`, `.download()`, `.downloadAll()` (3 snippets broken)
+- `sessions.waitForRecording()` (1 snippet broken)
+- `SessionRun[Symbol.asyncIterator]` (streaming broken)
+- **~35% of TS code examples in docs fail with the published package**
 
----
-
-## Code Snippet Audit
-
-### Python (49 snippets tested)
-- **49/49 syntax pass** (100%)
-- **9/11 live tests pass** (2 failures were test setup issues, not doc bugs)
-- **1 warning:** `browsers.create(custom_proxy=...)` sends snake_case key via `**extra` instead of camelCase `customProxy`. Need to add `custom_proxy` as explicit parameter.
-
-### TypeScript (44 snippets tested)
-- **34/44 pass** (77%)
-- **4 SDK type bugs:** `browsers.create()` requires `timeout`, `allowResizing`, `enableRecording` as required fields (they have API defaults, should be optional in types)
-- **3 doc bugs (wrong property names):**
-  - `legacy/agent.mdx`: `upload.presignedUrl` → should be `upload.url`
-  - `legacy/agent.mdx`: `output.presignedUrl` → should be `output.downloadUrl`
-  - `legacy/public-share.mdx`: `share.url` → should be `share.shareUrl`
-- **1 null-safety issue:** `streaming.mdx`: `run.result.output` → should be `run.result!.output` or `run.result?.output`
-- **2 expected failures:** External deps (playwright, puppeteer-core) not installed
+### 4. `proxy_country_code=None` Doesn't Disable Proxies
+- SDK uses `if proxy_country_code is not None:` guard -- passing `None` just omits the field
+- API default (US proxy) still applies
+- Docs claim this disables proxies -- it doesn't
+- Affects both Python and TS SDKs
 
 ---
 
-## Broken Links
+## P1: High Priority Issues
 
-| Type | File | Link | Issue |
-|------|------|------|-------|
-| Internal | `cloud/browser/proxies.mdx:7` | `/cloud/api-v3/browsers/create-browser` | 404 — correct: `/cloud/api-v3/browsers/create-browser-session` |
-| External | `open-source/browser-use-cli.mdx:274` | `github.com/browser-use/profile-use` | Repo doesn't exist |
-| External | `open-source/customize/integrations/mcp-server.mdx:240` | `github.com/browser-use/browser-use/tree/main/examples/mcp` | Directory doesn't exist |
+### 5. Concurrency/Parallel Execution Not Documented Anywhere
+- Zero examples of running parallel sessions across entire docs
+- No `asyncio.gather()` / `Promise.all()` patterns shown
+- No rate limits documented (just "contact support")
+- No concurrency caps mentioned
+- **Blocks: AI startups, data extraction, QA testing personas**
 
----
+### 6. Model Values Undocumented
+- OpenAPI spec defines `bu-mini`, `bu-max`, `bu-ultra`
+- No docs page lists available models or explains the differences
+- Users have to guess or read the spec
 
-## API Reference Discrepancies
+### 7. SessionResponse Rich Fields Never Documented
+- `isTaskSuccessful` -- success/failure boolean
+- `totalCostUsd`, `llmCostUsd`, `proxyCostUsd`, `browserCostUsd` -- cost breakdown
+- `totalInputTokens`, `totalOutputTokens` -- token usage
+- `stepCount`, `lastStepSummary` -- progress tracking
+- `screenshotUrl` -- last screenshot
+- Users don't know these exist
 
-| # | Severity | Issue |
-|---|----------|-------|
-| 1 | **Critical** | Auth header wrong in `api-reference.mdx` (see Blockers) |
-| 2 | Should fix | `RunTaskRequest` — 13 fields have no description in OpenAPI spec |
-| 3 | Should fix | `SessionResponse` — all fields missing descriptions (titles are just camelCase names) |
-| 4 | Should fix | `GET /workspaces/{id}/size` — response schema is `{}` (empty) |
-| 5 | Should fix | Default `maxCostUsd` of $20 is undocumented |
-| 6 | Nice to have | `totalInputTokens`/`totalOutputTokens` meaning unclear |
-| 7 | Nice to have | `agentmailEmail` returned by default but not explained |
-| 8 | Nice to have | `output` field typed as "any" in spec but rendered as "object" in docs |
-
----
-
-## Persona Scorecard
-
-### Persona 1: AI Automation Startup ("just run tasks fast")
-| Metric | Score |
-|--------|-------|
-| Intuitiveness | 7/10 |
-| Time-to-value | 8/10 |
-| Completeness | 5/10 |
-
-**Journey:** 4 pages to first successful task. `client.run()` is genuinely simple.
-**Friction:** Two quickstart pages confuse; streaming broken; no pricing/cost info; no error handling examples.
-**Key ask:** Consolidate quickstarts, add pricing section, fix streaming.
-
-### Persona 2: Enterprise User
-| Metric | Score |
-|--------|-------|
-| Security docs | 4/10 |
-| Enterprise readiness | 3/10 |
-| Clarity | 6/10 |
-
-**Gaps (critical for enterprise):**
-- No compliance page (SOC 2, GDPR, data residency)
-- No data retention/deletion policy
-- No API key scoping, rotation, or RBAC
+### 8. No Security/Compliance Page
+- No SOC 2, GDPR, DPA documentation
+- No data retention policy
+- No encryption (at rest/in transit) documentation
+- No RBAC or API key scoping
 - No audit logging
-- No SLA documentation
-- `curl | sh` profile sync is a red flag
-- Auth story fragmented across 4 pages with no unifying guide
+- TOTP secrets travel as plaintext in prompts
+- **Blocks enterprise adoption**
 
-### Persona 3: Sub-agent Embedder (live browser in app)
-| Metric | Score |
-|--------|-------|
-| Embed docs | 6/10 |
-| Streaming docs | 3/10 |
-| Overall flow | 5/10 |
+### 9. Task Lifecycle/Status Mapping Never Explained
+- Webhook statuses: `running`, `idle`, `stopped` -- but no `completed`?
+- `idle` listed as terminal in streaming docs but means "session alive, task done"
+- No state diagram showing: created -> running -> idle/stopped/error/timed_out
+- Confusing across multiple pages
 
-**Friction:** Must read 4 pages to assemble the embed pattern. `liveUrl` is null from simple `run()` — not documented. Streaming broken in published SDK.
-**Key ask:** Add "Embed in Your App" recipe page showing full flow in one place.
-
-### Persona 4: QA Tester
-| Metric | Score |
-|--------|-------|
-| QA docs | 4/10 |
-| Playwright integration | 8/10 |
-| Clarity | 6/10 |
-
-**Friction:** No dedicated QA/testing guide. No CI/CD examples. No screenshot example on Playwright page. No parallel session guidance.
-**Key ask:** Add a "Testing & QA" guide page with pytest/Jest fixtures, CI/CD patterns, visual regression.
-
-### Persona 5: Data Extraction at Scale
-| Metric | Score |
-|--------|-------|
-| Extraction docs | 4/10 |
-| Structured output | 6/10 |
-| Proxy docs | 4/10 |
-
-**Friction:** No dedicated extraction guide. No concurrency/parallel execution docs. No pagination guidance. No cost estimation. No complex schema examples.
-**Key ask:** Add "Data Extraction at Scale" guide with parallel patterns, pagination, proxy rotation.
+### 10. `sessions.stop()` Missing From Profile Examples
+- Warning says "Always call `sessions.stop()` when done" to persist profile state
+- Zero code examples actually call `sessions.stop()`
+- Data-loss footgun -- users copy examples, skip stop, lose profile state
 
 ---
 
-## llms.txt Evaluation
+## P2: Medium Priority Issues
 
-**Score: 7.5/10**
+### 11. llms.txt Improvements
+- Blockquote too marketing-heavy -- should be technical ("Browser Use Cloud is a managed API for...")
+- Missing `## Optional` section -- Legacy/v2 content should go there
+- Python quick start missing `asyncio.run()` wrapper
+- Duplicate GitHub link (lines 5 and 8)
+- No curl example
+- No LLM behavioral instructions (e.g., "Always use v3")
 
-**What's good:**
-- Strong structure, clear hierarchy
-- Inline code for quick start (most llms.txt files don't do this)
-- v3 callout prevents outdated code generation
-- Pointer to llms-full.txt
+### 12. Profile Docs Inconsistencies
+- Two-step flow shown when `client.run(..., profile_id=...)` works directly (simpler)
+- Workspaces docs use the simpler one-step pattern -- inconsistent
+- `user_id` field on `profiles.create()` undocumented (key production pattern)
+- No full lifecycle example (create -> login -> save -> reuse later)
+- Profile sync page too thin -- doesn't explain what the `curl | sh` script does
 
-**What to improve:**
-1. Blockquote is too marketing-heavy ("most SOTA", "most scalable") — LLMs need facts, not persuasion
-2. Duplicate GitHub link (lines 5 and 8)
-3. No `## Optional` section for legacy/v2 content (per llmstxt.org spec)
-4. Top-level links are unstructured — should be under `## Resources`
-5. No size hint for llms-full.txt (~60KB)
-6. Links point to HTML pages, not `.md` variants (if Mintlify supports them)
-7. Missing key parameters list for `client.run()`
+### 13. Workspace Docs Gaps
+- `workspaces.files()` undocumented -- users can't inspect workspace contents
+- `workspaces.delete_file()` undocumented
+- `workspaces.size()` undocumented
+- `prefix` parameter for directory organization undocumented
+- No file size limits or supported types documented
+- No explanation of how agent accesses files (mount path?)
+- **TS SDK bug**: `download()` doesn't paginate -- fails for workspaces with many files
 
-**llms.txt navigation test (can AI build from it alone?):**
-- llms.txt navigability: **8/10** — great sitemap, but not enough to write code beyond basics
-- llms-full.txt completeness: **7/10** — good but has zod v4 omission and wrong `client.profiles` examples for TS
+### 14. QA Testing Gaps
+- No Playwright feature compatibility matrix (screenshots? network interception? tracing?)
+- No migration guide from existing Playwright tests
+- No CI integration guidance (GitHub Actions, Jenkins)
+- Network/staging access model undocumented ("Can the browser reach my private server?")
+- No parallel browser session docs for test suites
+
+### 15. Data Extraction Gaps
+- No "Scraping at Scale" guide
+- Proxy rotation across sessions undocumented
+- Pagination patterns not covered
+- No batch/queue API guidance
+- CAPTCHA solving mentioned in quickstart but never explained
+- No cost estimation guidance
+
+### 16. Streaming Event Types Undocumented
+- `role` and `type` fields mentioned but all possible values never listed
+- Developers building UIs must guess what event shapes look like
+- No error handling/reconnection patterns for stream failures
+
+### 17. CSP/iframe Embedding Undocumented
+- Live preview iframe embedding shown but CSP `frame-ancestors` issues never mentioned
+- Guaranteed production blocker for anyone embedding the browser view
+- No responsive sizing guidance
+
+### 18. Human-in-the-Loop is CLI-Only
+- Examples use `input()` / readline -- only works in CLI
+- No web app pattern (webhook, button click, state machine)
+- No timeout/cleanup guidance (what if human never resumes?)
 
 ---
 
-## Chat UI Example
+## P3: Low Priority / Polish
 
-**Score: 4/10**
+### 19. Broken External Link
+- `https://github.com/browser-use/browser-use-cli` in `browser-use-cli.mdx` -- 404
 
-**BLOCKER:** Published SDK doesn't have `Symbol.asyncIterator`, so `npm run build` fails with:
-```
-Type 'SessionRun<string>' must have a '[Symbol.asyncIterator]()' method
-```
+### 20. Orphaned Pages
+- `open-source/development.mdx` -- not in navigation, not linked
+- `open-source/customize/skills/basics.mdx` -- only referenced from agent params page
+- `open-source/development/roadmap.mdx` -- empty ("Big things coming soon!")
 
-**Other issues:**
-- Docs page has ZERO setup commands (no `git clone`, `npm install`, `npm run dev`)
-- It's a conceptual guide, not a tutorial — setup instructions only exist in the GitHub repo README
-- Should at minimum include quick-start commands on the docs page
+### 21. Minor Type Issues
+- `browsers.create()` -- OpenAPI codegen makes defaulted fields required instead of optional
+- `run.result.output` -- null safety issue (`result` can be null)
+- `profileId` type UUID vs string inconsistency between spec and SDK
 
----
-
-## File Upload/Download
-
-**Score: Docs 6/10, Functionality 8/10**
-
-**What works:** All file types upload/download correctly. Round-trip integrity confirmed. Agent can read uploaded files and write new ones.
-
-**What's missing from docs:**
-- File size limits
-- Supported file types (SDK supports 20+ MIME types, undocumented)
-- `prefix` parameter for organizing files
-- `delete_file()` method
-- `size()` endpoint
-- Workspace lifecycle/persistence
-- Agent leaves cache artifacts in workspace (undocumented)
+### 22. Docs vs Chat UI Code Discrepancies
+- Docs import only v3, actual code imports both v2 and v3 (profiles not on v3 yet)
+- Docs show `for await` in context, actual code uses SSE route handler pattern
+- SSE route handler architecture completely absent from tutorial
+- `createSession` in actual code accepts many more params than docs show
 
 ---
 
-## Profile System
+## Persona Scorecards
 
-**Score: Docs 7/10, API 8/10, SDK 9/10**
+### AI Automation Startup (15-20 min to first success)
+| Page | Clarity | Completeness | Time to Success | Code Quality |
+|------|---------|-------------|-----------------|-------------|
+| Quickstart | 8 | 6 | 9 | 8 |
+| Structured Output | 9 | 7 | 8 | 9 |
+| Agent Quickstart | 7 | 5 | 8 | 7 |
+| Webhooks | 8 | 7 | 7 | 8 |
+| Vibecoding | 6 | 3 | N/A | N/A |
+| **Blocking issue:** No concurrent/parallel execution docs |||||
 
-**Key issue:** Main profiles doc is `authentication.mdx` at URL `/guides/authentication` under sidebar group "Authentication". A user searching for "profiles" won't find it easily.
+### Sub-agent Embedder (2-4 hours to prototype)
+| Page | Score | Notes |
+|------|-------|-------|
+| Quickstart | 7 | No mention of liveUrl, streaming, or sessions |
+| Live Preview | 6 | No CSP guidance, no responsive sizing |
+| Streaming | 8 | Best page -- `for await` is the aha moment |
+| Human in the Loop | 7 | CLI-only examples |
+| Follow-up Tasks | 7 | "Agents don't share context" is alarming, under-explained |
+| Chat UI Tutorial | 8 | Ties everything together, but broken in practice |
+| **Blocking issue:** CSP, streaming event reference, broken chat UI ||
 
-**Missing:**
-- No explanation of what a profile actually stores
-- `user_id` field is undocumented
-- No curl/raw API examples
-- Warning about `sessions.stop()` saving profile state is buried at bottom
+### QA Tester (2-4 hours basic migration)
+| Page | Score | Notes |
+|------|-------|-------|
+| Quickstart | 5 | Not oriented toward QA use case |
+| Playwright/CDP | 8 | Strongest page -- CDP flow crystal clear |
+| Stealth | 4 | Low relevance for testing own app |
+| Proxies | 5 | Doesn't explain network access model |
+| Authentication | 7 | No Playwright-with-profile flow shown |
+| Live Preview | 7 | No screenshot support clarity |
+| **Blocking issue:** No feature compatibility matrix, no parallel sessions, no CI guide ||
+
+### Data Extraction at Scale
+| Page | Score | Notes |
+|------|-------|-------|
+| Quickstart | 5 | No scale/batch patterns |
+| Structured Output | 7 | Good pattern, no failure handling |
+| Proxies | 6 | No rotation docs |
+| Stealth | 6 | No success rate info |
+| Agent Quickstart | 7 | Mentions "thousands of listings" but no example |
+| FAQ | 4 | Rate limits = "contact support" |
+| **Blocking issue:** No scale guide, no concurrency docs, no pricing ||
+
+### Enterprise Architect (5.1/10 overall)
+| Area | Score | Notes |
+|------|-------|-------|
+| API Key Security | 4 | No RBAC, no key scoping, no rotation docs |
+| Data Handling | 3 | No retention policy, no encryption docs |
+| Compliance | 1 | No SOC 2, GDPR, DPA -- nothing |
+| Webhooks | 8 | Proper HMAC-SHA256 -- best security page |
+| Integration | 5 | MCP works, no SSO/SAML |
+| Reliability | 3 | No SLA, no status page, no error codes |
+| **Blocking issue:** No security page exists at all ||
 
 ---
 
 ## Top 10 Recommendations (Priority Order)
 
-### Must Fix Now
-1. **Republish npm package** — include `Symbol.asyncIterator` in v3 dist
-2. **Republish PyPI package** — include `browsers`, `profiles`, `billing` resources in v3
-3. **Fix auth header in `api-reference.mdx`** — change `Authorization: Bearer` to `X-Browser-Use-API-Key`
-4. **Fix 3 broken links** (proxies internal link, 2 dead GitHub repos)
-
-### Should Fix Soon
-5. **Fix TS doc bugs** — wrong property names in legacy docs (`presignedUrl` → `url`/`downloadUrl`, `share.url` → `share.shareUrl`)
-6. **Fix SDK types** — make `CreateBrowserSessionRequest` fields with defaults optional; add `custom_proxy` as explicit param to Python `browsers.create()`
-7. **Add setup commands to chat-ui tutorial page** (clone, install, env, run)
-
-### Should Add (New Content)
-8. **"Embed in Your App" recipe page** — single page showing full embed flow
-9. **"Data Extraction at Scale" guide** — parallel patterns, pagination, complex schemas
-10. **"Testing & QA" guide** — pytest/Jest fixtures, CI/CD, screenshots, parallel sessions
-
-### Nice to Have
-- Consolidate two quickstart pages into one
-- Add OpenAPI field descriptions for RunTaskRequest and SessionResponse
-- Add `## Optional` section to llms.txt for legacy content
-- Rewrite llms.txt blockquote to be factual, not marketing
-- Add pricing/cost section to docs
-- Add error handling examples
-- Document `maxCostUsd` default of $20
-- Document workspace lifecycle and file size limits
-- Rename `authentication.mdx` → `profiles.mdx` (or add "Profiles" to sidebar title)
-- Add unified "Authentication Architecture" page for enterprise users
-- Add compliance/security page for enterprise evaluation
-- Document concurrency limits and parallel execution patterns
-- Add zod v4 requirement note to structured output docs
+1. **Publish the SDK** -- browsers, profiles, upload/download, waitForRecording, async iterator all need to ship to npm/PyPI
+2. **Fix auth header** in `agent/quickstart.mdx` cURL and both `llms-full.txt` files (use `X-Browser-Use-API-Key`)
+3. **Fix chat UI example** -- either publish SDK with async iterator or rewrite to use polling
+4. **Add concurrency/parallel docs** -- examples, rate limits, caps. Every persona needs this
+5. **Add a security/trust page** -- SOC 2 status, data retention, encryption, DPA availability
+6. **Document model values** -- what are `bu-mini`, `bu-max`, `bu-ultra` and when to use each
+7. **Document SessionResponse fields** -- cost breakdown, token usage, isTaskSuccessful
+8. **Add task lifecycle state diagram** -- created -> running -> idle/stopped/error/timed_out
+9. **Fix proxy disable docs** -- `None`/`null` doesn't disable proxies, document the correct way
+10. **Add `sessions.stop()` to all profile examples** -- prevent data loss
 
 ---
 
-*Report generated by 14 autonomous agents testing docs from different angles.*
-*Full path: `/Users/magnus/.superset/worktrees/sdk/magnus/citrine-function/docs-audit-report.md`*
+## Methodology
+
+12 AI agents ran in parallel, each with a specific persona or test objective:
+
+| Agent | Duration | Findings |
+|-------|----------|----------|
+| Chat UI Tester | 4.8 min | Build broken, code/docs mismatch |
+| llms.txt Researcher | 3.0 min | 7/10 score, 7 improvements identified |
+| Python Snippets | 3.2 min | 26 checked, 1 bug found |
+| TS Snippets | 7.5 min | 28 checked, 10 issues (SDK publishing gap) |
+| API Types Checker | 3.7 min | 12 discrepancies, auth header critical |
+| Link Checker | 7.5 min | 1 broken external link, 6 orphaned pages |
+| Persona: AI Startup | 2.7 min | Concurrent execution is #1 gap |
+| Persona: Embedder | 2.4 min | CSP and streaming events undocumented |
+| Persona: QA | 2.0 min | No Playwright compat matrix |
+| Persona: Scraper | 2.3 min | No scale guide |
+| Persona: Enterprise | 2.3 min | No security page |
+| File/Profiles | 3.0 min | Inconsistent patterns, undocumented methods |

--- a/docs/cloud/agent/quickstart.mdx
+++ b/docs/cloud/agent/quickstart.mdx
@@ -25,7 +25,7 @@ console.log(result.output);
 ```
 ```bash curl
 curl -X POST https://api.browser-use.com/api/v3/sessions \
-  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "X-Browser-Use-API-Key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"task": "List the top 20 posts on Hacker News today with their points"}'
 ```

--- a/docs/cloud/legacy/agent.mdx
+++ b/docs/cloud/legacy/agent.mdx
@@ -56,7 +56,7 @@ upload = await client.files.session_url(
 
 with open("input.pdf", "rb") as f:
     async with httpx.AsyncClient() as http:
-        await http.put(upload.presigned_url, content=f.read(), headers={"Content-Type": "application/pdf"})
+        await http.post(upload.url, content=f.read(), headers={"Content-Type": "application/pdf"})
 
 result = await client.run("Summarize the uploaded PDF", session_id=session.id)
 ```
@@ -94,7 +94,7 @@ const result = await client.run("Summarize the uploaded PDF", { sessionId: sessi
 result = await client.tasks.get(task_id)
 for file in result.output_files:
     output = await client.files.task_output(task_id, file.id)
-    print(output.presigned_url)  # download URL
+    print(output.download_url)  # download URL
 ```
 ```typescript TypeScript
 const result = await client.tasks.get(taskId);

--- a/docs/cloud/legacy/agent.mdx
+++ b/docs/cloud/legacy/agent.mdx
@@ -73,8 +73,8 @@ const upload = await client.files.sessionUrl(session.id, {
   sizeBytes: 1024,
 });
 
-await fetch(upload.presignedUrl, {
-  method: "PUT",
+await fetch(upload.url, {
+  method: "POST",
   body: readFileSync("input.pdf"),
   headers: { "Content-Type": "application/pdf" },
 });
@@ -100,7 +100,7 @@ for file in result.output_files:
 const result = await client.tasks.get(taskId);
 for (const file of result.outputFiles) {
   const output = await client.files.taskOutput(taskId, file.id);
-  console.log(output.presignedUrl);
+  console.log(output.downloadUrl);
 }
 ```
 </CodeGroup>

--- a/docs/cloud/legacy/agent.mdx
+++ b/docs/cloud/legacy/agent.mdx
@@ -37,7 +37,7 @@ Upload images, PDFs, documents, and text files (10 MB max) to sessions, and down
 
 ### Upload a file
 
-Get a presigned URL, then upload via PUT.
+Get a presigned URL, then upload via POST.
 
 <CodeGroup>
 ```python Python

--- a/docs/cloud/legacy/public-share.mdx
+++ b/docs/cloud/legacy/public-share.mdx
@@ -9,10 +9,10 @@ Generate a public URL that anyone can open to watch the entire agent session —
 <CodeGroup>
 ```python Python
 share = await client.sessions.create_share(session.id)
-print(share.url)
+print(share.share_url)
 ```
 ```typescript TypeScript
 const share = await client.sessions.createShare(session.id);
-console.log(share.url);
+console.log(share.shareUrl);
 ```
 </CodeGroup>

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -27,9 +27,9 @@ import asyncio
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 async def main():
-    client = AsyncBrowserUse()
-    result = await client.run("List the top 20 posts on Hacker News today with their points")
-    print(result.output)
+client = AsyncBrowserUse()
+result = await client.run("List the top 20 posts on Hacker News today with their points")
+print(result.output)
 
 asyncio.run(main())
 ```
@@ -128,20 +128,20 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 from pydantic import BaseModel
 
 class Post(BaseModel):
-    name: str
-    points: int
-    comments: int
+name: str
+points: int
+comments: int
 
 class HNPosts(BaseModel):
-    posts: list[Post]
+posts: list[Post]
 
 client = AsyncBrowserUse()
 result = await client.run(
-    "List the top 20 posts on Hacker News today with their points",
-    output_schema=HNPosts,
+"List the top 20 posts on Hacker News today with their points",
+output_schema=HNPosts,
 )
 for post in result.output.posts:
-    print(f"{post.name} ({post.points} pts, {post.comments} comments)")
+print(f"{post.name} ({post.points} pts, {post.comments} comments)")
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
@@ -183,12 +183,12 @@ client = AsyncBrowserUse()
 session = await client.sessions.create()
 
 result1 = await client.run(
-    "Go to amazon.com, search for laptops, and open the first result",
-    session_id=session.id,
+"Go to amazon.com, search for laptops, and open the first result",
+session_id=session.id,
 )
 result2 = await client.run(
-    "Extract the customer reviews",
-    session_id=session.id,
+"Extract the customer reviews",
+session_id=session.id,
 )
 
 await client.sessions.stop(session.id)
@@ -231,7 +231,7 @@ client = AsyncBrowserUse()
 
 run = client.run("Find the top story on Hacker News")
 async for msg in run:
-    print(f"[{msg.role}] {msg.summary}")
+print(f"[{msg.role}] {msg.summary}")
 
 print(run.result.output)
 ```
@@ -270,15 +270,15 @@ session = await client.sessions.create(task="Find the top story on Hacker News")
 
 cursor = None
 while True:
-    msgs = await client.sessions.messages(session.id, after=cursor, limit=100)
-    for m in msgs.messages:
-        print(f"[{m.role}] {m.summary}")
-        cursor = m.id
+msgs = await client.sessions.messages(session.id, after=cursor, limit=100)
+for m in msgs.messages:
+    print(f"[{m.role}] {m.summary}")
+    cursor = m.id
 
-    s = await client.sessions.get(session.id)
-    if s.status.value in ("idle", "stopped", "error", "timed_out"):
-        break
-    await asyncio.sleep(2)
+s = await client.sessions.get(session.id)
+if s.status.value in ("idle", "stopped", "error", "timed_out"):
+    break
+await asyncio.sleep(2)
 
 print(s.output)
 ```
@@ -294,14 +294,14 @@ let cursor: string | undefined;
 while (true) {
   const msgs = await client.sessions.messages(session.id, { after: cursor, limit: 100 });
   for (const m of msgs.messages) {
-    console.log(`[${m.role}] ${m.summary}`);
-    cursor = m.id;
+console.log(`[${m.role}] ${m.summary}`);
+cursor = m.id;
   }
 
   const s = await client.sessions.get(session.id);
   if (["idle", "stopped", "error", "timed_out"].includes(s.status)) {
-    console.log(s.output);
-    break;
+console.log(s.output);
+break;
   }
   await new Promise((r) => setTimeout(r, 2000));
 }
@@ -335,8 +335,8 @@ await client.workspaces.upload(workspace.id, "people.csv")
 
 # Agent can now read it
 result = await client.run(
-    "Read people.csv and tell me who works at Google",
-    workspace_id=workspace.id,
+"Read people.csv and tell me who works at Google",
+workspace_id=workspace.id,
 )
 print(result.output)
 ```
@@ -376,8 +376,8 @@ workspace = await client.workspaces.create(name="my-workspace")
 
 # Agent creates a file
 result = await client.run(
-    "Go to Hacker News and save the top 3 posts as posts.json",
-    workspace_id=workspace.id,
+"Go to Hacker News and save the top 3 posts as posts.json",
+workspace_id=workspace.id,
 )
 
 # Download a single file
@@ -386,7 +386,7 @@ await client.workspaces.download(workspace.id, "posts.json", to="./posts.json")
 # Or download everything
 paths = await client.workspaces.download_all(workspace.id, to="./output")
 for p in paths:
-    print(f"Downloaded: {p}")
+print(f"Downloaded: {p}")
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
@@ -417,7 +417,7 @@ workspace = await client.workspaces.get(workspace_id)
 updated = await client.workspaces.update(workspace_id, name="renamed")
 response = await client.workspaces.list()
 for w in response.items:
-    print(w.id, w.name)
+print(w.id, w.name)
 await client.workspaces.delete(workspace_id)
 ```
 ```typescript TypeScript
@@ -462,8 +462,8 @@ print(f"Live view: {session.live_url}")
 
 # 2. Agent does the first part
 result = await client.run(
-    "Go to amazon.com and search for noise cancelling headphones",
-    session_id=session.id,
+"Go to amazon.com and search for noise cancelling headphones",
+session_id=session.id,
 )
 print(result.output)
 
@@ -472,8 +472,8 @@ input("Press Enter after you've selected a product in the live view...")
 
 # 4. Agent continues where the human left off
 result = await client.run(
-    "Get the details of the selected product — name, price, and rating",
-    session_id=session.id,
+"Get the details of the selected product — name, price, and rating",
+session_id=session.id,
 )
 print(result.output)
 
@@ -591,12 +591,12 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 browser = await client.browsers.create(
-    custom_proxy={
-        "host": "proxy.example.com",
-        "port": 8080,
-        "username": "user",
-        "password": "pass",
-    },
+custom_proxy={
+    "host": "proxy.example.com",
+    "port": 8080,
+    "username": "user",
+    "password": "pass",
+},
 )
 ```
 ```typescript TypeScript
@@ -605,10 +605,10 @@ import { BrowserUse } from "browser-use-sdk/v3";
 const client = new BrowserUse();
 const browser = await client.browsers.create({
   customProxy: {
-    host: "proxy.example.com",
-    port: 8080,
-    username: "user",
-    password: "pass",
+host: "proxy.example.com",
+port: 8080,
+username: "user",
+password: "pass",
   },
 });
 ```
@@ -687,14 +687,14 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 result = await client.run(
-    "Check how many GitHub stars browser-use has",
-    enable_recording=True,
+"Check how many GitHub stars browser-use has",
+enable_recording=True,
 )
 
 # Waits up to 15s for recording to be ready. Returns [] if no browser was opened.
 urls = await client.sessions.wait_for_recording(result.id)
 for url in urls:
-    print(url)  # presigned MP4 download URL
+print(url)  # presigned MP4 download URL
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
@@ -753,11 +753,11 @@ from playwright.async_api import async_playwright
 WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us"
 
 async with async_playwright() as p:
-    browser = await p.chromium.connect_over_cdp(WSS_URL)
-    page = browser.contexts[0].pages[0]
-    await page.goto("https://example.com")
-    print(await page.title())
-    await browser.close()
+browser = await p.chromium.connect_over_cdp(WSS_URL)
+page = browser.contexts[0].pages[0]
+await page.goto("https://example.com")
+print(await page.title())
+await browser.close()
 # Browser is automatically stopped when the WebSocket disconnects
 ```
 ```typescript TypeScript
@@ -882,7 +882,7 @@ profile = await client.profiles.create(name="work-account")
 # List all
 response = await client.profiles.list()
 for p in response.items:
-    print(p.id, p.name)
+print(p.id, p.name)
 
 # Search by name
 response = await client.profiles.list(query="user-id-1")
@@ -1048,8 +1048,8 @@ print(f"Live view: {session.live_url}")
 
 # Agent navigates to login
 result = await client.run(
-    "Go to example.com/login and enter username user@example.com and password mypassword, then stop before 2FA",
-    session_id=session.id,
+"Go to example.com/login and enter username user@example.com and password mypassword, then stop before 2FA",
+session_id=session.id,
 )
 
 # Human completes 2FA in the live view
@@ -1057,8 +1057,8 @@ input("Complete 2FA in the live view, then press Enter...")
 
 # Agent continues
 result = await client.run(
-    "You are now logged in. Go to the dashboard and export the monthly report",
-    session_id=session.id,
+"You are now logged in. Go to the dashboard and export the monthly report",
+session_id=session.id,
 )
 print(result.output)
 await client.sessions.stop(session.id)
@@ -1107,14 +1107,14 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 client = AsyncBrowserUse()
 
 result = await client.run(
-    """
-    1. Go to example.com/signup
-    2. Sign up with the agent's email address (use the email available to you)
-    3. Check your email inbox for the verification code
-    4. Enter the code on the website
-    5. Complete the registration
-    """,
-    agentmail=True,  # default, shown for clarity
+"""
+1. Go to example.com/signup
+2. Sign up with the agent's email address (use the email available to you)
+3. Check your email inbox for the verification code
+4. Enter the code on the website
+5. Complete the registration
+""",
+agentmail=True,  # default, shown for clarity
 )
 print(result.output)
 ```
@@ -1164,16 +1164,16 @@ client = AsyncBrowserUse()
 totp_secret = "JBSWY3DPEHPK3PXP"
 
 result = await client.run(
-    f"""
-    Log into example.com with username user@example.com and password mypassword.
-    When prompted for a 2FA code, generate one using pyotp:
+f"""
+Log into example.com with username user@example.com and password mypassword.
+When prompted for a 2FA code, generate one using pyotp:
 
-    import pyotp
-    totp = pyotp.TOTP("{totp_secret}")
-    code = totp.now()
+import pyotp
+totp = pyotp.TOTP("{totp_secret}")
+code = totp.now()
 
-    Enter the generated code.
-    """,
+Enter the generated code.
+""",
 )
 print(result.output)
 ```
@@ -1211,10 +1211,10 @@ This works because the Browser Use agent can execute Python code as part of its 
 
 ## Which approach should I use?
 
-    Start with **Profiles** — log in once, reuse cookies. If cookies expire frequently, add **TOTP secret in prompt** for fully automated re-login.
-    Use **Profiles** with one profile per user. For initial login, use **Human in the loop** — your user logs in once via the live view, then the agent reuses the session. For email 2FA, set up **Agent Mail** with email forwarding from your user.
-    Use **Agent Mail** (enabled by default). For end-client scenarios, have them forward 2FA emails to a dedicated inbox.
-    Use **TOTP secret in prompt** — the agent generates codes via pyotp, no human intervention needed.
+Start with **Profiles** — log in once, reuse cookies. If cookies expire frequently, add **TOTP secret in prompt** for fully automated re-login.
+Use **Profiles** with one profile per user. For initial login, use **Human in the loop** — your user logs in once via the live view, then the agent reuses the session. For email 2FA, set up **Agent Mail** with email forwarding from your user.
+Use **Agent Mail** (enabled by default). For end-client scenarios, have them forward 2FA emails to a dedicated inbox.
+Use **TOTP secret in prompt** — the agent generates codes via pyotp, no human intervention needed.
 
 
 # OpenClaw
@@ -1244,16 +1244,16 @@ Open `~/.openclaw/openclaw.json` and add a `browser-use` profile:
 ```json5
 {
   browser: {
-    enabled: true,
-    defaultProfile: "browser-use",
-    remoteCdpTimeoutMs: 3000,
-    remoteCdpHandshakeTimeoutMs: 5000,
-    profiles: {
-      "browser-use": {
-        cdpUrl: "wss://connect.browser-use.com?apiKey=<BROWSER_USE_API_KEY>&proxyCountryCode=us",
-        color: "#ff750e",
-      },
-    },
+enabled: true,
+defaultProfile: "browser-use",
+remoteCdpTimeoutMs: 3000,
+remoteCdpHandshakeTimeoutMs: 5000,
+profiles: {
+  "browser-use": {
+    cdpUrl: "wss://connect.browser-use.com?apiKey=<BROWSER_USE_API_KEY>&proxyCountryCode=us",
+    color: "#ff750e",
+  },
+},
   },
 }
 ```
@@ -1336,12 +1336,12 @@ Add to `claude_desktop_config.json`:
 ```json
 {
   "mcpServers": {
-    "browser-use": {
-      "url": "https://api.browser-use.com/v3/mcp",
-      "headers": {
-        "x-browser-use-api-key": "YOUR_API_KEY"
-      }
-    }
+"browser-use": {
+  "url": "https://api.browser-use.com/v3/mcp",
+  "headers": {
+    "x-browser-use-api-key": "YOUR_API_KEY"
+  }
+}
   }
 }
 ```
@@ -1353,12 +1353,12 @@ Add to `.cursor/mcp.json`:
 ```json
 {
   "mcpServers": {
-    "browser-use": {
-      "url": "https://api.browser-use.com/v3/mcp",
-      "headers": {
-        "x-browser-use-api-key": "YOUR_API_KEY"
-      }
-    }
+"browser-use": {
+  "url": "https://api.browser-use.com/v3/mcp",
+  "headers": {
+    "x-browser-use-api-key": "YOUR_API_KEY"
+  }
+}
   }
 }
 ```
@@ -1370,12 +1370,12 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 ```json
 {
   "mcpServers": {
-    "browser-use": {
-      "serverUrl": "https://api.browser-use.com/v3/mcp",
-      "headers": {
-        "x-browser-use-api-key": "YOUR_API_KEY"
-      }
-    }
+"browser-use": {
+  "serverUrl": "https://api.browser-use.com/v3/mcp",
+  "headers": {
+    "x-browser-use-api-key": "YOUR_API_KEY"
+  }
+}
   }
 }
 ```
@@ -1413,10 +1413,10 @@ Set up webhooks at [cloud.browser-use.com/settings?tab=webhooks](https://cloud.b
   "type": "agent.task.status_update",
   "timestamp": "2025-01-15T10:30:00Z",
   "payload": {
-    "task_id": "task_abc123",
-    "session_id": "session_xyz",
-    "status": "idle",
-    "metadata": {}
+"task_id": "task_abc123",
+"session_id": "session_xyz",
+"status": "idle",
+"metadata": {}
   }
 }
 ```
@@ -1437,17 +1437,17 @@ import json
 import time
 
 def verify_webhook(body: bytes, signature: str, timestamp: str, secret: str) -> bool:
-    # Reject requests older than 5 minutes
-    try:
-        ts = int(timestamp)
-    except (ValueError, TypeError):
-        return False
-    if abs(time.time() - ts) > 300:
-        return False
-    payload = json.loads(body)
-    message = f"{timestamp}.{json.dumps(payload, separators=(',', ':'), sort_keys=True)}"
-    expected = hmac.new(secret.encode(), message.encode(), hashlib.sha256).hexdigest()
-    return hmac.compare_digest(expected, signature)
+# Reject requests older than 5 minutes
+try:
+    ts = int(timestamp)
+except (ValueError, TypeError):
+    return False
+if abs(time.time() - ts) > 300:
+    return False
+payload = json.loads(body)
+message = f"{timestamp}.{json.dumps(payload, separators=(',', ':'), sort_keys=True)}"
+expected = hmac.new(secret.encode(), message.encode(), hashlib.sha256).hexdigest()
+return hmac.compare_digest(expected, signature)
 ```
 ```typescript TypeScript
 import { createHmac, timingSafeEqual } from "crypto";
@@ -1455,12 +1455,12 @@ import { createHmac, timingSafeEqual } from "crypto";
 function sortKeys(obj: unknown): unknown {
   if (Array.isArray(obj)) return obj.map(sortKeys);
   if (obj !== null && typeof obj === "object") {
-    return Object.keys(obj as object)
-      .sort()
-      .reduce((acc, key) => {
-        (acc as Record<string, unknown>)[key] = sortKeys((obj as Record<string, unknown>)[key]);
-        return acc;
-      }, {} as Record<string, unknown>);
+return Object.keys(obj as object)
+  .sort()
+  .reduce((acc, key) => {
+    (acc as Record<string, unknown>)[key] = sortKeys((obj as Record<string, unknown>)[key]);
+    return acc;
+  }, {} as Record<string, unknown>);
   }
   return obj;
 }
@@ -1489,12 +1489,12 @@ const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET!;
 function sortKeys(obj: unknown): unknown {
   if (Array.isArray(obj)) return obj.map(sortKeys);
   if (obj !== null && typeof obj === "object") {
-    return Object.keys(obj as object)
-      .sort()
-      .reduce((acc, key) => {
-        (acc as Record<string, unknown>)[key] = sortKeys((obj as Record<string, unknown>)[key]);
-        return acc;
-      }, {} as Record<string, unknown>);
+return Object.keys(obj as object)
+  .sort()
+  .reduce((acc, key) => {
+    (acc as Record<string, unknown>)[key] = sortKeys((obj as Record<string, unknown>)[key]);
+    return acc;
+  }, {} as Record<string, unknown>);
   }
   return obj;
 }
@@ -1504,7 +1504,7 @@ app.post("/webhook", (req, res) => {
   const timestamp = req.headers["x-browser-use-timestamp"] as string;
 
   if (Math.abs(Date.now() / 1000 - parseInt(timestamp)) > 300) {
-    return res.status(401).send("Request too old");
+return res.status(401).send("Request too old");
   }
 
   const body = req.body.toString();
@@ -1513,12 +1513,12 @@ app.post("/webhook", (req, res) => {
   const expected = createHmac("sha256", WEBHOOK_SECRET).update(message).digest("hex");
 
   if (!timingSafeEqual(Buffer.from(expected), Buffer.from(signature))) {
-    return res.status(401).send("Invalid signature");
+return res.status(401).send("Invalid signature");
   }
 
   if (payload.type === "agent.task.status_update") {
-    const { task_id, status, session_id } = payload.payload;
-    console.log(`Task ${task_id} is now ${status}`);
+const { task_id, status, session_id } = payload.payload;
+console.log(`Task ${task_id} is now ${status}`);
   }
 
   res.status(200).send("OK");
@@ -1543,31 +1543,31 @@ WEBHOOK_SECRET = os.environ["WEBHOOK_SECRET"]
 
 @app.post("/webhook")
 async def handle_webhook(request: Request):
-    body = await request.body()
-    signature = request.headers.get("x-browser-use-signature", "")
-    timestamp = request.headers.get("x-browser-use-timestamp", "")
+body = await request.body()
+signature = request.headers.get("x-browser-use-signature", "")
+timestamp = request.headers.get("x-browser-use-timestamp", "")
 
-    # Reject requests older than 5 minutes
-    try:
-        ts = int(timestamp)
-    except (ValueError, TypeError):
-        raise HTTPException(status_code=401, detail="Invalid timestamp")
-    if abs(time.time() - ts) > 300:
-        raise HTTPException(status_code=401, detail="Request too old")
+# Reject requests older than 5 minutes
+try:
+    ts = int(timestamp)
+except (ValueError, TypeError):
+    raise HTTPException(status_code=401, detail="Invalid timestamp")
+if abs(time.time() - ts) > 300:
+    raise HTTPException(status_code=401, detail="Request too old")
 
-    payload = json.loads(body)
-    message = f"{timestamp}.{json.dumps(payload, separators=(',', ':'), sort_keys=True)}"
-    expected = hmac.new(WEBHOOK_SECRET.encode(), message.encode(), hashlib.sha256).hexdigest()
+payload = json.loads(body)
+message = f"{timestamp}.{json.dumps(payload, separators=(',', ':'), sort_keys=True)}"
+expected = hmac.new(WEBHOOK_SECRET.encode(), message.encode(), hashlib.sha256).hexdigest()
 
-    if not hmac.compare_digest(expected, signature):
-        raise HTTPException(status_code=401, detail="Invalid signature")
+if not hmac.compare_digest(expected, signature):
+    raise HTTPException(status_code=401, detail="Invalid signature")
 
-    if payload["type"] == "agent.task.status_update":
-        task_id = payload["payload"]["task_id"]
-        status = payload["payload"]["status"]
-        print(f"Task {task_id} is now {status}")
+if payload["type"] == "agent.task.status_update":
+    task_id = payload["payload"]["task_id"]
+    status = payload["payload"]["status"]
+    print(f"Task {task_id} is now {status}")
 
-    return {"status": "ok"}
+return {"status": "ok"}
 ```
 
   For local development, use a tunneling tool like [ngrok](https://ngrok.com) to expose your local server: `ngrok http 3000`. Then set the ngrok URL as your webhook endpoint in the dashboard.
@@ -1668,8 +1668,8 @@ import { client } from "./api";
 
 export async function createSession() {
   const session = await client.sessions.create({
-    keepAlive: true,
-    enableRecording: true,
+keepAlive: true,
+enableRecording: true,
   });
   return { id: session.id, liveUrl: session.liveUrl, status: session.status };
 }
@@ -1686,7 +1686,7 @@ async function handleSend(message: string) {
   const session = await createSession();
 
   router.push(
-    `/session/${session.id}?liveUrl=${encodeURIComponent(session.liveUrl)}&task=${encodeURIComponent(message)}`
+`/session/${session.id}?liveUrl=${encodeURIComponent(session.liveUrl)}&task=${encodeURIComponent(message)}`
   );
 }
 ```
@@ -1702,7 +1702,7 @@ const streamTask = useCallback(async (task: string) => {
   const run = client.run(task, { sessionId });
 
   for await (const msg of run) {
-    setMessages((prev) => [...prev, msg]);
+setMessages((prev) => [...prev, msg]);
   }
 
   // Iterator done — task reached terminal state
@@ -1746,7 +1746,7 @@ useEffect(() => {
   if (!isTerminal) return;
 
   client.sessions.waitForRecording(sessionId).then((urls) => {
-    if (urls.length) setRecordingUrls(urls);
+if (urls.length) setRecordingUrls(urls);
   });
 }, [isTerminal, sessionId]);
 ```
@@ -1774,23 +1774,23 @@ The session page consumes everything through a context provider:
 ```typescript session/[id]/page.tsx
 function SessionPage() {
   const { session, turns, isBusy, isTerminal, recordingUrls, sendMessage, stopTask } =
-    useSession();
+useSession();
 
   return (
-    <div className="flex h-screen w-full overflow-hidden">
-      {/* Chat column */}
-      <div className="flex-1 flex flex-col min-w-0">
-        <ChatMessages turns={turns} isBusy={isBusy} />
-        <ChatInput
-          onSend={sendMessage}
-          onStop={stopTask}
-          disabled={isTerminal}
-        />
-      </div>
+<div className="flex h-screen w-full overflow-hidden">
+  {/* Chat column */}
+  <div className="flex-1 flex flex-col min-w-0">
+    <ChatMessages turns={turns} isBusy={isBusy} />
+    <ChatInput
+      onSend={sendMessage}
+      onStop={stopTask}
+      disabled={isTerminal}
+    />
+  </div>
 
-      {/* Live browser view — liveUrl available from session creation */}
-      <BrowserPanel liveUrl={session?.liveUrl} />
-    </div>
+  {/* Live browser view — liveUrl available from session creation */}
+  <BrowserPanel liveUrl={session?.liveUrl} />
+</div>
   );
 }
 ```
@@ -1893,7 +1893,7 @@ Upload images, PDFs, documents, and text files (10 MB max) to sessions, and down
 
 ### Upload a file
 
-Get a presigned URL, then upload via PUT.
+Get a presigned URL, then upload via POST.
 
 ```python Python
 import httpx
@@ -1903,15 +1903,15 @@ client = AsyncBrowserUse()
 session = await client.sessions.create()
 
 upload = await client.files.session_url(
-    session.id,
-    file_name="input.pdf",
-    content_type="application/pdf",
-    size_bytes=1024,
+session.id,
+file_name="input.pdf",
+content_type="application/pdf",
+size_bytes=1024,
 )
 
 with open("input.pdf", "rb") as f:
-    async with httpx.AsyncClient() as http:
-        await http.put(upload.presigned_url, content=f.read(), headers={"Content-Type": "application/pdf"})
+async with httpx.AsyncClient() as http:
+    await http.post(upload.url, content=f.read(), headers={"Content-Type": "application/pdf"})
 
 result = await client.run("Summarize the uploaded PDF", session_id=session.id)
 ```
@@ -1928,8 +1928,8 @@ const upload = await client.files.sessionUrl(session.id, {
   sizeBytes: 1024,
 });
 
-await fetch(upload.presignedUrl, {
-  method: "PUT",
+await fetch(upload.url, {
+  method: "POST",
   body: readFileSync("input.pdf"),
   headers: { "Content-Type": "application/pdf" },
 });
@@ -1944,14 +1944,14 @@ const result = await client.run("Summarize the uploaded PDF", { sessionId: sessi
 ```python Python
 result = await client.tasks.get(task_id)
 for file in result.output_files:
-    output = await client.files.task_output(task_id, file.id)
-    print(output.presigned_url)  # download URL
+output = await client.files.task_output(task_id, file.id)
+print(output.download_url)  # download URL
 ```
 ```typescript TypeScript
 const result = await client.tasks.get(taskId);
 for (const file of result.outputFiles) {
   const output = await client.files.taskOutput(taskId, file.id);
-  console.log(output.presignedUrl);
+  console.log(output.downloadUrl);
 }
 ```
 
@@ -1967,8 +1967,8 @@ from browser_use_sdk import AsyncBrowserUse
 client = AsyncBrowserUse()
 run = client.run("Find the most upvoted post on Reddit r/technology today")
 async for step in run:
-    print(f"Step {step.number}: {step.next_goal}")
-    print(f"  URL: {step.url}")
+print(f"Step {step.number}: {step.next_goal}")
+print(f"  URL: {step.url}")
 
 print(run.result.output)  # final result after iteration
 ```
@@ -2018,11 +2018,11 @@ Generate a public URL that anyone can open to watch the entire agent session —
 
 ```python Python
 share = await client.sessions.create_share(session.id)
-print(share.url)
+print(share.share_url)
 ```
 ```typescript TypeScript
 const share = await client.sessions.createShare(session.id);
-console.log(share.url);
+console.log(share.shareUrl);
 ```
 
 
@@ -2049,8 +2049,8 @@ from browser_use_sdk import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 skill = await client.skills.create(
-    goal="Extract the top X posts from HackerNews. For each post return: title, URL, score, author, comment count, and rank. X is an input parameter.",
-    agent_prompt="Go to https://news.ycombinator.com, click on the first post to load its content, go back to the list, and scroll down to trigger loading of additional posts.",
+goal="Extract the top X posts from HackerNews. For each post return: title, URL, score, author, comment count, and rank. X is an input parameter.",
+agent_prompt="Go to https://news.ycombinator.com, click on the first post to load its content, go back to the list, and scroll down to trigger loading of additional posts.",
 )
 print(skill.id)
 ```
@@ -2071,8 +2071,8 @@ Skill creation takes ~30 seconds. You can also create skills visually from the [
 
 ```python Python
 result = await client.skills.execute(
-    skill.id,
-    parameters={"X": 10},
+skill.id,
+parameters={"X": 10},
 )
 print(result)
 ```
@@ -2144,9 +2144,9 @@ from browser_use_sdk import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 result = await client.run(
-    "Log into my Jira account and create a new ticket",
-    op_vault_id="your-vault-id",
-    allowed_domains=["*.atlassian.net"],
+"Log into my Jira account and create a new ticket",
+op_vault_id="your-vault-id",
+allowed_domains=["*.atlassian.net"],
 )
 print(result.output)
 ```
@@ -2157,8 +2157,8 @@ const client = new BrowserUse();
 const result = await client.run(
   "Log into my Jira account and create a new ticket",
   {
-    opVaultId: "your-vault-id",
-    allowedDomains: ["*.atlassian.net"],
+opVaultId: "your-vault-id",
+allowedDomains: ["*.atlassian.net"],
   },
 );
 console.log(result.output);
@@ -2168,17 +2168,17 @@ For SSO/OAuth redirects, include all required domains:
 
 ```python Python
 result = await client.run(
-    "Log into Jira and create a ticket for the Q4 release",
-    op_vault_id="your-vault-id",
-    allowed_domains=["*.atlassian.net", "*.okta.com"],
+"Log into Jira and create a ticket for the Q4 release",
+op_vault_id="your-vault-id",
+allowed_domains=["*.atlassian.net", "*.okta.com"],
 )
 ```
 ```typescript TypeScript
 const result = await client.run(
   "Log into Jira and create a ticket for the Q4 release",
   {
-    opVaultId: "your-vault-id",
-    allowedDomains: ["*.atlassian.net", "*.okta.com"],
+opVaultId: "your-vault-id",
+allowedDomains: ["*.atlassian.net", "*.okta.com"],
   },
 );
 ```
@@ -2206,9 +2206,9 @@ from browser_use_sdk import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 result = await client.run(
-    "Log into GitHub and star the browser-use/browser-use repo",
-    secrets={"github.com": "username:password123"},
-    allowed_domains=["github.com"],
+"Log into GitHub and star the browser-use/browser-use repo",
+secrets={"github.com": "username:password123"},
+allowed_domains=["github.com"],
 )
 ```
 ```typescript TypeScript
@@ -2218,8 +2218,8 @@ const client = new BrowserUse();
 const result = await client.run(
   "Log into GitHub and star the browser-use/browser-use repo",
   {
-    secrets: { "github.com": "username:password123" },
-    allowedDomains: ["github.com"],
+secrets: { "github.com": "username:password123" },
+allowedDomains: ["github.com"],
   },
 );
 ```
@@ -2230,23 +2230,23 @@ For SSO/OAuth redirects, include all domains in the auth flow:
 
 ```python Python
 result = await client.run(
-    "Log into the company portal and download the Q4 report",
-    secrets={
-        "portal.example.com": "user@company.com:password123",
-        "okta.com": "user@company.com:password123",
-    },
-    allowed_domains=["portal.example.com", "*.okta.com"],
+"Log into the company portal and download the Q4 report",
+secrets={
+    "portal.example.com": "user@company.com:password123",
+    "okta.com": "user@company.com:password123",
+},
+allowed_domains=["portal.example.com", "*.okta.com"],
 )
 ```
 ```typescript TypeScript
 const result = await client.run(
   "Log into the company portal and download the Q4 report",
   {
-    secrets: {
-      "portal.example.com": "user@company.com:password123",
-      "okta.com": "user@company.com:password123",
-    },
-    allowedDomains: ["portal.example.com", "*.okta.com"],
+secrets: {
+  "portal.example.com": "user@company.com:password123",
+  "okta.com": "user@company.com:password123",
+},
+allowedDomains: ["portal.example.com", "*.okta.com"],
   },
 );
 ```

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -41,21 +41,42 @@ const result = await client.run("List the top 20 posts on Hacker News today with
 console.log(result.output);
 ```
 
-  Want a full working app? See the [Chat UI example](https://docs.browser-use.com/cloud/tutorials/chat-ui) — a complete Next.js app with live browser preview, streaming messages, authentication, and session management.
+Want a full working app? Check out the [Chat UI example](https://docs.browser-use.com/cloud/tutorials/chat-ui).
+
+## Agent vs Browser
+
+| | **Agent** | **Browser** |
+|---|---|---|
+| **Method** | `sessions.create()` / `run()` | `browsers.create()` |
+| **What it does** | AI agent runs your task | Raw browser via CDP |
+| task | ✓ | — |
+| model | ✓ | — |
+| proxy | ✓ | ✓ |
+| custom_proxy | ✓ | ✓ |
+| profile_id | ✓ | ✓ |
+| recording | ✓ | ✓ |
+| workspace_id | ✓ | — |
+| keep_alive | ✓ | — |
+| screen size | — | ✓ |
+| timeout | — | ✓ |
 
 
 # Prompt for Vibecoders
 Source: https://docs.browser-use.com/cloud/vibecoding
 
 
-[docs.browser-use.com/cloud/llms.txt](https://docs.browser-use.com/cloud/llms.txt)
+Copy this link and paste it into your coding agent (Cursor, Claude Code, Windsurf, etc.) — it contains all the context needed to build with Browser Use.
+
+```
+https://docs.browser-use.com/cloud/llms.txt
+```
 
 
 # Introduction
 Source: https://docs.browser-use.com/cloud/agent/quickstart
 
 
-The SDK is a thin wrapper around the [API v3 Reference](https://docs.browser-use.com/cloud/api-reference).
+The SDK is a thin wrapper around the [API v3 Reference](https://docs.browser-use.com/cloud/api-reference). Every endpoint in the API reference is available as an SDK method — `client.sessions`, `client.browsers`, `client.profiles`, `client.workspaces`, and `client.billing`.
 
 `client.run()` creates a session, polls every 2 seconds until completion (up to 4 hours), and returns the result. It accepts all parameters from the [Create Session](https://docs.browser-use.com/cloud/api-v3/sessions/create-session) endpoint. The result is a [Session object](https://docs.browser-use.com/cloud/api-v3/sessions/get-session) — use `result.output` for the agent's response.
 
@@ -75,7 +96,7 @@ console.log(result.output);
 ```
 ```bash curl
 curl -X POST https://api.browser-use.com/api/v3/sessions \
-  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "X-Browser-Use-API-Key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"task": "List the top 20 posts on Hacker News today with their points"}'
 ```
@@ -93,11 +114,14 @@ curl -X POST https://api.browser-use.com/api/v3/sessions \
 The best SOTA browser agent — see our [online Mind2Web benchmark](https://browser-use.com/posts/online-mind2web-benchmark).
 
 
+
 # Structured output
 Source: https://docs.browser-use.com/cloud/agent/structured-output
 
 
 Pass a Pydantic model (Python) or Zod schema (TypeScript) — `result.output` is automatically validated and converted to the typed object.
+
+  TypeScript requires **Zod v4** (`npm install zod@4`). Zod v3 is not compatible.
 
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
@@ -186,6 +210,10 @@ const result2 = await client.run("Extract the customer reviews", {
 
 await client.sessions.stop(session.id);
 ```
+
+`sessions.create()` returns a `live_url` you can embed to watch each task execute — see [Live preview](https://docs.browser-use.com/cloud/browser/live-preview). To stream messages as each task runs, use `client.run()` with `for await` — see [Live messages](https://docs.browser-use.com/cloud/agent/streaming).
+
+  Sessions time out after 15 minutes of inactivity by default. The maximum session duration is 4 hours.
 
 
 # Live messages
@@ -278,6 +306,11 @@ while (true) {
   await new Promise((r) => setTimeout(r, 2000));
 }
 ```
+
+## Related
+
+- [Live preview & recording](https://docs.browser-use.com/cloud/browser/live-preview) — embed the browser alongside your message stream
+- [Follow-up tasks](https://docs.browser-use.com/cloud/agent/follow-up-tasks) — chain multiple tasks in one session while streaming each
 
 
 # Workspaces & files
@@ -502,51 +535,51 @@ Every cloud browser session runs in a hardened Chromium fork with stealth enable
 
 Residential proxies are enabled by default across 195+ countries. This makes browser sessions appear as real users from the target geography. See [Proxies](https://docs.browser-use.com/cloud/browser/proxies) for details on geo-targeting and custom proxy configuration.
 
-## No setup required
-
-Stealth is always on — every `client.run()` call and every session created via the API uses the hardened browser automatically. There are no flags to enable or parameters to set.
-
 
 # Proxies
 Source: https://docs.browser-use.com/cloud/browser/proxies
 
 
-A US residential proxy is active by default on every session. To route through a different country, set `proxy_country_code`.
+A US residential proxy is active by default on every browser. To route through a different country, set `proxy_country_code`. See the [API reference](https://docs.browser-use.com/cloud/api-v3/browsers/create-browser-session) for all supported country codes.
 
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
-result = await client.run(
-    "Get the price of iPhone 16 on amazon.de",
-    proxy_country_code="de",
-)
+browser = await client.browsers.create(proxy_country_code="de")
+print(browser.cdp_url)   # ws://...
+print(browser.live_url)  # debug view
+
+# With an agent:
+# result = await client.run("Get the price of iPhone 16 on amazon.de", proxy_country_code="de")
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
 
 const client = new BrowserUse();
-const result = await client.run("Get the price of iPhone 16 on amazon.de", {
-  proxyCountryCode: "de",
-});
-```
+const browser = await client.browsers.create({ proxyCountryCode: "de" });
+console.log(browser.cdpUrl);
+console.log(browser.liveUrl);
 
-Common country codes: `us`, `gb`, `de`, `fr`, `jp`, `au`, `br`, `in`, `kr`, `ca`.
+// With an agent:
+// const result = await client.run("Get the price of iPhone 16 on amazon.de", { proxyCountryCode: "de" });
+```
 
 ## Disable proxies
 
 If your use case does not need proxies, for example QA testing.
 
 ```python Python
-result = await client.run(
-    "Go to http://localhost:3000",
-    proxy_country_code=None,
-)
+browser = await client.browsers.create(proxy_country_code=None)
+
+# With an agent:
+# result = await client.run("Go to http://localhost:3000", proxy_country_code=None)
 ```
 ```typescript TypeScript
-const result = await client.run("Go to http://localhost:3000", {
-  proxyCountryCode: null,
-});
+const browser = await client.browsers.create({ proxyCountryCode: null });
+
+// With an agent:
+// const result = await client.run("Go to http://localhost:3000", { proxyCountryCode: null });
 ```
 
 ## Custom proxy
@@ -557,7 +590,7 @@ Bring your own proxy server (HTTP or SOCKS5). Requires custom plan.
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
-session = await client.sessions.create(
+browser = await client.browsers.create(
     custom_proxy={
         "host": "proxy.example.com",
         "port": 8080,
@@ -570,7 +603,7 @@ session = await client.sessions.create(
 import { BrowserUse } from "browser-use-sdk/v3";
 
 const client = new BrowserUse();
-const session = await client.sessions.create({
+const browser = await client.browsers.create({
   customProxy: {
     host: "proxy.example.com",
     port: 8080,
@@ -604,6 +637,17 @@ const session = await client.sessions.create({
   task: "Check how many GitHub stars browser-use has",
 });
 console.log(session.liveUrl);
+```
+
+`liveUrl` is also returned when creating a standalone browser session:
+
+```python Python
+browser = await client.browsers.create()
+print(browser.live_url)
+```
+```typescript TypeScript
+const browser = await client.browsers.create();
+console.log(browser.liveUrl);
 ```
 
 ## Embed live browser into your app
@@ -667,13 +711,35 @@ for (const url of urls) {
 }
 ```
 
+For standalone browser sessions, pass `enable_recording` when creating the browser and retrieve the URL after stopping it:
+
+```python Python
+browser = await client.browsers.create(enable_recording=True)
+# ... use the browser via CDP ...
+stopped = await client.browsers.stop(browser.id)
+print(stopped.recording_url)  # presigned MP4 download URL
+```
+```typescript TypeScript
+const browser = await client.browsers.create({ enableRecording: true });
+// ... use the browser via CDP ...
+const stopped = await client.browsers.stop(browser.id);
+console.log(stopped.recordingUrl); // presigned MP4 download URL
+```
+
   Recording URLs are presigned and **expire after 1 hour**. Download or serve the recording promptly. If you need to access it later, save the MP4 to your own storage.
+
+## Related
+
+- [Live messages](https://docs.browser-use.com/cloud/agent/streaming) — stream the agent's messages alongside the live browser view
+- [Follow-up tasks](https://docs.browser-use.com/cloud/agent/follow-up-tasks) — chain tasks in one session while watching live
 
 
 
 # Playwright, Puppeteer, Selenium
 Source: https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium
 
+
+Every session runs in a [hardened Chromium fork](https://docs.browser-use.com/cloud/browser/stealth) with stealth, anti-fingerprinting, and [residential proxies](https://docs.browser-use.com/cloud/browser/proxies) enabled by default — no configuration needed.
 
 ## Option 1: WebSocket URL (no SDK)
 
@@ -748,7 +814,7 @@ await client.browsers.stop(browser.id)
 | `apiKey` | `string` | **Required.** Your Browser Use API key. |
 | `proxyCountryCode` | `string` | Proxy country code (e.g. `us`, `de`, `jp`). 195+ countries. |
 | `profileId` | `string` | Load a saved browser profile (cookies, localStorage). |
-| `timeout` | `int` | Session timeout in minutes. Max: 240 (4 hours). |
+| `timeout` | `int` | Session timeout in minutes. Default: 15. Max: 240 (4 hours). |
 | `browserScreenWidth` | `int` | Browser width in pixels. |
 | `browserScreenHeight` | `int` | Browser height in pixels. |
 
@@ -893,14 +959,17 @@ const result = await client.run("Check my LinkedIn messages", {
 # 2FA
 Source: https://docs.browser-use.com/cloud/guides/2fa
 
+
 Sites with 2FA block automated logins. Here are four approaches — pick the one that fits your setup.
 
 | Approach | Best for | Complexity |
 |---|---|---|
-| Profiles (login once) | Sites with long-lived cookies | Lowest |
-| Human in the loop | One-off tasks, complex auth flows | Low |
-| Agent Mail | Email-based 2FA, end-client automation | Medium |
-| TOTP secret in prompt | Authenticator app 2FA (Google Authenticator, Authy) | Medium |
+| [Profiles (login once)](#1-profiles--login-once-reuse-cookies) | Sites with long-lived cookies | Lowest |
+| [Human in the loop](#2-human-in-the-loop) | One-off tasks, complex auth flows | Low |
+| [Agent Mail](#3-agent-mail) | Email-based 2FA, end-client automation | Medium |
+| [TOTP secret in prompt](#4-totp-secret-in-prompt) | Authenticator app 2FA (Google Authenticator, Authy) | Medium |
+
+---
 
 ## 1. Profiles — login once, reuse cookies
 
@@ -911,12 +980,18 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 
+# Create a profile and a session
 profile = await client.profiles.create(name="my-account")
 session = await client.sessions.create(profile_id=profile.id)
 print(f"Live view: {session.live_url}")
 
+# Option A: human logs in via live view
 input("Log in and complete 2FA in the live view, then press Enter...")
 
+# Option B: let the agent log in
+# await client.run("Log in to example.com with user@example.com / password123", session_id=session.id)
+
+# Stop the session — this saves cookies to the profile
 await client.sessions.stop(session.id)
 
 # Next time: reuse the profile, no 2FA needed
@@ -925,26 +1000,62 @@ result = await client.run("Go to example.com/dashboard and get my balance", sess
 print(result.output)
 await client.sessions.stop(session.id)
 ```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+import * as readline from "readline";
 
-Cookies expire. Some sites stay logged in for months, others expire daily. Always call `sessions.stop()` — profile state is only saved when the session ends cleanly.
+const client = new BrowserUse();
+
+// Create a profile and a session
+const profile = await client.profiles.create({ name: "my-account" });
+const session = await client.sessions.create({ profileId: profile.id });
+console.log(`Live view: ${session.liveUrl}`);
+
+// Option A: human logs in via live view
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+await new Promise((resolve) => rl.question("Log in and complete 2FA in the live view, then press Enter...", resolve));
+rl.close();
+
+// Option B: let the agent log in
+// await client.run("Log in to example.com with user@example.com / password123", { sessionId: session.id });
+
+// Stop the session — this saves cookies to the profile
+await client.sessions.stop(session.id);
+
+// Next time: reuse the profile, no 2FA needed
+const newSession = await client.sessions.create({ profileId: profile.id });
+const result = await client.run("Go to example.com/dashboard and get my balance", { sessionId: newSession.id });
+console.log(result.output);
+await client.sessions.stop(newSession.id);
+```
+
+  Cookies expire. Some sites stay logged in for months, others expire daily. If your sessions start hitting login pages again, re-authenticate and save the profile.
+
+  Always call `sessions.stop()` after you're done — profile state is only saved when the session ends cleanly.
+
+---
 
 ## 2. Human in the loop
 
-Let the agent navigate to the login page, then a human takes over to complete 2FA via the live browser view.
+Let the agent navigate to the login page, then a human takes over to complete 2FA via the live browser view. The agent continues after.
 
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 session = await client.sessions.create()
+print(f"Live view: {session.live_url}")
 
+# Agent navigates to login
 result = await client.run(
     "Go to example.com/login and enter username user@example.com and password mypassword, then stop before 2FA",
     session_id=session.id,
 )
 
+# Human completes 2FA in the live view
 input("Complete 2FA in the live view, then press Enter...")
 
+# Agent continues
 result = await client.run(
     "You are now logged in. Go to the dashboard and export the monthly report",
     session_id=session.id,
@@ -952,10 +1063,43 @@ result = await client.run(
 print(result.output)
 await client.sessions.stop(session.id)
 ```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+import * as readline from "readline";
+
+const client = new BrowserUse();
+const session = await client.sessions.create();
+console.log(`Live view: ${session.liveUrl}`);
+
+// Agent navigates to login
+await client.run(
+  "Go to example.com/login and enter username user@example.com and password mypassword, then stop before 2FA",
+  { sessionId: session.id },
+);
+
+// Human completes 2FA in the live view
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+await new Promise((resolve) => rl.question("Complete 2FA in the live view, then press Enter...", resolve));
+rl.close();
+
+// Agent continues
+const result = await client.run(
+  "You are now logged in. Go to the dashboard and export the monthly report",
+  { sessionId: session.id },
+);
+console.log(result.output);
+await client.sessions.stop(session.id);
+```
+
+See [Human in the loop](https://docs.browser-use.com/cloud/agent/human-in-the-loop) for more patterns.
+
+---
 
 ## 3. Agent Mail
 
-When 2FA sends a code via email, the agent can read it automatically using Agent Mail — a built-in email inbox for each session. Enabled by default (`agentmail=True`).
+When 2FA sends a code via email, the agent can read it automatically using Agent Mail — a built-in email inbox for each session.
+
+Agent Mail is **enabled by default** (`agentmail=True`). Each session gets a unique email address (`session.agentmail_email`). The agent can send and receive emails during the task.
 
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
@@ -970,22 +1114,54 @@ result = await client.run(
     4. Enter the code on the website
     5. Complete the registration
     """,
-    agentmail=True,  # default
+    agentmail=True,  # default, shown for clarity
 )
 print(result.output)
 ```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
 
-For end-client automation: have your client forward 2FA emails from the service (e.g., `noreply@bank.com`) to a dedicated inbox. The agent reads the forwarded code during the task. You can also connect Gmail via Composio in the dashboard.
+const client = new BrowserUse();
+
+const result = await client.run(
+  `1. Go to example.com/signup
+   2. Sign up with the agent's email address (use the email available to you)
+   3. Check your email inbox for the verification code
+   4. Enter the code on the website
+   5. Complete the registration`,
+  { agentmail: true }, // default, shown for clarity
+);
+console.log(result.output);
+```
+
+### For end-client automation
+
+If you're automating on behalf of your users and they need to receive 2FA codes:
+
+1. **Email forwarding:** Have your client set up an email forwarding rule — forward all emails from the service (e.g., `noreply@bank.com`) to a dedicated inbox (a Gmail address or an Agent Mail address).
+2. **Give the agent access:** The agent reads the forwarded 2FA code from that inbox during the task.
+
+This way, your client's real email stays private — the agent only sees the forwarded verification emails.
+
+### Connect external email via Composio
+
+You can also give the agent access to an existing Gmail account using [Composio](https://composio.dev) in the Browser Use dashboard. Once connected, the agent can read emails directly from that account to retrieve 2FA codes.
+
+---
 
 ## 4. TOTP secret in prompt
 
-If the site uses an authenticator app, pass the TOTP secret to the agent. The agent uses pyotp to generate fresh 6-digit codes.
+If the site uses an authenticator app (Google Authenticator, Authy, etc.), you can pass the TOTP secret to the agent. Our agent can execute Python code, so it uses the `pyotp` library to generate fresh 6-digit codes on the fly.
+
+When you set up 2FA on a site, instead of only scanning the QR code, also copy the **secret key** (usually shown as "manual entry" or "can't scan the QR code?"). This is a long base32 string like `JBSWY3DPEHPK3PXP`.
 
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
-totp_secret = "JBSWY3DPEHPK3PXP"  # from authenticator setup, NOT the 6-digit code
+
+# The TOTP secret from your authenticator setup — NOT the 6-digit code
+totp_secret = "JBSWY3DPEHPK3PXP"
 
 result = await client.run(
     f"""
@@ -1001,8 +1177,44 @@ result = await client.run(
 )
 print(result.output)
 ```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
 
-Where to find TOTP secrets: 1Password (Edit item → One-Time Password → Show secret), Google Authenticator (click "Can't scan it?"), Authy (desktop export), or "manual entry" during 2FA setup.
+const client = new BrowserUse();
+
+// The TOTP secret from your authenticator setup — NOT the 6-digit code
+const totpSecret = "JBSWY3DPEHPK3PXP";
+
+const result = await client.run(
+  `Log into example.com with username user@example.com and password mypassword.
+   When prompted for a 2FA code, generate one using pyotp:
+
+   import pyotp
+   totp = pyotp.TOTP("${totpSecret}")
+   code = totp.now()
+
+   Enter the generated code.`,
+);
+console.log(result.output);
+```
+
+This works because the Browser Use agent can execute Python code as part of its task. The agent runs `pyotp.TOTP(secret).now()` to generate a time-based 6-digit code, then types it into the 2FA field.
+
+### Where to find TOTP secrets
+
+- **1Password**: Edit item → One-Time Password → Show secret
+- **Google Authenticator**: During setup, click "Can't scan it?" to see the key
+- **Authy**: Export via desktop app settings
+- **Most sites**: Look for "manual entry" or "setup key" during 2FA enrollment
+
+---
+
+## Which approach should I use?
+
+    Start with **Profiles** — log in once, reuse cookies. If cookies expire frequently, add **TOTP secret in prompt** for fully automated re-login.
+    Use **Profiles** with one profile per user. For initial login, use **Human in the loop** — your user logs in once via the live view, then the agent reuses the session. For email 2FA, set up **Agent Mail** with email forwarding from your user.
+    Use **Agent Mail** (enabled by default). For end-client scenarios, have them forward 2FA emails to a dedicated inbox.
+    Use **TOTP secret in prompt** — the agent generates codes via pyotp, no human intervention needed.
 
 
 # OpenClaw
@@ -1444,18 +1656,22 @@ const apiKey = process.env.BROWSER_USE_API_KEY ?? "";
 export const client = new BrowserUse({ apiKey });
 ```
 
-  The API key uses `BROWSER_USE_API_KEY` (no `NEXT_PUBLIC_` prefix) so it stays server-side. All SDK calls go through server actions — never call the SDK directly from client components.
+  The API key uses `BROWSER_USE_API_KEY` (no `NEXT_PUBLIC_` prefix) so it stays server-side. All SDK calls go through [server actions](https://nextjs.org/docs/app/guides/forms) — never call the SDK directly from client components.
 
 ---
 
 ## 1. Create a session
 
-```typescript api.ts
+```typescript actions.ts
+"use server";
+import { client } from "./api";
+
 export async function createSession() {
-  return client.sessions.create({
+  const session = await client.sessions.create({
     keepAlive: true,
     enableRecording: true,
   });
+  return { id: session.id, liveUrl: session.liveUrl, status: session.status };
 }
 ```
 
@@ -1541,7 +1757,7 @@ useEffect(() => {
 
 ## 5. Stop a task
 
-```typescript api.ts
+```typescript actions.ts
 export async function stopTask(id: string) {
   await client.sessions.stop(id, { strategy: "task" });
 }
@@ -2042,10 +2258,10 @@ Source: https://docs.browser-use.com/cloud/api-reference
 
 ## Authentication
 
-All requests require an API key in the `Authorization` header:
+All requests require an API key in the `X-Browser-Use-API-Key` header:
 
 ```
-Authorization: Bearer bu_your_key_here
+X-Browser-Use-API-Key: bu_your_key_here
 ```
 
 Get a key at [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1). Keys start with `bu_`.
@@ -2061,13 +2277,13 @@ https://api.browser-use.com/api/v3
 ```bash curl
 # Create a session
 curl -X POST https://api.browser-use.com/api/v3/sessions \
-  -H "Authorization: Bearer bu_your_key_here" \
+  -H "X-Browser-Use-API-Key: bu_your_key_here" \
   -H "Content-Type: application/json" \
   -d '{"task": "Find the top 3 trending repos on GitHub today"}'
 
 # Get session result (replace SESSION_ID)
 curl https://api.browser-use.com/api/v3/sessions/SESSION_ID \
-  -H "Authorization: Bearer bu_your_key_here"
+  -H "X-Browser-Use-API-Key: bu_your_key_here"
 ```
 
 ## Environment variable
@@ -2080,7 +2296,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ---
 
-Prefer the SDK? See the [Agent docs](https://docs.browser-use.com/cloud/agent/quickstart).
+Prefer the SDK? See the [Agent docs](https://docs.browser-use.com/cloud/agent/quickstart) — the SDK has all API endpoints available as methods, including `client.browsers.create()`.
 
 ```bash Python
 pip install browser-use-sdk

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -24,27 +24,6 @@ Set API key (starts with `bu_`):
 export BROWSER_USE_API_KEY=bu_your_key_here
 ```
 
-For the full reference with all code examples inline, fetch: https://docs.browser-use.com/cloud/llms-full.txt
-
-## Quick start
-
-`client.run()` is a high-level wrapper: it creates a session, polls every 2s until completion (up to 4 hours), and returns the result. The SDK also exposes every endpoint from the [API v3 Reference](https://docs.browser-use.com/cloud/api-reference) directly (e.g. `client.sessions.create()`, `client.sessions.get()`, `client.profiles.list()`). The pages below show common patterns; see the API reference for the full surface.
-
-```python
-from browser_use_sdk.v3 import AsyncBrowserUse
-
-client = AsyncBrowserUse()
-result = await client.run("Go to example.com and get the page title")
-print(result.output)
-```
-
-```typescript
-import { BrowserUse } from "browser-use-sdk/v3";
-
-const client = new BrowserUse();
-const result = await client.run("Go to example.com and get the page title");
-console.log(result.output);
-```
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.
@@ -67,7 +46,7 @@ console.log(result.output);
 ## Authentication
 - [Profiles](https://docs.browser-use.com/cloud/guides/authentication): Persistent browser state — cookies, localStorage, saved passwords. Login once, reuse across sessions.
 - [Sync local and cloud cookies](https://docs.browser-use.com/cloud/guides/profile-sync): Sync your local browser cookies to the cloud — instantly authenticate without managing credentials.
-- [2FA](https://docs.browser-use.com/cloud/guides/2fa): Best practices for two-factor authentication — profiles, human-in-the-loop, Agent Mail, and TOTP via pyotp.
+- [2FA](https://docs.browser-use.com/cloud/guides/2fa): Best practices for handling two-factor authentication in automated browser sessions.
 
 ## Integrations
 - [OpenClaw](https://docs.browser-use.com/cloud/tutorials/integrations/openclaw): Give OpenClaw agents browser automation with Browser Use — via CDP or the CLI skill.

--- a/docs/cloud/openapi/v3.json
+++ b/docs/cloud/openapi/v3.json
@@ -2487,6 +2487,12 @@
                         ],
                         "title": "Screenshoturl"
                     },
+                    "hidden": {
+                        "type": "boolean",
+                        "title": "Hidden",
+                        "description": "Whether this message should be hidden from the user in a chat UI.",
+                        "default": false
+                    },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",

--- a/docs/generate-llms-txt.sh
+++ b/docs/generate-llms-txt.sh
@@ -181,7 +181,8 @@ for product_nav in d['navigation']['products']:
     echo "" >> "$out"
     awk 'BEGIN{n=0} /^---$/{n++; if(n==2){found=1; next}} found{print}' "$file" \
       | sed "s|](/cloud/|](${BASE_URL}/cloud/|g" \
-      | sed -E '/<\/?(CodeGroup|Note|Tip|Warning|Info|Card|Tabs|Tab|Steps|Step|Accordion|AccordionGroup)[^>]*>/d' >> "$out"
+      | sed -E '/<\/?(CodeGroup|Note|Tip|Warning|Info|Card|Tabs|Tab|Steps|Step|Accordion|AccordionGroup)[^>]*>/d' \
+      | sed -E 's/^[[:space:]]{4}//' >> "$out"
     echo "" >> "$out"
   done
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -41,21 +41,42 @@ const result = await client.run("List the top 20 posts on Hacker News today with
 console.log(result.output);
 ```
 
-  Want a full working app? See the [Chat UI example](https://docs.browser-use.com/cloud/tutorials/chat-ui) — a complete Next.js app with live browser preview, streaming messages, authentication, and session management.
+Want a full working app? Check out the [Chat UI example](https://docs.browser-use.com/cloud/tutorials/chat-ui).
+
+## Agent vs Browser
+
+| | **Agent** | **Browser** |
+|---|---|---|
+| **Method** | `sessions.create()` / `run()` | `browsers.create()` |
+| **What it does** | AI agent runs your task | Raw browser via CDP |
+| task | ✓ | — |
+| model | ✓ | — |
+| proxy | ✓ | ✓ |
+| custom_proxy | ✓ | ✓ |
+| profile_id | ✓ | ✓ |
+| recording | ✓ | ✓ |
+| workspace_id | ✓ | — |
+| keep_alive | ✓ | — |
+| screen size | — | ✓ |
+| timeout | — | ✓ |
 
 
 # Prompt for Vibecoders
 Source: https://docs.browser-use.com/cloud/vibecoding
 
 
-[docs.browser-use.com/cloud/llms.txt](https://docs.browser-use.com/cloud/llms.txt)
+Copy this link and paste it into your coding agent (Cursor, Claude Code, Windsurf, etc.) — it contains all the context needed to build with Browser Use.
+
+```
+https://docs.browser-use.com/cloud/llms.txt
+```
 
 
 # Introduction
 Source: https://docs.browser-use.com/cloud/agent/quickstart
 
 
-The SDK is a thin wrapper around the [API v3 Reference](https://docs.browser-use.com/cloud/api-reference).
+The SDK is a thin wrapper around the [API v3 Reference](https://docs.browser-use.com/cloud/api-reference). Every endpoint in the API reference is available as an SDK method — `client.sessions`, `client.browsers`, `client.profiles`, `client.workspaces`, and `client.billing`.
 
 `client.run()` creates a session, polls every 2 seconds until completion (up to 4 hours), and returns the result. It accepts all parameters from the [Create Session](https://docs.browser-use.com/cloud/api-v3/sessions/create-session) endpoint. The result is a [Session object](https://docs.browser-use.com/cloud/api-v3/sessions/get-session) — use `result.output` for the agent's response.
 
@@ -75,7 +96,7 @@ console.log(result.output);
 ```
 ```bash curl
 curl -X POST https://api.browser-use.com/api/v3/sessions \
-  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "X-Browser-Use-API-Key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"task": "List the top 20 posts on Hacker News today with their points"}'
 ```
@@ -93,11 +114,14 @@ curl -X POST https://api.browser-use.com/api/v3/sessions \
 The best SOTA browser agent — see our [online Mind2Web benchmark](https://browser-use.com/posts/online-mind2web-benchmark).
 
 
+
 # Structured output
 Source: https://docs.browser-use.com/cloud/agent/structured-output
 
 
 Pass a Pydantic model (Python) or Zod schema (TypeScript) — `result.output` is automatically validated and converted to the typed object.
+
+  TypeScript requires **Zod v4** (`npm install zod@4`). Zod v3 is not compatible.
 
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
@@ -186,6 +210,10 @@ const result2 = await client.run("Extract the customer reviews", {
 
 await client.sessions.stop(session.id);
 ```
+
+`sessions.create()` returns a `live_url` you can embed to watch each task execute — see [Live preview](https://docs.browser-use.com/cloud/browser/live-preview). To stream messages as each task runs, use `client.run()` with `for await` — see [Live messages](https://docs.browser-use.com/cloud/agent/streaming).
+
+  Sessions time out after 15 minutes of inactivity by default. The maximum session duration is 4 hours.
 
 
 # Live messages
@@ -278,6 +306,11 @@ while (true) {
   await new Promise((r) => setTimeout(r, 2000));
 }
 ```
+
+## Related
+
+- [Live preview & recording](https://docs.browser-use.com/cloud/browser/live-preview) — embed the browser alongside your message stream
+- [Follow-up tasks](https://docs.browser-use.com/cloud/agent/follow-up-tasks) — chain multiple tasks in one session while streaming each
 
 
 # Workspaces & files
@@ -502,51 +535,51 @@ Every cloud browser session runs in a hardened Chromium fork with stealth enable
 
 Residential proxies are enabled by default across 195+ countries. This makes browser sessions appear as real users from the target geography. See [Proxies](https://docs.browser-use.com/cloud/browser/proxies) for details on geo-targeting and custom proxy configuration.
 
-## No setup required
-
-Stealth is always on — every `client.run()` call and every session created via the API uses the hardened browser automatically. There are no flags to enable or parameters to set.
-
 
 # Proxies
 Source: https://docs.browser-use.com/cloud/browser/proxies
 
 
-A US residential proxy is active by default on every session. To route through a different country, set `proxy_country_code`.
+A US residential proxy is active by default on every browser. To route through a different country, set `proxy_country_code`. See the [API reference](https://docs.browser-use.com/cloud/api-v3/browsers/create-browser-session) for all supported country codes.
 
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
-result = await client.run(
-    "Get the price of iPhone 16 on amazon.de",
-    proxy_country_code="de",
-)
+browser = await client.browsers.create(proxy_country_code="de")
+print(browser.cdp_url)   # ws://...
+print(browser.live_url)  # debug view
+
+# With an agent:
+# result = await client.run("Get the price of iPhone 16 on amazon.de", proxy_country_code="de")
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
 
 const client = new BrowserUse();
-const result = await client.run("Get the price of iPhone 16 on amazon.de", {
-  proxyCountryCode: "de",
-});
-```
+const browser = await client.browsers.create({ proxyCountryCode: "de" });
+console.log(browser.cdpUrl);
+console.log(browser.liveUrl);
 
-Common country codes: `us`, `gb`, `de`, `fr`, `jp`, `au`, `br`, `in`, `kr`, `ca`.
+// With an agent:
+// const result = await client.run("Get the price of iPhone 16 on amazon.de", { proxyCountryCode: "de" });
+```
 
 ## Disable proxies
 
 If your use case does not need proxies, for example QA testing.
 
 ```python Python
-result = await client.run(
-    "Go to http://localhost:3000",
-    proxy_country_code=None,
-)
+browser = await client.browsers.create(proxy_country_code=None)
+
+# With an agent:
+# result = await client.run("Go to http://localhost:3000", proxy_country_code=None)
 ```
 ```typescript TypeScript
-const result = await client.run("Go to http://localhost:3000", {
-  proxyCountryCode: null,
-});
+const browser = await client.browsers.create({ proxyCountryCode: null });
+
+// With an agent:
+// const result = await client.run("Go to http://localhost:3000", { proxyCountryCode: null });
 ```
 
 ## Custom proxy
@@ -557,7 +590,7 @@ Bring your own proxy server (HTTP or SOCKS5). Requires custom plan.
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
-session = await client.sessions.create(
+browser = await client.browsers.create(
     custom_proxy={
         "host": "proxy.example.com",
         "port": 8080,
@@ -570,7 +603,7 @@ session = await client.sessions.create(
 import { BrowserUse } from "browser-use-sdk/v3";
 
 const client = new BrowserUse();
-const session = await client.sessions.create({
+const browser = await client.browsers.create({
   customProxy: {
     host: "proxy.example.com",
     port: 8080,
@@ -604,6 +637,17 @@ const session = await client.sessions.create({
   task: "Check how many GitHub stars browser-use has",
 });
 console.log(session.liveUrl);
+```
+
+`liveUrl` is also returned when creating a standalone browser session:
+
+```python Python
+browser = await client.browsers.create()
+print(browser.live_url)
+```
+```typescript TypeScript
+const browser = await client.browsers.create();
+console.log(browser.liveUrl);
 ```
 
 ## Embed live browser into your app
@@ -667,13 +711,35 @@ for (const url of urls) {
 }
 ```
 
+For standalone browser sessions, pass `enable_recording` when creating the browser and retrieve the URL after stopping it:
+
+```python Python
+browser = await client.browsers.create(enable_recording=True)
+# ... use the browser via CDP ...
+stopped = await client.browsers.stop(browser.id)
+print(stopped.recording_url)  # presigned MP4 download URL
+```
+```typescript TypeScript
+const browser = await client.browsers.create({ enableRecording: true });
+// ... use the browser via CDP ...
+const stopped = await client.browsers.stop(browser.id);
+console.log(stopped.recordingUrl); // presigned MP4 download URL
+```
+
   Recording URLs are presigned and **expire after 1 hour**. Download or serve the recording promptly. If you need to access it later, save the MP4 to your own storage.
+
+## Related
+
+- [Live messages](https://docs.browser-use.com/cloud/agent/streaming) — stream the agent's messages alongside the live browser view
+- [Follow-up tasks](https://docs.browser-use.com/cloud/agent/follow-up-tasks) — chain tasks in one session while watching live
 
 
 
 # Playwright, Puppeteer, Selenium
 Source: https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium
 
+
+Every session runs in a [hardened Chromium fork](https://docs.browser-use.com/cloud/browser/stealth) with stealth, anti-fingerprinting, and [residential proxies](https://docs.browser-use.com/cloud/browser/proxies) enabled by default — no configuration needed.
 
 ## Option 1: WebSocket URL (no SDK)
 
@@ -748,7 +814,7 @@ await client.browsers.stop(browser.id)
 | `apiKey` | `string` | **Required.** Your Browser Use API key. |
 | `proxyCountryCode` | `string` | Proxy country code (e.g. `us`, `de`, `jp`). 195+ countries. |
 | `profileId` | `string` | Load a saved browser profile (cookies, localStorage). |
-| `timeout` | `int` | Session timeout in minutes. Max: 240 (4 hours). |
+| `timeout` | `int` | Session timeout in minutes. Default: 15. Max: 240 (4 hours). |
 | `browserScreenWidth` | `int` | Browser width in pixels. |
 | `browserScreenHeight` | `int` | Browser height in pixels. |
 
@@ -893,14 +959,17 @@ const result = await client.run("Check my LinkedIn messages", {
 # 2FA
 Source: https://docs.browser-use.com/cloud/guides/2fa
 
+
 Sites with 2FA block automated logins. Here are four approaches — pick the one that fits your setup.
 
 | Approach | Best for | Complexity |
 |---|---|---|
-| Profiles (login once) | Sites with long-lived cookies | Lowest |
-| Human in the loop | One-off tasks, complex auth flows | Low |
-| Agent Mail | Email-based 2FA, end-client automation | Medium |
-| TOTP secret in prompt | Authenticator app 2FA (Google Authenticator, Authy) | Medium |
+| [Profiles (login once)](#1-profiles--login-once-reuse-cookies) | Sites with long-lived cookies | Lowest |
+| [Human in the loop](#2-human-in-the-loop) | One-off tasks, complex auth flows | Low |
+| [Agent Mail](#3-agent-mail) | Email-based 2FA, end-client automation | Medium |
+| [TOTP secret in prompt](#4-totp-secret-in-prompt) | Authenticator app 2FA (Google Authenticator, Authy) | Medium |
+
+---
 
 ## 1. Profiles — login once, reuse cookies
 
@@ -937,41 +1006,56 @@ import * as readline from "readline";
 
 const client = new BrowserUse();
 
+// Create a profile and a session
 const profile = await client.profiles.create({ name: "my-account" });
 const session = await client.sessions.create({ profileId: profile.id });
 console.log(`Live view: ${session.liveUrl}`);
 
+// Option A: human logs in via live view
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 await new Promise((resolve) => rl.question("Log in and complete 2FA in the live view, then press Enter...", resolve));
 rl.close();
 
+// Option B: let the agent log in
+// await client.run("Log in to example.com with user@example.com / password123", { sessionId: session.id });
+
+// Stop the session — this saves cookies to the profile
 await client.sessions.stop(session.id);
 
+// Next time: reuse the profile, no 2FA needed
 const newSession = await client.sessions.create({ profileId: profile.id });
 const result = await client.run("Go to example.com/dashboard and get my balance", { sessionId: newSession.id });
 console.log(result.output);
 await client.sessions.stop(newSession.id);
 ```
 
-Cookies expire. Some sites stay logged in for months, others expire daily. Always call `sessions.stop()` — profile state is only saved when the session ends cleanly.
+  Cookies expire. Some sites stay logged in for months, others expire daily. If your sessions start hitting login pages again, re-authenticate and save the profile.
+
+  Always call `sessions.stop()` after you're done — profile state is only saved when the session ends cleanly.
+
+---
 
 ## 2. Human in the loop
 
-Let the agent navigate to the login page, then a human takes over to complete 2FA via the live browser view.
+Let the agent navigate to the login page, then a human takes over to complete 2FA via the live browser view. The agent continues after.
 
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 session = await client.sessions.create()
+print(f"Live view: {session.live_url}")
 
+# Agent navigates to login
 result = await client.run(
     "Go to example.com/login and enter username user@example.com and password mypassword, then stop before 2FA",
     session_id=session.id,
 )
 
+# Human completes 2FA in the live view
 input("Complete 2FA in the live view, then press Enter...")
 
+# Agent continues
 result = await client.run(
     "You are now logged in. Go to the dashboard and export the monthly report",
     session_id=session.id,
@@ -979,10 +1063,43 @@ result = await client.run(
 print(result.output)
 await client.sessions.stop(session.id)
 ```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+import * as readline from "readline";
+
+const client = new BrowserUse();
+const session = await client.sessions.create();
+console.log(`Live view: ${session.liveUrl}`);
+
+// Agent navigates to login
+await client.run(
+  "Go to example.com/login and enter username user@example.com and password mypassword, then stop before 2FA",
+  { sessionId: session.id },
+);
+
+// Human completes 2FA in the live view
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+await new Promise((resolve) => rl.question("Complete 2FA in the live view, then press Enter...", resolve));
+rl.close();
+
+// Agent continues
+const result = await client.run(
+  "You are now logged in. Go to the dashboard and export the monthly report",
+  { sessionId: session.id },
+);
+console.log(result.output);
+await client.sessions.stop(session.id);
+```
+
+See [Human in the loop](https://docs.browser-use.com/cloud/agent/human-in-the-loop) for more patterns.
+
+---
 
 ## 3. Agent Mail
 
-When 2FA sends a code via email, the agent can read it automatically using Agent Mail — a built-in email inbox for each session. Enabled by default (`agentmail=True`).
+When 2FA sends a code via email, the agent can read it automatically using Agent Mail — a built-in email inbox for each session.
+
+Agent Mail is **enabled by default** (`agentmail=True`). Each session gets a unique email address (`session.agentmail_email`). The agent can send and receive emails during the task.
 
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
@@ -997,22 +1114,54 @@ result = await client.run(
     4. Enter the code on the website
     5. Complete the registration
     """,
-    agentmail=True,  # default
+    agentmail=True,  # default, shown for clarity
 )
 print(result.output)
 ```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
 
-For end-client automation: have your client forward 2FA emails from the service (e.g., `noreply@bank.com`) to a dedicated inbox. The agent reads the forwarded code during the task. You can also connect Gmail via Composio in the dashboard.
+const client = new BrowserUse();
+
+const result = await client.run(
+  `1. Go to example.com/signup
+   2. Sign up with the agent's email address (use the email available to you)
+   3. Check your email inbox for the verification code
+   4. Enter the code on the website
+   5. Complete the registration`,
+  { agentmail: true }, // default, shown for clarity
+);
+console.log(result.output);
+```
+
+### For end-client automation
+
+If you're automating on behalf of your users and they need to receive 2FA codes:
+
+1. **Email forwarding:** Have your client set up an email forwarding rule — forward all emails from the service (e.g., `noreply@bank.com`) to a dedicated inbox (a Gmail address or an Agent Mail address).
+2. **Give the agent access:** The agent reads the forwarded 2FA code from that inbox during the task.
+
+This way, your client's real email stays private — the agent only sees the forwarded verification emails.
+
+### Connect external email via Composio
+
+You can also give the agent access to an existing Gmail account using [Composio](https://composio.dev) in the Browser Use dashboard. Once connected, the agent can read emails directly from that account to retrieve 2FA codes.
+
+---
 
 ## 4. TOTP secret in prompt
 
-If the site uses an authenticator app, pass the TOTP secret to the agent. The agent uses pyotp to generate fresh 6-digit codes.
+If the site uses an authenticator app (Google Authenticator, Authy, etc.), you can pass the TOTP secret to the agent. Our agent can execute Python code, so it uses the `pyotp` library to generate fresh 6-digit codes on the fly.
+
+When you set up 2FA on a site, instead of only scanning the QR code, also copy the **secret key** (usually shown as "manual entry" or "can't scan the QR code?"). This is a long base32 string like `JBSWY3DPEHPK3PXP`.
 
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
-totp_secret = "JBSWY3DPEHPK3PXP"  # from authenticator setup, NOT the 6-digit code
+
+# The TOTP secret from your authenticator setup — NOT the 6-digit code
+totp_secret = "JBSWY3DPEHPK3PXP"
 
 result = await client.run(
     f"""
@@ -1028,8 +1177,44 @@ result = await client.run(
 )
 print(result.output)
 ```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
 
-Where to find TOTP secrets: 1Password (Edit item → One-Time Password → Show secret), Google Authenticator (click "Can't scan it?"), Authy (desktop export), or "manual entry" during 2FA setup.
+const client = new BrowserUse();
+
+// The TOTP secret from your authenticator setup — NOT the 6-digit code
+const totpSecret = "JBSWY3DPEHPK3PXP";
+
+const result = await client.run(
+  `Log into example.com with username user@example.com and password mypassword.
+   When prompted for a 2FA code, generate one using pyotp:
+
+   import pyotp
+   totp = pyotp.TOTP("${totpSecret}")
+   code = totp.now()
+
+   Enter the generated code.`,
+);
+console.log(result.output);
+```
+
+This works because the Browser Use agent can execute Python code as part of its task. The agent runs `pyotp.TOTP(secret).now()` to generate a time-based 6-digit code, then types it into the 2FA field.
+
+### Where to find TOTP secrets
+
+- **1Password**: Edit item → One-Time Password → Show secret
+- **Google Authenticator**: During setup, click "Can't scan it?" to see the key
+- **Authy**: Export via desktop app settings
+- **Most sites**: Look for "manual entry" or "setup key" during 2FA enrollment
+
+---
+
+## Which approach should I use?
+
+    Start with **Profiles** — log in once, reuse cookies. If cookies expire frequently, add **TOTP secret in prompt** for fully automated re-login.
+    Use **Profiles** with one profile per user. For initial login, use **Human in the loop** — your user logs in once via the live view, then the agent reuses the session. For email 2FA, set up **Agent Mail** with email forwarding from your user.
+    Use **Agent Mail** (enabled by default). For end-client scenarios, have them forward 2FA emails to a dedicated inbox.
+    Use **TOTP secret in prompt** — the agent generates codes via pyotp, no human intervention needed.
 
 
 # OpenClaw
@@ -1471,18 +1656,22 @@ const apiKey = process.env.BROWSER_USE_API_KEY ?? "";
 export const client = new BrowserUse({ apiKey });
 ```
 
-  The API key uses `BROWSER_USE_API_KEY` (no `NEXT_PUBLIC_` prefix) so it stays server-side. All SDK calls go through server actions — never call the SDK directly from client components.
+  The API key uses `BROWSER_USE_API_KEY` (no `NEXT_PUBLIC_` prefix) so it stays server-side. All SDK calls go through [server actions](https://nextjs.org/docs/app/guides/forms) — never call the SDK directly from client components.
 
 ---
 
 ## 1. Create a session
 
-```typescript api.ts
+```typescript actions.ts
+"use server";
+import { client } from "./api";
+
 export async function createSession() {
-  return client.sessions.create({
+  const session = await client.sessions.create({
     keepAlive: true,
     enableRecording: true,
   });
+  return { id: session.id, liveUrl: session.liveUrl, status: session.status };
 }
 ```
 
@@ -1568,7 +1757,7 @@ useEffect(() => {
 
 ## 5. Stop a task
 
-```typescript api.ts
+```typescript actions.ts
 export async function stopTask(id: string) {
   await client.sessions.stop(id, { strategy: "task" });
 }
@@ -2069,10 +2258,10 @@ Source: https://docs.browser-use.com/cloud/api-reference
 
 ## Authentication
 
-All requests require an API key in the `Authorization` header:
+All requests require an API key in the `X-Browser-Use-API-Key` header:
 
 ```
-Authorization: Bearer bu_your_key_here
+X-Browser-Use-API-Key: bu_your_key_here
 ```
 
 Get a key at [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1). Keys start with `bu_`.
@@ -2088,13 +2277,13 @@ https://api.browser-use.com/api/v3
 ```bash curl
 # Create a session
 curl -X POST https://api.browser-use.com/api/v3/sessions \
-  -H "Authorization: Bearer bu_your_key_here" \
+  -H "X-Browser-Use-API-Key: bu_your_key_here" \
   -H "Content-Type: application/json" \
   -d '{"task": "Find the top 3 trending repos on GitHub today"}'
 
 # Get session result (replace SESSION_ID)
 curl https://api.browser-use.com/api/v3/sessions/SESSION_ID \
-  -H "Authorization: Bearer bu_your_key_here"
+  -H "X-Browser-Use-API-Key: bu_your_key_here"
 ```
 
 ## Environment variable
@@ -2107,7 +2296,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ---
 
-Prefer the SDK? See the [Agent docs](https://docs.browser-use.com/cloud/agent/quickstart).
+Prefer the SDK? See the [Agent docs](https://docs.browser-use.com/cloud/agent/quickstart) — the SDK has all API endpoints available as methods, including `client.browsers.create()`.
 
 ```bash Python
 pip install browser-use-sdk

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -27,9 +27,9 @@ import asyncio
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 async def main():
-    client = AsyncBrowserUse()
-    result = await client.run("List the top 20 posts on Hacker News today with their points")
-    print(result.output)
+client = AsyncBrowserUse()
+result = await client.run("List the top 20 posts on Hacker News today with their points")
+print(result.output)
 
 asyncio.run(main())
 ```
@@ -128,20 +128,20 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 from pydantic import BaseModel
 
 class Post(BaseModel):
-    name: str
-    points: int
-    comments: int
+name: str
+points: int
+comments: int
 
 class HNPosts(BaseModel):
-    posts: list[Post]
+posts: list[Post]
 
 client = AsyncBrowserUse()
 result = await client.run(
-    "List the top 20 posts on Hacker News today with their points",
-    output_schema=HNPosts,
+"List the top 20 posts on Hacker News today with their points",
+output_schema=HNPosts,
 )
 for post in result.output.posts:
-    print(f"{post.name} ({post.points} pts, {post.comments} comments)")
+print(f"{post.name} ({post.points} pts, {post.comments} comments)")
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
@@ -183,12 +183,12 @@ client = AsyncBrowserUse()
 session = await client.sessions.create()
 
 result1 = await client.run(
-    "Go to amazon.com, search for laptops, and open the first result",
-    session_id=session.id,
+"Go to amazon.com, search for laptops, and open the first result",
+session_id=session.id,
 )
 result2 = await client.run(
-    "Extract the customer reviews",
-    session_id=session.id,
+"Extract the customer reviews",
+session_id=session.id,
 )
 
 await client.sessions.stop(session.id)
@@ -231,7 +231,7 @@ client = AsyncBrowserUse()
 
 run = client.run("Find the top story on Hacker News")
 async for msg in run:
-    print(f"[{msg.role}] {msg.summary}")
+print(f"[{msg.role}] {msg.summary}")
 
 print(run.result.output)
 ```
@@ -270,15 +270,15 @@ session = await client.sessions.create(task="Find the top story on Hacker News")
 
 cursor = None
 while True:
-    msgs = await client.sessions.messages(session.id, after=cursor, limit=100)
-    for m in msgs.messages:
-        print(f"[{m.role}] {m.summary}")
-        cursor = m.id
+msgs = await client.sessions.messages(session.id, after=cursor, limit=100)
+for m in msgs.messages:
+    print(f"[{m.role}] {m.summary}")
+    cursor = m.id
 
-    s = await client.sessions.get(session.id)
-    if s.status.value in ("idle", "stopped", "error", "timed_out"):
-        break
-    await asyncio.sleep(2)
+s = await client.sessions.get(session.id)
+if s.status.value in ("idle", "stopped", "error", "timed_out"):
+    break
+await asyncio.sleep(2)
 
 print(s.output)
 ```
@@ -294,14 +294,14 @@ let cursor: string | undefined;
 while (true) {
   const msgs = await client.sessions.messages(session.id, { after: cursor, limit: 100 });
   for (const m of msgs.messages) {
-    console.log(`[${m.role}] ${m.summary}`);
-    cursor = m.id;
+console.log(`[${m.role}] ${m.summary}`);
+cursor = m.id;
   }
 
   const s = await client.sessions.get(session.id);
   if (["idle", "stopped", "error", "timed_out"].includes(s.status)) {
-    console.log(s.output);
-    break;
+console.log(s.output);
+break;
   }
   await new Promise((r) => setTimeout(r, 2000));
 }
@@ -335,8 +335,8 @@ await client.workspaces.upload(workspace.id, "people.csv")
 
 # Agent can now read it
 result = await client.run(
-    "Read people.csv and tell me who works at Google",
-    workspace_id=workspace.id,
+"Read people.csv and tell me who works at Google",
+workspace_id=workspace.id,
 )
 print(result.output)
 ```
@@ -376,8 +376,8 @@ workspace = await client.workspaces.create(name="my-workspace")
 
 # Agent creates a file
 result = await client.run(
-    "Go to Hacker News and save the top 3 posts as posts.json",
-    workspace_id=workspace.id,
+"Go to Hacker News and save the top 3 posts as posts.json",
+workspace_id=workspace.id,
 )
 
 # Download a single file
@@ -386,7 +386,7 @@ await client.workspaces.download(workspace.id, "posts.json", to="./posts.json")
 # Or download everything
 paths = await client.workspaces.download_all(workspace.id, to="./output")
 for p in paths:
-    print(f"Downloaded: {p}")
+print(f"Downloaded: {p}")
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
@@ -417,7 +417,7 @@ workspace = await client.workspaces.get(workspace_id)
 updated = await client.workspaces.update(workspace_id, name="renamed")
 response = await client.workspaces.list()
 for w in response.items:
-    print(w.id, w.name)
+print(w.id, w.name)
 await client.workspaces.delete(workspace_id)
 ```
 ```typescript TypeScript
@@ -462,8 +462,8 @@ print(f"Live view: {session.live_url}")
 
 # 2. Agent does the first part
 result = await client.run(
-    "Go to amazon.com and search for noise cancelling headphones",
-    session_id=session.id,
+"Go to amazon.com and search for noise cancelling headphones",
+session_id=session.id,
 )
 print(result.output)
 
@@ -472,8 +472,8 @@ input("Press Enter after you've selected a product in the live view...")
 
 # 4. Agent continues where the human left off
 result = await client.run(
-    "Get the details of the selected product — name, price, and rating",
-    session_id=session.id,
+"Get the details of the selected product — name, price, and rating",
+session_id=session.id,
 )
 print(result.output)
 
@@ -591,12 +591,12 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 browser = await client.browsers.create(
-    custom_proxy={
-        "host": "proxy.example.com",
-        "port": 8080,
-        "username": "user",
-        "password": "pass",
-    },
+custom_proxy={
+    "host": "proxy.example.com",
+    "port": 8080,
+    "username": "user",
+    "password": "pass",
+},
 )
 ```
 ```typescript TypeScript
@@ -605,10 +605,10 @@ import { BrowserUse } from "browser-use-sdk/v3";
 const client = new BrowserUse();
 const browser = await client.browsers.create({
   customProxy: {
-    host: "proxy.example.com",
-    port: 8080,
-    username: "user",
-    password: "pass",
+host: "proxy.example.com",
+port: 8080,
+username: "user",
+password: "pass",
   },
 });
 ```
@@ -687,14 +687,14 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 result = await client.run(
-    "Check how many GitHub stars browser-use has",
-    enable_recording=True,
+"Check how many GitHub stars browser-use has",
+enable_recording=True,
 )
 
 # Waits up to 15s for recording to be ready. Returns [] if no browser was opened.
 urls = await client.sessions.wait_for_recording(result.id)
 for url in urls:
-    print(url)  # presigned MP4 download URL
+print(url)  # presigned MP4 download URL
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
@@ -753,11 +753,11 @@ from playwright.async_api import async_playwright
 WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us"
 
 async with async_playwright() as p:
-    browser = await p.chromium.connect_over_cdp(WSS_URL)
-    page = browser.contexts[0].pages[0]
-    await page.goto("https://example.com")
-    print(await page.title())
-    await browser.close()
+browser = await p.chromium.connect_over_cdp(WSS_URL)
+page = browser.contexts[0].pages[0]
+await page.goto("https://example.com")
+print(await page.title())
+await browser.close()
 # Browser is automatically stopped when the WebSocket disconnects
 ```
 ```typescript TypeScript
@@ -882,7 +882,7 @@ profile = await client.profiles.create(name="work-account")
 # List all
 response = await client.profiles.list()
 for p in response.items:
-    print(p.id, p.name)
+print(p.id, p.name)
 
 # Search by name
 response = await client.profiles.list(query="user-id-1")
@@ -1048,8 +1048,8 @@ print(f"Live view: {session.live_url}")
 
 # Agent navigates to login
 result = await client.run(
-    "Go to example.com/login and enter username user@example.com and password mypassword, then stop before 2FA",
-    session_id=session.id,
+"Go to example.com/login and enter username user@example.com and password mypassword, then stop before 2FA",
+session_id=session.id,
 )
 
 # Human completes 2FA in the live view
@@ -1057,8 +1057,8 @@ input("Complete 2FA in the live view, then press Enter...")
 
 # Agent continues
 result = await client.run(
-    "You are now logged in. Go to the dashboard and export the monthly report",
-    session_id=session.id,
+"You are now logged in. Go to the dashboard and export the monthly report",
+session_id=session.id,
 )
 print(result.output)
 await client.sessions.stop(session.id)
@@ -1107,14 +1107,14 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 client = AsyncBrowserUse()
 
 result = await client.run(
-    """
-    1. Go to example.com/signup
-    2. Sign up with the agent's email address (use the email available to you)
-    3. Check your email inbox for the verification code
-    4. Enter the code on the website
-    5. Complete the registration
-    """,
-    agentmail=True,  # default, shown for clarity
+"""
+1. Go to example.com/signup
+2. Sign up with the agent's email address (use the email available to you)
+3. Check your email inbox for the verification code
+4. Enter the code on the website
+5. Complete the registration
+""",
+agentmail=True,  # default, shown for clarity
 )
 print(result.output)
 ```
@@ -1164,16 +1164,16 @@ client = AsyncBrowserUse()
 totp_secret = "JBSWY3DPEHPK3PXP"
 
 result = await client.run(
-    f"""
-    Log into example.com with username user@example.com and password mypassword.
-    When prompted for a 2FA code, generate one using pyotp:
+f"""
+Log into example.com with username user@example.com and password mypassword.
+When prompted for a 2FA code, generate one using pyotp:
 
-    import pyotp
-    totp = pyotp.TOTP("{totp_secret}")
-    code = totp.now()
+import pyotp
+totp = pyotp.TOTP("{totp_secret}")
+code = totp.now()
 
-    Enter the generated code.
-    """,
+Enter the generated code.
+""",
 )
 print(result.output)
 ```
@@ -1211,10 +1211,10 @@ This works because the Browser Use agent can execute Python code as part of its 
 
 ## Which approach should I use?
 
-    Start with **Profiles** — log in once, reuse cookies. If cookies expire frequently, add **TOTP secret in prompt** for fully automated re-login.
-    Use **Profiles** with one profile per user. For initial login, use **Human in the loop** — your user logs in once via the live view, then the agent reuses the session. For email 2FA, set up **Agent Mail** with email forwarding from your user.
-    Use **Agent Mail** (enabled by default). For end-client scenarios, have them forward 2FA emails to a dedicated inbox.
-    Use **TOTP secret in prompt** — the agent generates codes via pyotp, no human intervention needed.
+Start with **Profiles** — log in once, reuse cookies. If cookies expire frequently, add **TOTP secret in prompt** for fully automated re-login.
+Use **Profiles** with one profile per user. For initial login, use **Human in the loop** — your user logs in once via the live view, then the agent reuses the session. For email 2FA, set up **Agent Mail** with email forwarding from your user.
+Use **Agent Mail** (enabled by default). For end-client scenarios, have them forward 2FA emails to a dedicated inbox.
+Use **TOTP secret in prompt** — the agent generates codes via pyotp, no human intervention needed.
 
 
 # OpenClaw
@@ -1244,16 +1244,16 @@ Open `~/.openclaw/openclaw.json` and add a `browser-use` profile:
 ```json5
 {
   browser: {
-    enabled: true,
-    defaultProfile: "browser-use",
-    remoteCdpTimeoutMs: 3000,
-    remoteCdpHandshakeTimeoutMs: 5000,
-    profiles: {
-      "browser-use": {
-        cdpUrl: "wss://connect.browser-use.com?apiKey=<BROWSER_USE_API_KEY>&proxyCountryCode=us",
-        color: "#ff750e",
-      },
-    },
+enabled: true,
+defaultProfile: "browser-use",
+remoteCdpTimeoutMs: 3000,
+remoteCdpHandshakeTimeoutMs: 5000,
+profiles: {
+  "browser-use": {
+    cdpUrl: "wss://connect.browser-use.com?apiKey=<BROWSER_USE_API_KEY>&proxyCountryCode=us",
+    color: "#ff750e",
+  },
+},
   },
 }
 ```
@@ -1336,12 +1336,12 @@ Add to `claude_desktop_config.json`:
 ```json
 {
   "mcpServers": {
-    "browser-use": {
-      "url": "https://api.browser-use.com/v3/mcp",
-      "headers": {
-        "x-browser-use-api-key": "YOUR_API_KEY"
-      }
-    }
+"browser-use": {
+  "url": "https://api.browser-use.com/v3/mcp",
+  "headers": {
+    "x-browser-use-api-key": "YOUR_API_KEY"
+  }
+}
   }
 }
 ```
@@ -1353,12 +1353,12 @@ Add to `.cursor/mcp.json`:
 ```json
 {
   "mcpServers": {
-    "browser-use": {
-      "url": "https://api.browser-use.com/v3/mcp",
-      "headers": {
-        "x-browser-use-api-key": "YOUR_API_KEY"
-      }
-    }
+"browser-use": {
+  "url": "https://api.browser-use.com/v3/mcp",
+  "headers": {
+    "x-browser-use-api-key": "YOUR_API_KEY"
+  }
+}
   }
 }
 ```
@@ -1370,12 +1370,12 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 ```json
 {
   "mcpServers": {
-    "browser-use": {
-      "serverUrl": "https://api.browser-use.com/v3/mcp",
-      "headers": {
-        "x-browser-use-api-key": "YOUR_API_KEY"
-      }
-    }
+"browser-use": {
+  "serverUrl": "https://api.browser-use.com/v3/mcp",
+  "headers": {
+    "x-browser-use-api-key": "YOUR_API_KEY"
+  }
+}
   }
 }
 ```
@@ -1413,10 +1413,10 @@ Set up webhooks at [cloud.browser-use.com/settings?tab=webhooks](https://cloud.b
   "type": "agent.task.status_update",
   "timestamp": "2025-01-15T10:30:00Z",
   "payload": {
-    "task_id": "task_abc123",
-    "session_id": "session_xyz",
-    "status": "idle",
-    "metadata": {}
+"task_id": "task_abc123",
+"session_id": "session_xyz",
+"status": "idle",
+"metadata": {}
   }
 }
 ```
@@ -1437,17 +1437,17 @@ import json
 import time
 
 def verify_webhook(body: bytes, signature: str, timestamp: str, secret: str) -> bool:
-    # Reject requests older than 5 minutes
-    try:
-        ts = int(timestamp)
-    except (ValueError, TypeError):
-        return False
-    if abs(time.time() - ts) > 300:
-        return False
-    payload = json.loads(body)
-    message = f"{timestamp}.{json.dumps(payload, separators=(',', ':'), sort_keys=True)}"
-    expected = hmac.new(secret.encode(), message.encode(), hashlib.sha256).hexdigest()
-    return hmac.compare_digest(expected, signature)
+# Reject requests older than 5 minutes
+try:
+    ts = int(timestamp)
+except (ValueError, TypeError):
+    return False
+if abs(time.time() - ts) > 300:
+    return False
+payload = json.loads(body)
+message = f"{timestamp}.{json.dumps(payload, separators=(',', ':'), sort_keys=True)}"
+expected = hmac.new(secret.encode(), message.encode(), hashlib.sha256).hexdigest()
+return hmac.compare_digest(expected, signature)
 ```
 ```typescript TypeScript
 import { createHmac, timingSafeEqual } from "crypto";
@@ -1455,12 +1455,12 @@ import { createHmac, timingSafeEqual } from "crypto";
 function sortKeys(obj: unknown): unknown {
   if (Array.isArray(obj)) return obj.map(sortKeys);
   if (obj !== null && typeof obj === "object") {
-    return Object.keys(obj as object)
-      .sort()
-      .reduce((acc, key) => {
-        (acc as Record<string, unknown>)[key] = sortKeys((obj as Record<string, unknown>)[key]);
-        return acc;
-      }, {} as Record<string, unknown>);
+return Object.keys(obj as object)
+  .sort()
+  .reduce((acc, key) => {
+    (acc as Record<string, unknown>)[key] = sortKeys((obj as Record<string, unknown>)[key]);
+    return acc;
+  }, {} as Record<string, unknown>);
   }
   return obj;
 }
@@ -1489,12 +1489,12 @@ const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET!;
 function sortKeys(obj: unknown): unknown {
   if (Array.isArray(obj)) return obj.map(sortKeys);
   if (obj !== null && typeof obj === "object") {
-    return Object.keys(obj as object)
-      .sort()
-      .reduce((acc, key) => {
-        (acc as Record<string, unknown>)[key] = sortKeys((obj as Record<string, unknown>)[key]);
-        return acc;
-      }, {} as Record<string, unknown>);
+return Object.keys(obj as object)
+  .sort()
+  .reduce((acc, key) => {
+    (acc as Record<string, unknown>)[key] = sortKeys((obj as Record<string, unknown>)[key]);
+    return acc;
+  }, {} as Record<string, unknown>);
   }
   return obj;
 }
@@ -1504,7 +1504,7 @@ app.post("/webhook", (req, res) => {
   const timestamp = req.headers["x-browser-use-timestamp"] as string;
 
   if (Math.abs(Date.now() / 1000 - parseInt(timestamp)) > 300) {
-    return res.status(401).send("Request too old");
+return res.status(401).send("Request too old");
   }
 
   const body = req.body.toString();
@@ -1513,12 +1513,12 @@ app.post("/webhook", (req, res) => {
   const expected = createHmac("sha256", WEBHOOK_SECRET).update(message).digest("hex");
 
   if (!timingSafeEqual(Buffer.from(expected), Buffer.from(signature))) {
-    return res.status(401).send("Invalid signature");
+return res.status(401).send("Invalid signature");
   }
 
   if (payload.type === "agent.task.status_update") {
-    const { task_id, status, session_id } = payload.payload;
-    console.log(`Task ${task_id} is now ${status}`);
+const { task_id, status, session_id } = payload.payload;
+console.log(`Task ${task_id} is now ${status}`);
   }
 
   res.status(200).send("OK");
@@ -1543,31 +1543,31 @@ WEBHOOK_SECRET = os.environ["WEBHOOK_SECRET"]
 
 @app.post("/webhook")
 async def handle_webhook(request: Request):
-    body = await request.body()
-    signature = request.headers.get("x-browser-use-signature", "")
-    timestamp = request.headers.get("x-browser-use-timestamp", "")
+body = await request.body()
+signature = request.headers.get("x-browser-use-signature", "")
+timestamp = request.headers.get("x-browser-use-timestamp", "")
 
-    # Reject requests older than 5 minutes
-    try:
-        ts = int(timestamp)
-    except (ValueError, TypeError):
-        raise HTTPException(status_code=401, detail="Invalid timestamp")
-    if abs(time.time() - ts) > 300:
-        raise HTTPException(status_code=401, detail="Request too old")
+# Reject requests older than 5 minutes
+try:
+    ts = int(timestamp)
+except (ValueError, TypeError):
+    raise HTTPException(status_code=401, detail="Invalid timestamp")
+if abs(time.time() - ts) > 300:
+    raise HTTPException(status_code=401, detail="Request too old")
 
-    payload = json.loads(body)
-    message = f"{timestamp}.{json.dumps(payload, separators=(',', ':'), sort_keys=True)}"
-    expected = hmac.new(WEBHOOK_SECRET.encode(), message.encode(), hashlib.sha256).hexdigest()
+payload = json.loads(body)
+message = f"{timestamp}.{json.dumps(payload, separators=(',', ':'), sort_keys=True)}"
+expected = hmac.new(WEBHOOK_SECRET.encode(), message.encode(), hashlib.sha256).hexdigest()
 
-    if not hmac.compare_digest(expected, signature):
-        raise HTTPException(status_code=401, detail="Invalid signature")
+if not hmac.compare_digest(expected, signature):
+    raise HTTPException(status_code=401, detail="Invalid signature")
 
-    if payload["type"] == "agent.task.status_update":
-        task_id = payload["payload"]["task_id"]
-        status = payload["payload"]["status"]
-        print(f"Task {task_id} is now {status}")
+if payload["type"] == "agent.task.status_update":
+    task_id = payload["payload"]["task_id"]
+    status = payload["payload"]["status"]
+    print(f"Task {task_id} is now {status}")
 
-    return {"status": "ok"}
+return {"status": "ok"}
 ```
 
   For local development, use a tunneling tool like [ngrok](https://ngrok.com) to expose your local server: `ngrok http 3000`. Then set the ngrok URL as your webhook endpoint in the dashboard.
@@ -1668,8 +1668,8 @@ import { client } from "./api";
 
 export async function createSession() {
   const session = await client.sessions.create({
-    keepAlive: true,
-    enableRecording: true,
+keepAlive: true,
+enableRecording: true,
   });
   return { id: session.id, liveUrl: session.liveUrl, status: session.status };
 }
@@ -1686,7 +1686,7 @@ async function handleSend(message: string) {
   const session = await createSession();
 
   router.push(
-    `/session/${session.id}?liveUrl=${encodeURIComponent(session.liveUrl)}&task=${encodeURIComponent(message)}`
+`/session/${session.id}?liveUrl=${encodeURIComponent(session.liveUrl)}&task=${encodeURIComponent(message)}`
   );
 }
 ```
@@ -1702,7 +1702,7 @@ const streamTask = useCallback(async (task: string) => {
   const run = client.run(task, { sessionId });
 
   for await (const msg of run) {
-    setMessages((prev) => [...prev, msg]);
+setMessages((prev) => [...prev, msg]);
   }
 
   // Iterator done — task reached terminal state
@@ -1746,7 +1746,7 @@ useEffect(() => {
   if (!isTerminal) return;
 
   client.sessions.waitForRecording(sessionId).then((urls) => {
-    if (urls.length) setRecordingUrls(urls);
+if (urls.length) setRecordingUrls(urls);
   });
 }, [isTerminal, sessionId]);
 ```
@@ -1774,23 +1774,23 @@ The session page consumes everything through a context provider:
 ```typescript session/[id]/page.tsx
 function SessionPage() {
   const { session, turns, isBusy, isTerminal, recordingUrls, sendMessage, stopTask } =
-    useSession();
+useSession();
 
   return (
-    <div className="flex h-screen w-full overflow-hidden">
-      {/* Chat column */}
-      <div className="flex-1 flex flex-col min-w-0">
-        <ChatMessages turns={turns} isBusy={isBusy} />
-        <ChatInput
-          onSend={sendMessage}
-          onStop={stopTask}
-          disabled={isTerminal}
-        />
-      </div>
+<div className="flex h-screen w-full overflow-hidden">
+  {/* Chat column */}
+  <div className="flex-1 flex flex-col min-w-0">
+    <ChatMessages turns={turns} isBusy={isBusy} />
+    <ChatInput
+      onSend={sendMessage}
+      onStop={stopTask}
+      disabled={isTerminal}
+    />
+  </div>
 
-      {/* Live browser view — liveUrl available from session creation */}
-      <BrowserPanel liveUrl={session?.liveUrl} />
-    </div>
+  {/* Live browser view — liveUrl available from session creation */}
+  <BrowserPanel liveUrl={session?.liveUrl} />
+</div>
   );
 }
 ```
@@ -1893,7 +1893,7 @@ Upload images, PDFs, documents, and text files (10 MB max) to sessions, and down
 
 ### Upload a file
 
-Get a presigned URL, then upload via PUT.
+Get a presigned URL, then upload via POST.
 
 ```python Python
 import httpx
@@ -1903,15 +1903,15 @@ client = AsyncBrowserUse()
 session = await client.sessions.create()
 
 upload = await client.files.session_url(
-    session.id,
-    file_name="input.pdf",
-    content_type="application/pdf",
-    size_bytes=1024,
+session.id,
+file_name="input.pdf",
+content_type="application/pdf",
+size_bytes=1024,
 )
 
 with open("input.pdf", "rb") as f:
-    async with httpx.AsyncClient() as http:
-        await http.put(upload.presigned_url, content=f.read(), headers={"Content-Type": "application/pdf"})
+async with httpx.AsyncClient() as http:
+    await http.post(upload.url, content=f.read(), headers={"Content-Type": "application/pdf"})
 
 result = await client.run("Summarize the uploaded PDF", session_id=session.id)
 ```
@@ -1928,8 +1928,8 @@ const upload = await client.files.sessionUrl(session.id, {
   sizeBytes: 1024,
 });
 
-await fetch(upload.presignedUrl, {
-  method: "PUT",
+await fetch(upload.url, {
+  method: "POST",
   body: readFileSync("input.pdf"),
   headers: { "Content-Type": "application/pdf" },
 });
@@ -1944,14 +1944,14 @@ const result = await client.run("Summarize the uploaded PDF", { sessionId: sessi
 ```python Python
 result = await client.tasks.get(task_id)
 for file in result.output_files:
-    output = await client.files.task_output(task_id, file.id)
-    print(output.presigned_url)  # download URL
+output = await client.files.task_output(task_id, file.id)
+print(output.download_url)  # download URL
 ```
 ```typescript TypeScript
 const result = await client.tasks.get(taskId);
 for (const file of result.outputFiles) {
   const output = await client.files.taskOutput(taskId, file.id);
-  console.log(output.presignedUrl);
+  console.log(output.downloadUrl);
 }
 ```
 
@@ -1967,8 +1967,8 @@ from browser_use_sdk import AsyncBrowserUse
 client = AsyncBrowserUse()
 run = client.run("Find the most upvoted post on Reddit r/technology today")
 async for step in run:
-    print(f"Step {step.number}: {step.next_goal}")
-    print(f"  URL: {step.url}")
+print(f"Step {step.number}: {step.next_goal}")
+print(f"  URL: {step.url}")
 
 print(run.result.output)  # final result after iteration
 ```
@@ -2018,11 +2018,11 @@ Generate a public URL that anyone can open to watch the entire agent session —
 
 ```python Python
 share = await client.sessions.create_share(session.id)
-print(share.url)
+print(share.share_url)
 ```
 ```typescript TypeScript
 const share = await client.sessions.createShare(session.id);
-console.log(share.url);
+console.log(share.shareUrl);
 ```
 
 
@@ -2049,8 +2049,8 @@ from browser_use_sdk import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 skill = await client.skills.create(
-    goal="Extract the top X posts from HackerNews. For each post return: title, URL, score, author, comment count, and rank. X is an input parameter.",
-    agent_prompt="Go to https://news.ycombinator.com, click on the first post to load its content, go back to the list, and scroll down to trigger loading of additional posts.",
+goal="Extract the top X posts from HackerNews. For each post return: title, URL, score, author, comment count, and rank. X is an input parameter.",
+agent_prompt="Go to https://news.ycombinator.com, click on the first post to load its content, go back to the list, and scroll down to trigger loading of additional posts.",
 )
 print(skill.id)
 ```
@@ -2071,8 +2071,8 @@ Skill creation takes ~30 seconds. You can also create skills visually from the [
 
 ```python Python
 result = await client.skills.execute(
-    skill.id,
-    parameters={"X": 10},
+skill.id,
+parameters={"X": 10},
 )
 print(result)
 ```
@@ -2144,9 +2144,9 @@ from browser_use_sdk import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 result = await client.run(
-    "Log into my Jira account and create a new ticket",
-    op_vault_id="your-vault-id",
-    allowed_domains=["*.atlassian.net"],
+"Log into my Jira account and create a new ticket",
+op_vault_id="your-vault-id",
+allowed_domains=["*.atlassian.net"],
 )
 print(result.output)
 ```
@@ -2157,8 +2157,8 @@ const client = new BrowserUse();
 const result = await client.run(
   "Log into my Jira account and create a new ticket",
   {
-    opVaultId: "your-vault-id",
-    allowedDomains: ["*.atlassian.net"],
+opVaultId: "your-vault-id",
+allowedDomains: ["*.atlassian.net"],
   },
 );
 console.log(result.output);
@@ -2168,17 +2168,17 @@ For SSO/OAuth redirects, include all required domains:
 
 ```python Python
 result = await client.run(
-    "Log into Jira and create a ticket for the Q4 release",
-    op_vault_id="your-vault-id",
-    allowed_domains=["*.atlassian.net", "*.okta.com"],
+"Log into Jira and create a ticket for the Q4 release",
+op_vault_id="your-vault-id",
+allowed_domains=["*.atlassian.net", "*.okta.com"],
 )
 ```
 ```typescript TypeScript
 const result = await client.run(
   "Log into Jira and create a ticket for the Q4 release",
   {
-    opVaultId: "your-vault-id",
-    allowedDomains: ["*.atlassian.net", "*.okta.com"],
+opVaultId: "your-vault-id",
+allowedDomains: ["*.atlassian.net", "*.okta.com"],
   },
 );
 ```
@@ -2206,9 +2206,9 @@ from browser_use_sdk import AsyncBrowserUse
 
 client = AsyncBrowserUse()
 result = await client.run(
-    "Log into GitHub and star the browser-use/browser-use repo",
-    secrets={"github.com": "username:password123"},
-    allowed_domains=["github.com"],
+"Log into GitHub and star the browser-use/browser-use repo",
+secrets={"github.com": "username:password123"},
+allowed_domains=["github.com"],
 )
 ```
 ```typescript TypeScript
@@ -2218,8 +2218,8 @@ const client = new BrowserUse();
 const result = await client.run(
   "Log into GitHub and star the browser-use/browser-use repo",
   {
-    secrets: { "github.com": "username:password123" },
-    allowedDomains: ["github.com"],
+secrets: { "github.com": "username:password123" },
+allowedDomains: ["github.com"],
   },
 );
 ```
@@ -2230,23 +2230,23 @@ For SSO/OAuth redirects, include all domains in the auth flow:
 
 ```python Python
 result = await client.run(
-    "Log into the company portal and download the Q4 report",
-    secrets={
-        "portal.example.com": "user@company.com:password123",
-        "okta.com": "user@company.com:password123",
-    },
-    allowed_domains=["portal.example.com", "*.okta.com"],
+"Log into the company portal and download the Q4 report",
+secrets={
+    "portal.example.com": "user@company.com:password123",
+    "okta.com": "user@company.com:password123",
+},
+allowed_domains=["portal.example.com", "*.okta.com"],
 )
 ```
 ```typescript TypeScript
 const result = await client.run(
   "Log into the company portal and download the Q4 report",
   {
-    secrets: {
-      "portal.example.com": "user@company.com:password123",
-      "okta.com": "user@company.com:password123",
-    },
-    allowedDomains: ["portal.example.com", "*.okta.com"],
+secrets: {
+  "portal.example.com": "user@company.com:password123",
+  "okta.com": "user@company.com:password123",
+},
+allowedDomains: ["portal.example.com", "*.okta.com"],
   },
 );
 ```

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -24,27 +24,6 @@ Set API key (starts with `bu_`):
 export BROWSER_USE_API_KEY=bu_your_key_here
 ```
 
-For the full reference with all code examples inline, fetch: https://docs.browser-use.com/cloud/llms-full.txt
-
-## Quick start
-
-`client.run()` is a high-level wrapper: it creates a session, polls every 2s until completion (up to 4 hours), and returns the result. The SDK also exposes every endpoint from the [API v3 Reference](https://docs.browser-use.com/cloud/api-reference) directly (e.g. `client.sessions.create()`, `client.sessions.get()`, `client.profiles.list()`). The pages below show common patterns; see the API reference for the full surface.
-
-```python
-from browser_use_sdk.v3 import AsyncBrowserUse
-
-client = AsyncBrowserUse()
-result = await client.run("Go to example.com and get the page title")
-print(result.output)
-```
-
-```typescript
-import { BrowserUse } from "browser-use-sdk/v3";
-
-const client = new BrowserUse();
-const result = await client.run("Go to example.com and get the page title");
-console.log(result.output);
-```
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.
@@ -67,7 +46,7 @@ console.log(result.output);
 ## Authentication
 - [Profiles](https://docs.browser-use.com/cloud/guides/authentication): Persistent browser state — cookies, localStorage, saved passwords. Login once, reuse across sessions.
 - [Sync local and cloud cookies](https://docs.browser-use.com/cloud/guides/profile-sync): Sync your local browser cookies to the cloud — instantly authenticate without managing credentials.
-- [2FA](https://docs.browser-use.com/cloud/guides/2fa): Best practices for two-factor authentication — profiles, human-in-the-loop, Agent Mail, and TOTP via pyotp.
+- [2FA](https://docs.browser-use.com/cloud/guides/2fa): Best practices for handling two-factor authentication in automated browser sessions.
 
 ## Integrations
 - [OpenClaw](https://docs.browser-use.com/cloud/tutorials/integrations/openclaw): Give OpenClaw agents browser automation with Browser Use — via CDP or the CLI skill.

--- a/docs/open-source/browser-use-cli.mdx
+++ b/docs/open-source/browser-use-cli.mdx
@@ -271,7 +271,7 @@ browser-use open https://abc.trycloudflare.com
 
 ## Profile Management
 
-The `profile` subcommand delegates to the [profile-use](https://github.com/browser-use/browser-use-cli) Go binary, which syncs local browser cookies to Browser-Use cloud.
+The `profile` subcommand syncs local browser cookies to Browser-Use cloud.
 
 The binary is managed at `~/.browser-use/bin/profile-use` and auto-downloaded on first use.
 

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -901,7 +901,7 @@ browser-use open https://abc.trycloudflare.com
 
 ## Profile Management
 
-The `profile` subcommand delegates to the [profile-use](https://github.com/browser-use/profile-use) Go binary, which syncs local browser cookies to Browser-Use cloud.
+The `profile` subcommand delegates to the [profile-use](https://github.com/browser-use/browser-use-cli) Go binary, which syncs local browser cookies to Browser-Use cloud.
 
 The binary is managed at `~/.browser-use/bin/profile-use` and auto-downloaded on first use.
 
@@ -2632,7 +2632,7 @@ uvx --from 'browser-use[cli]' browser-use --mcp
 
 ## Next Steps
 
-- Explore the [examples directory](https://github.com/browser-use/browser-use/tree/main/examples/mcp) for more usage patterns
+- Explore the [examples directory](https://github.com/browser-use/browser-use/tree/main/examples) for more usage patterns
 - Check out [MCP documentation](https://modelcontextprotocol.io/) to learn more about the protocol
 - Join our [Discord](https://link.browser-use.com/discord) for support and discussions
 

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -8,8 +8,8 @@ Source: https://docs.browser-use.com/open-source/introduction
 <img src="/images/intro-oss-light.svg" alt="Browser Use Open Source" noZoom className="block dark:hidden" />
 <img src="/images/intro-oss-dark.svg" alt="Browser Use Open Source" noZoom className="hidden dark:block" />
 
-    Install and run your first agent.
-    Full SDK reference in a single page.
+Install and run your first agent.
+Full SDK reference in a single page.
 
   Try [Browser Use Cloud](https://docs.browser-use.com/cloud/introduction) for our SOTA model, stealth browsers, CAPTCHA solving, and managed infrastructure.
 
@@ -84,13 +84,13 @@ import asyncio
 load_dotenv()
 
 async def main():
-    llm = ChatBrowserUse()
-    task = "Find the number 1 post on Show HN"
-    agent = Agent(task=task, llm=llm)
-    await agent.run()
+llm = ChatBrowserUse()
+task = "Find the number 1 post on Show HN"
+agent = Agent(task=task, llm=llm)
+await agent.run()
 
 if __name__ == "__main__":
-    asyncio.run(main())
+asyncio.run(main())
 ```
 ```python Google
 from browser_use import Agent, ChatGoogle
@@ -100,13 +100,13 @@ import asyncio
 load_dotenv()
 
 async def main():
-    llm = ChatGoogle(model="gemini-flash-latest")
-    task = "Find the number 1 post on Show HN"
-    agent = Agent(task=task, llm=llm)
-    await agent.run()
+llm = ChatGoogle(model="gemini-flash-latest")
+task = "Find the number 1 post on Show HN"
+agent = Agent(task=task, llm=llm)
+await agent.run()
 
 if __name__ == "__main__":
-    asyncio.run(main())
+asyncio.run(main())
 ```
 ```python OpenAI
 from browser_use import Agent, ChatOpenAI
@@ -116,13 +116,13 @@ import asyncio
 load_dotenv()
 
 async def main():
-    llm = ChatOpenAI(model="gpt-4.1-mini")
-    task = "Find the number 1 post on Show HN"
-    agent = Agent(task=task, llm=llm)
-    await agent.run()
+llm = ChatOpenAI(model="gpt-4.1-mini")
+task = "Find the number 1 post on Show HN"
+agent = Agent(task=task, llm=llm)
+await agent.run()
 
 if __name__ == "__main__":
-    asyncio.run(main())
+asyncio.run(main())
 ```
 ```python Anthropic
 from browser_use import Agent, ChatAnthropic
@@ -132,13 +132,13 @@ import asyncio
 load_dotenv()
 
 async def main():
-    llm = ChatAnthropic(model='claude-sonnet-4-0', temperature=0.0)
-    task = "Find the number 1 post on Show HN"
-    agent = Agent(task=task, llm=llm)
-    await agent.run()
+llm = ChatAnthropic(model='claude-sonnet-4-0', temperature=0.0)
+task = "Find the number 1 post on Show HN"
+agent = Agent(task=task, llm=llm)
+await agent.run()
 
 if __name__ == "__main__":
-    asyncio.run(main())
+asyncio.run(main())
 ```
 
 
@@ -155,15 +155,15 @@ from browser_use.agent.service import Agent
 
 @sandbox(cloud_profile_id='your-profile-id')
 async def production_task(browser: Browser):
-    agent = Agent(
-        task="Your authenticated task",
-        browser=browser,
-        llm=ChatBrowserUse(),
-    )
-    await agent.run()
+agent = Agent(
+    task="Your authenticated task",
+    browser=browser,
+    llm=ChatBrowserUse(),
+)
+await agent.run()
 
 if __name__ == "__main__":
-    asyncio.run(production_task())
+asyncio.run(production_task())
 ```
 
 See [Browser Use Cloud](https://docs.browser-use.com/cloud/quickstart) for how to sync your cookies to the cloud.
@@ -199,8 +199,8 @@ llm = ChatBrowserUse(model='bu-2-0')
 
 # Create agent with the model
 agent = Agent(
-    task="...", # Your task here
-    llm=llm
+task="...", # Your task here
+llm=llm
 )
 ```
 
@@ -254,8 +254,8 @@ llm = ChatGoogle(model='gemini-flash-latest')
 
 # Create agent with the model
 agent = Agent(
-    task="Your task here",
-    llm=llm
+task="Your task here",
+llm=llm
 )
 ```
 
@@ -275,13 +275,13 @@ from browser_use import Agent, ChatOpenAI
 
 # Initialize the model
 llm = ChatOpenAI(
-    model="o3",
+model="o3",
 )
 
 # Create agent with the model
 agent = Agent(
-    task="...", # Your task here
-    llm=llm
+task="...", # Your task here
+llm=llm
 )
 ```
 
@@ -302,13 +302,13 @@ from browser_use import Agent, ChatAnthropic
 
 # Initialize the model
 llm = ChatAnthropic(
-    model="claude-sonnet-4-0",
+model="claude-sonnet-4-0",
 )
 
 # Create agent with the model
 agent = Agent(
-    task="...", # Your task here
-    llm=llm
+task="...", # Your task here
+llm=llm
 )
 ```
 
@@ -327,13 +327,13 @@ import os
 
 # Initialize the model
 llm = ChatAzureOpenAI(
-    model="o4-mini",
+model="o4-mini",
 )
 
 # Create agent with the model
 agent = Agent(
-    task="...", # Your task here
-    llm=llm
+task="...", # Your task here
+llm=llm
 )
 ```
 
@@ -359,20 +359,20 @@ from browser_use import Agent, ChatAzureOpenAI
 
 # Auto-detection (recommended) - uses Responses API for gpt-5.1-codex-mini
 llm = ChatAzureOpenAI(
-    model="gpt-5.1-codex-mini",
-    api_version="2025-03-01-preview",  # Required for Responses API
+model="gpt-5.1-codex-mini",
+api_version="2025-03-01-preview",  # Required for Responses API
 )
 
 # Or explicitly enable/disable Responses API for any model
 llm = ChatAzureOpenAI(
-    model="gpt-4o",
-    api_version="2025-03-01-preview",
-    use_responses_api=True,  # Force Responses API (True/False/'auto')
+model="gpt-4o",
+api_version="2025-03-01-preview",
+use_responses_api=True,  # Force Responses API (True/False/'auto')
 )
 
 agent = Agent(
-    task="...",
-    llm=llm
+task="...",
+llm=llm
 )
 ```
 
@@ -393,14 +393,14 @@ from browser_use.llm import ChatAWSBedrock
 
 # Works with any Bedrock model (Anthropic, Meta, AI21, etc.)
 llm = ChatAWSBedrock(
-    model="anthropic.claude-3-5-sonnet-20240620-v1:0",  # or any Bedrock model
-    aws_region="us-east-1",
+model="anthropic.claude-3-5-sonnet-20240620-v1:0",  # or any Bedrock model
+aws_region="us-east-1",
 )
 
 # Create agent with the model
 agent = Agent(
-    task="Your task here",
-    llm=llm
+task="Your task here",
+llm=llm
 )
 ```
 
@@ -412,14 +412,14 @@ from browser_use.llm import ChatAnthropicBedrock
 
 # Anthropic-specific class with Claude defaults
 llm = ChatAnthropicBedrock(
-    model="anthropic.claude-3-5-sonnet-20240620-v1:0",
-    aws_region="us-east-1",
+model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+aws_region="us-east-1",
 )
 
 # Create agent with the model
 agent = Agent(
-    task="Your task here",
-    llm=llm
+task="Your task here",
+llm=llm
 )
 ```
 
@@ -449,8 +449,8 @@ from browser_use import Agent, ChatGroq
 llm = ChatGroq(model="meta-llama/llama-4-maverick-17b-128e-instruct")
 
 agent = Agent(
-    task="Your task here",
-    llm=llm
+task="Your task here",
+llm=llm
 )
 ```
 
@@ -469,21 +469,21 @@ from browser_use import Agent, ChatOCIRaw
 
 # Initialize the OCI model
 llm = ChatOCIRaw(
-    model_id="ocid1.generativeaimodel.oc1.us-chicago-1.amaaaaaask7dceya...",
-    service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
-    compartment_id="ocid1.tenancy.oc1..aaaaaaaayeiis5uk2nuubznrekd...",
-    provider="meta",  # or "cohere"
-    temperature=0.7,
-    max_tokens=800,
-    top_p=0.9,
-    auth_type="API_KEY",
-    auth_profile="DEFAULT"
+model_id="ocid1.generativeaimodel.oc1.us-chicago-1.amaaaaaask7dceya...",
+service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+compartment_id="ocid1.tenancy.oc1..aaaaaaaayeiis5uk2nuubznrekd...",
+provider="meta",  # or "cohere"
+temperature=0.7,
+max_tokens=800,
+top_p=0.9,
+auth_type="API_KEY",
+auth_profile="DEFAULT"
 )
 
 # Create agent with the model
 agent = Agent(
-    task="Your task here",
-    llm=llm
+task="Your task here",
+llm=llm
 )
 ```
 
@@ -532,9 +532,9 @@ base_url = 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1'
 llm = ChatOpenAI(model='qwen-vl-max', api_key=api_key, base_url=base_url)
 
 agent = Agent(
-    task="Your task here",
-    llm=llm,
-    use_vision=True
+task="Your task here",
+llm=llm,
+use_vision=True
 )
 ```
 
@@ -560,9 +560,9 @@ base_url = 'https://api-inference.modelscope.cn/v1/'
 llm = ChatOpenAI(model='Qwen/Qwen2.5-VL-72B-Instruct', api_key=api_key, base_url=base_url)
 
 agent = Agent(
-    task="Your task here",
-    llm=llm,
-    use_vision=True
+task="Your task here",
+llm=llm,
+use_vision=True
 )
 ```
 
@@ -588,29 +588,29 @@ load_dotenv()
 # Get API key (https://vercel.com/ai-gateway)
 api_key = os.getenv('VERCEL_API_KEY')
 if not api_key:
-    raise ValueError('VERCEL_API_KEY is not set')
+raise ValueError('VERCEL_API_KEY is not set')
 
 # Basic usage
 llm = ChatVercel(
-    model='openai/gpt-4o',
-    api_key=api_key,
+model='openai/gpt-4o',
+api_key=api_key,
 )
 
 # With provider options - control which providers are used and in what order
 # This will try Vertex AI first, then fall back to Anthropic if Vertex fails
 llm_with_provider_options = ChatVercel(
-    model='anthropic/claude-sonnet-4',
-    api_key=api_key,
-    provider_options={
-        'gateway': {
-            'order': ['vertex', 'anthropic']  # Try Vertex AI first, then Anthropic
-        }
-    },
+model='anthropic/claude-sonnet-4',
+api_key=api_key,
+provider_options={
+    'gateway': {
+        'order': ['vertex', 'anthropic']  # Try Vertex AI first, then Anthropic
+    }
+},
 )
 
 agent = Agent(
-    task="Your task here",
-    llm=llm
+task="Your task here",
+llm=llm
 )
 ```
 
@@ -901,7 +901,7 @@ browser-use open https://abc.trycloudflare.com
 
 ## Profile Management
 
-The `profile` subcommand delegates to the [profile-use](https://github.com/browser-use/browser-use-cli) Go binary, which syncs local browser cookies to Browser-Use cloud.
+The `profile` subcommand syncs local browser cookies to Browser-Use cloud.
 
 The binary is managed at `~/.browser-use/bin/profile-use` and auto-downloaded on first use.
 
@@ -982,8 +982,8 @@ browser-use eval "Array.from(document.querySelectorAll('.titleline a')).slice(0,
 browser-use open https://example.com
 browser-use python "
 for i in range(5):
-    browser.scroll('down')
-    browser.wait(0.5)
+browser.scroll('down')
+browser.wait(0.5)
 browser.screenshot('scrolled.png')
 "
 ```
@@ -1075,12 +1075,12 @@ Source: https://docs.browser-use.com/open-source/customize/agent/basics
 from browser_use import Agent, ChatBrowserUse
 
 agent = Agent(
-    task="Search for latest news about AI",
-    llm=ChatBrowserUse(),
+task="Search for latest news about AI",
+llm=ChatBrowserUse(),
 )
 
 async def main():
-    history = await agent.run(max_steps=100)
+history = await agent.run(max_steps=100)
 ```
 
 - `task`: The task you want to automate.
@@ -1157,8 +1157,8 @@ If the submit button cannot be clicked:
 # When you have custom actions
 @controller.action("Get 2FA code from authenticator app")
 async def get_2fa_code():
-    # Your implementation
-    pass
+# Your implementation
+pass
 
 task = """
 Login with 2FA:
@@ -1429,9 +1429,9 @@ from browser_use import Agent, Browser, ChatBrowserUse
 browser = Browser.from_system_chrome()
 
 agent = Agent(
-    task='Check my Gmail inbox',
-    browser=browser,
-    llm=ChatBrowserUse(),
+task='Check my Gmail inbox',
+browser=browser,
+llm=ChatBrowserUse(),
 )
 await agent.run()
 ```
@@ -1463,9 +1463,9 @@ from browser_use import Agent, Browser, ChatBrowserUse
 browser = Browser(storage_state='auth.json')
 
 agent = Agent(
-    task='Check my notifications',
-    browser=browser,
-    llm=ChatBrowserUse(),
+task='Check my notifications',
+browser=browser,
+llm=ChatBrowserUse(),
 )
 await agent.run()
 ```
@@ -1489,24 +1489,24 @@ The JSON file follows Playwright's format:
 ```json
 {
   "cookies": [
-    {
-      "name": "session_id",
-      "value": "abc123",
-      "domain": ".example.com",
-      "path": "/",
-      "expires": 1704067200,
-      "httpOnly": true,
-      "secure": true,
-      "sameSite": "Lax"
-    }
+{
+  "name": "session_id",
+  "value": "abc123",
+  "domain": ".example.com",
+  "path": "/",
+  "expires": 1704067200,
+  "httpOnly": true,
+  "secure": true,
+  "sameSite": "Lax"
+}
   ],
   "origins": [
-    {
-      "origin": "https://example.com",
-      "localStorage": [
-        {"name": "auth_token", "value": "xyz789"}
-      ]
-    }
+{
+  "origin": "https://example.com",
+  "localStorage": [
+    {"name": "auth_token", "value": "xyz789"}
+  ]
+}
   ]
 }
 ```
@@ -1533,17 +1533,17 @@ from browser_use import Agent, ChatBrowserUse
 totp_secret = 'JBSWY3DPEHPK3PXP'
 
 agent = Agent(
-    task='''
-    1. Go to https://example.com/login
-    2. Enter username x_user and password x_pass
-    3. When prompted for 2FA, enter bu_2fa_code
-    ''',
-    sensitive_data={
-        'x_user': 'myusername',
-        'x_pass': 'mypassword',
-        'bu_2fa_code': totp_secret,  # suffix must be bu_2fa_code
-    },
-    llm=ChatBrowserUse(),
+task='''
+1. Go to https://example.com/login
+2. Enter username x_user and password x_pass
+3. When prompted for 2FA, enter bu_2fa_code
+''',
+sensitive_data={
+    'x_user': 'myusername',
+    'x_pass': 'mypassword',
+    'bu_2fa_code': totp_secret,  # suffix must be bu_2fa_code
+},
+llm=ChatBrowserUse(),
 )
 await agent.run()
 ```
@@ -1578,19 +1578,19 @@ tools = Tools()
 
 @tools.registry.action('Get email address for signup')
 async def get_email_address():
-    return ActionResult(extracted_content=inbox.inbox_id)
+return ActionResult(extracted_content=inbox.inbox_id)
 
 @tools.registry.action('Get verification code from email')
 async def get_verification_code():
-    emails = await email_client.inboxes.messages.list(inbox_id=inbox.inbox_id)
-    if emails.messages:
-        return ActionResult(extracted_content=emails.messages[0].text)
-    return ActionResult(error='No emails found')
+emails = await email_client.inboxes.messages.list(inbox_id=inbox.inbox_id)
+if emails.messages:
+    return ActionResult(extracted_content=emails.messages[0].text)
+return ActionResult(error='No emails found')
 
 agent = Agent(
-    task='Sign up at example.com, get verification code from email',
-    tools=tools,
-    llm=ChatBrowserUse(),
+task='Sign up at example.com, get verification code from email',
+tools=tools,
+llm=ChatBrowserUse(),
 )
 await agent.run()
 ```
@@ -1610,18 +1610,18 @@ tools = Tools()
 
 @tools.registry.action('Get 2FA code from 1Password', domains=['*.google.com'])
 async def get_1password_2fa():
-    client = await Client.authenticate(
-        auth=os.environ['OP_SERVICE_ACCOUNT_TOKEN'],
-        integration_name='Browser-Use',
-        integration_version='v1.0.0',
-    )
-    code = await client.secrets.resolve('op://Private/Google/One-time passcode')
-    return ActionResult(extracted_content=code)
+client = await Client.authenticate(
+    auth=os.environ['OP_SERVICE_ACCOUNT_TOKEN'],
+    integration_name='Browser-Use',
+    integration_version='v1.0.0',
+)
+code = await client.secrets.resolve('op://Private/Google/One-time passcode')
+return ActionResult(extracted_content=code)
 
 agent = Agent(
-    task='Login to Google and check email',
-    tools=tools,
-    llm=ChatBrowserUse(),
+task='Login to Google and check email',
+tools=tools,
+llm=ChatBrowserUse(),
 )
 await agent.run()
 ```
@@ -1641,9 +1641,9 @@ tools = Tools()
 register_gmail_actions(tools, gmail_service=gmail_service)
 
 agent = Agent(
-    task='Login to example.com, then get the verification code from Gmail',
-    tools=tools,
-    llm=ChatBrowserUse(),
+task='Login to example.com, then get the verification code from Gmail',
+tools=tools,
+llm=ChatBrowserUse(),
 )
 await agent.run()
 ```
@@ -1667,7 +1667,7 @@ Limit where the browser can navigate to prevent credential leaks:
 
 ```python
 browser = Browser(
-    allowed_domains=['*.example.com', 'auth.example.com'],
+allowed_domains=['*.example.com', 'auth.example.com'],
 )
 ```
 
@@ -1677,10 +1677,10 @@ Prevent screenshots from being sent to the LLM:
 
 ```python
 agent = Agent(
-    task='Login and check balance',
-    use_vision=False,  # No screenshots sent to LLM
-    sensitive_data={'password': 'secret123'},
-    llm=ChatBrowserUse(),
+task='Login and check balance',
+use_vision=False,  # No screenshots sent to LLM
+sensitive_data={'password': 'secret123'},
+llm=ChatBrowserUse(),
 )
 ```
 
@@ -1690,14 +1690,14 @@ Route credentials to specific domains only:
 
 ```python
 sensitive_data = {
-    'https://*.work.com': {
-        'work_user': 'alice@work.com',
-        'work_pass': 'work_password',
-    },
-    'https://personal.com': {
-        'personal_user': 'alice@gmail.com',
-        'personal_pass': 'personal_password',
-    },
+'https://*.work.com': {
+    'work_user': 'alice@work.com',
+    'work_pass': 'work_password',
+},
+'https://personal.com': {
+    'personal_user': 'alice@gmail.com',
+    'personal_pass': 'personal_password',
+},
 }
 ```
 
@@ -1718,9 +1718,9 @@ from browser_use import Agent, Browser, ChatBrowserUse
 browser = Browser(cdp_url='wss://cloud.browser-use.com/...')
 
 agent = Agent(
-    task='Check my orders',
-    browser=browser,
-    llm=ChatBrowserUse(),
+task='Check my orders',
+browser=browser,
+llm=ChatBrowserUse(),
 )
 await agent.run()
 ```
@@ -1743,16 +1743,16 @@ from browser_use import Agent, Browser, ChatOpenAI
 browser = Browser.from_system_chrome()
 
 agent = Agent(
-    task='Visit https://duckduckgo.com and search for "browser-use founders"',
-    browser=browser,
-    llm=ChatOpenAI(model='gpt-4.1-mini'),
+task='Visit https://duckduckgo.com and search for "browser-use founders"',
+browser=browser,
+llm=ChatOpenAI(model='gpt-4.1-mini'),
 )
 
 async def main():
-    await agent.run()
+await agent.run()
 
 if __name__ == "__main__":
-    asyncio.run(main())
+asyncio.run(main())
 ```
 
 
@@ -1766,7 +1766,7 @@ from browser_use import Browser
 # List available profiles
 profiles = Browser.list_chrome_profiles()
 for p in profiles:
-    print(f"{p['directory']}: {p['name']}")
+print(f"{p['directory']}: {p['name']}")
 # Output:
 # Profile 1: Work
 # Profile 5: Personal
@@ -1782,9 +1782,9 @@ If auto-detection does not work, specify paths manually:
 
 ```python
 browser = Browser(
-    executable_path='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-    user_data_dir='~/Library/Application Support/Google/Chrome',
-    profile_directory='Default',
+executable_path='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+user_data_dir='~/Library/Application Support/Google/Chrome',
+profile_directory='Default',
 )
 ```
 
@@ -1814,26 +1814,26 @@ from browser_use import Agent, Browser, ChatBrowserUse
 
 # Simple: Use Browser-Use cloud browser service
 browser = Browser(
-    use_cloud=True,  # Automatically provisions a cloud browser
+use_cloud=True,  # Automatically provisions a cloud browser
 )
 
 # Advanced: Configure cloud browser parameters
 # Using this settings can bypass any captcha protection on any website
 browser = Browser(
-    cloud_profile_id='your-profile-id',  # Optional: specific browser profile
-    cloud_proxy_country_code='us',  # Optional: proxy location (us, uk, fr, it, jp, au, de, fi, ca, in)
-    cloud_timeout=30,  # Optional: session timeout in minutes (MAX free: 15min, paid: 240min)
+cloud_profile_id='your-profile-id',  # Optional: specific browser profile
+cloud_proxy_country_code='us',  # Optional: proxy location (us, uk, fr, it, jp, au, de, fi, ca, in)
+cloud_timeout=30,  # Optional: session timeout in minutes (MAX free: 15min, paid: 240min)
 )
 
 # Or use a CDP URL from any cloud browser provider
 browser = Browser(
-    cdp_url="http://remote-server:9222"  # Get a CDP URL from any provider
+cdp_url="http://remote-server:9222"  # Get a CDP URL from any provider
 )
 
 agent = Agent(
-    task="Your task here",
-    llm=ChatBrowserUse(),
-    browser=browser,
+task="Your task here",
+llm=ChatBrowserUse(),
+browser=browser,
 )
 ```
 
@@ -1866,20 +1866,20 @@ from browser_use import Agent, Browser, ChatBrowserUse
 from browser_use.browser import ProxySettings
 
 browser = Browser(
-    headless=False,
-    proxy=ProxySettings(
-        server="http://proxy-server:8080",
-        username="proxy-user",
-        password="proxy-pass"
-    ),
-    cdp_url="http://remote-server:9222"
+headless=False,
+proxy=ProxySettings(
+    server="http://proxy-server:8080",
+    username="proxy-user",
+    password="proxy-pass"
+),
+cdp_url="http://remote-server:9222"
 )
 
 
 agent = Agent(
-    task="Your task here",
-    llm=ChatBrowserUse(),
-    browser=browser,
+task="Your task here",
+llm=ChatBrowserUse(),
+browser=browser,
 )
 ```
 
@@ -2052,7 +2052,7 @@ from browser_use import Browser
 
 profiles = Browser.list_chrome_profiles()
 for p in profiles:
-    print(f"{p['directory']}: {p['name']}")
+print(f"{p['directory']}: {p['name']}")
 # Output:
 # Profile 1: Work
 # Profile 5: Personal
@@ -2063,9 +2063,9 @@ for p in profiles:
 **Example return value:**
 ```python
 [
-    {'directory': 'Default', 'name': 'Person 1'},
-    {'directory': 'Profile 1', 'name': 'Work'},
-    {'directory': 'Profile 5', 'name': 'Personal'}
+{'directory': 'Default', 'name': 'Person 1'},
+{'directory': 'Profile 1', 'name': 'Work'},
+{'directory': 'Profile 5', 'name': 'Personal'}
 ]
 ```
 
@@ -2085,13 +2085,13 @@ tools = Tools()
 
 @tools.action('Ask human for help with a question')
 async def ask_human(question: str, browser_session: BrowserSession) -> ActionResult:
-    answer = input(f'{question} > ')
-    return ActionResult(extracted_content=f'The human responded with: {answer}')
+answer = input(f'{question} > ')
+return ActionResult(extracted_content=f'The human responded with: {answer}')
 
 agent = Agent(
-    task='Ask human for help',
-    llm=llm,
-    tools=tools,
+task='Ask human for help',
+llm=llm,
+tools=tools,
 )
 ```
 
@@ -2174,8 +2174,8 @@ tools = Tools()
 
 @tools.action(description='Ask human for help with a question')
 async def ask_human(question: str) -> ActionResult:
-    answer = input(f'{question} > ')
-    return ActionResult(extracted_content=f'The human responded with: {answer}')
+answer = input(f'{question} > ')
+return ActionResult(extracted_content=f'The human responded with: {answer}')
 ```
 
 ```python
@@ -2215,19 +2215,19 @@ tools = Tools()
 
 @tools.action(description='Click the submit button using CSS selector')
 async def click_submit_button(browser_session: BrowserSession):
-    # Get the current page
-    page = await browser_session.must_get_current_page()
+# Get the current page
+page = await browser_session.must_get_current_page()
 
-    # Get element(s) by CSS selector
-    elements = await page.get_elements_by_css_selector('button[type="submit"]')
+# Get element(s) by CSS selector
+elements = await page.get_elements_by_css_selector('button[type="submit"]')
 
-    if not elements:
-        return ActionResult(extracted_content='No submit button found')
+if not elements:
+    return ActionResult(extracted_content='No submit button found')
 
-    # Click the first matching element
-    await elements[0].click()
+# Click the first matching element
+await elements[0].click()
 
-    return ActionResult(extracted_content='Submit button clicked!')
+return ActionResult(extracted_content='Submit button clicked!')
 ```
 
 
@@ -2250,14 +2250,14 @@ You can use Pydantic for the tool parameters:
 from pydantic import BaseModel
 
 class Cars(BaseModel):
-    name: str = Field(description='The name of the car, e.g. "Toyota Camry"')
-    price: int = Field(description='The price of the car as int in USD, e.g. 25000')
+name: str = Field(description='The name of the car, e.g. "Toyota Camry"')
+price: int = Field(description='The price of the car as int in USD, e.g. 25000')
 
 @tools.action(description='Save cars to file')
 def save_cars(cars: list[Cars]) -> str:
-    with open('cars.json', 'w') as f:
-        json.dump(cars, f)
-    return f'Saved {len(cars)} cars to file'
+with open('cars.json', 'w') as f:
+    json.dump(cars, f)
+return f'Saved {len(cars)} cars to file'
 
 task = "find cars and save them to file"
 ```
@@ -2267,12 +2267,12 @@ Limit tools to specific domains:
 
 ```python
 @tools.action(
-    description='Fill out banking forms',
-    allowed_domains=['https://mybank.com']
+description='Fill out banking forms',
+allowed_domains=['https://mybank.com']
 )
 def fill_bank_form(account_number: str) -> str:
-    # Only works on mybank.com
-    return f'Filled form for account {account_number}'
+# Only works on mybank.com
+return f'Filled form for account {account_number}'
 ```
 
 ## Advanced Example
@@ -2293,8 +2293,8 @@ from browser_use import Tools, ActionResult, Browser
 
 @tools.action('My action')
 def my_action(browser: Browser) -> ActionResult:  # WRONG!
-    # This will NOT receive the browser session
-    pass
+# This will NOT receive the browser session
+pass
 ```
 
 ### ✅ Correct: Using `browser_session: BrowserSession`
@@ -2304,9 +2304,9 @@ from browser_use import Tools, ActionResult, BrowserSession
 
 @tools.action('My action')
 async def my_action(browser_session: BrowserSession) -> ActionResult:  # CORRECT!
-    page = await browser_session.must_get_current_page()
-    # Now you have access to the browser
-    return ActionResult(extracted_content='Done')
+page = await browser_session.must_get_current_page()
+# Now you have access to the browser
+return ActionResult(extracted_content='Done')
 ```
 
 ### Key Points
@@ -2341,18 +2341,18 @@ Tools return results using `ActionResult` or simple strings.
 ```python
 @tools.action('My tool')
 def my_tool() -> str:
-    return "Task completed successfully"
+return "Task completed successfully"
 
 @tools.action('Advanced tool')
 def advanced_tool() -> ActionResult:
-    return ActionResult(
-        extracted_content="Main result",
-        long_term_memory="Remember this info",
-        error="Something went wrong",
-        is_done=True,
-        success=True,
-        attachments=["file.pdf"],
-    )
+return ActionResult(
+    extracted_content="Main result",
+    long_term_memory="Remember this info",
+    error="Something went wrong",
+    is_done=True,
+    success=True,
+    attachments=["file.pdf"],
+)
 ```
 
 ## ActionResult Properties
@@ -2372,15 +2372,15 @@ With this you control the context for the LLM.
 ### 1. Include short content always in context
 ```python
 def simple_tool() -> str:
-    return "Hello, world!"  # Keep in context for all future steps 
+return "Hello, world!"  # Keep in context for all future steps 
 ```
 
 ### 2. Show long content once, remember subset in context
 ```python
 return ActionResult(
-    extracted_content="[500 lines of product data...]",     # Shows to LLM once
-    include_extracted_content_only_once=True,               # Never show full output again
-    long_term_memory="Found 50 products"        # Only this in future steps
+extracted_content="[500 lines of product data...]",     # Shows to LLM once
+include_extracted_content_only_once=True,               # Never show full output again
+long_term_memory="Found 50 products"        # Only this in future steps
 )
 ```
 We save the full `extracted_content` to files which the LLM can read in future steps.
@@ -2388,8 +2388,8 @@ We save the full `extracted_content` to files which the LLM can read in future s
 ### 3. Don't show long content, remember subset in context
 ```python
 return ActionResult(
-    extracted_content="[500 lines of product data...]",      # The LLM never sees this because `long_term_memory` overrides it and `include_extracted_content_only_once` is not used
-    long_term_memory="Saved user's favorite products",      # This is shown to the LLM in future steps
+extracted_content="[500 lines of product data...]",      # The LLM never sees this because `long_term_memory` overrides it and `include_extracted_content_only_once` is not used
+long_term_memory="Saved user's favorite products",      # This is shown to the LLM in future steps
 )
 ```
 
@@ -2400,11 +2400,11 @@ Set `is_done=True` to stop the agent completely. Use when your tool finishes the
 ```python
 @tools.action(description='Complete the task')
 def finish_task() -> ActionResult:
-    return ActionResult(
-        extracted_content="Task completed!",
-        is_done=True,        # Stops the agent
-        success=True         # Task succeeded 
-    )
+return ActionResult(
+    extracted_content="Task completed!",
+    is_done=True,        # Stops the agent
+    success=True         # Task succeeded 
+)
 ```
 
 
@@ -2436,13 +2436,13 @@ Add to your Claude Desktop config file:
 ```json
 {
   "mcpServers": {
-    "browser-use": {
-      "command": "/Users/your-username/.local/bin/uvx",
-      "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
-      "env": {
-        "OPENAI_API_KEY": "your-openai-api-key-here"
-      }
-    }
+"browser-use": {
+  "command": "/Users/your-username/.local/bin/uvx",
+  "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
+  "env": {
+    "OPENAI_API_KEY": "your-openai-api-key-here"
+  }
+}
   }
 }
 ```
@@ -2452,13 +2452,13 @@ Add to your Claude Desktop config file:
 ```json
 {
   "mcpServers": {
-    "browser-use": {
-      "command": "uvx",
-      "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
-      "env": {
-        "OPENAI_API_KEY": "your-openai-api-key-here"
-      }
-    }
+"browser-use": {
+  "command": "uvx",
+  "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
+  "env": {
+    "OPENAI_API_KEY": "your-openai-api-key-here"
+  }
+}
   }
 }
 ```
@@ -2476,13 +2476,13 @@ Add to `~/.cursor/mcp.json`:
 ```json
 {
   "mcpServers": {
-    "browser-use": {
-      "command": "uvx",
-      "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
-      "env": {
-        "OPENAI_API_KEY": "your-openai-api-key-here"
-      }
-    }
+"browser-use": {
+  "command": "uvx",
+  "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
+  "env": {
+    "OPENAI_API_KEY": "your-openai-api-key-here"
+  }
+}
   }
 }
 ```
@@ -2491,13 +2491,13 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 ```json
 {
   "mcpServers": {
-    "browser-use": {
-      "command": "uvx",
-      "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
-      "env": {
-        "OPENAI_API_KEY": "your-openai-api-key-here"
-      }
-    }
+"browser-use": {
+  "command": "uvx",
+  "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
+  "env": {
+    "OPENAI_API_KEY": "your-openai-api-key-here"
+  }
+}
   }
 }
 ```
@@ -2559,29 +2559,29 @@ from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
 async def use_browser_mcp():
-    # Connect to browser-use MCP server
-    server_params = StdioServerParameters(
-        command="uvx",
-        args=["--from", "browser-use[cli]", "browser-use", "--mcp"]
-    )
+# Connect to browser-use MCP server
+server_params = StdioServerParameters(
+    command="uvx",
+    args=["--from", "browser-use[cli]", "browser-use", "--mcp"]
+)
 
-    async with stdio_client(server_params) as (read, write):
-        async with ClientSession(read, write) as session:
-            await session.initialize()
+async with stdio_client(server_params) as (read, write):
+    async with ClientSession(read, write) as session:
+        await session.initialize()
 
-            # Navigate to a website
-            result = await session.call_tool(
-                "browser_navigate",
-                arguments={"url": "https://example.com"}
-            )
-            print(result.content[0].text)
+        # Navigate to a website
+        result = await session.call_tool(
+            "browser_navigate",
+            arguments={"url": "https://example.com"}
+        )
+        print(result.content[0].text)
 
-            # Get page state
-            result = await session.call_tool(
-                "browser_get_state",
-                arguments={"include_screenshot": True}
-            )
-            print("Page state retrieved!")
+        # Get page state
+        result = await session.call_tool(
+            "browser_get_state",
+            arguments={"include_screenshot": True}
+        )
+        print("Page state retrieved!")
 
 asyncio.run(use_browser_mcp())
 ```
@@ -2645,13 +2645,13 @@ Source: https://docs.browser-use.com/open-source/legacy/actor/basics
 
 ```mermaid
 graph TD
-    A[Browser] --> B[Page]
-    B --> C[Element]
-    B --> D[Mouse]
-    B --> E[AI Features]
-    C --> F[DOM Interactions]
-    D --> G[Coordinate Operations]
-    E --> H[LLM Integration]
+A[Browser] --> B[Page]
+B --> C[Element]
+B --> D[Mouse]
+B --> E[AI Features]
+C --> F[DOM Interactions]
+D --> G[Coordinate Operations]
+E --> H[LLM Integration]
 ```
 
 ### Core Classes
@@ -2668,20 +2668,20 @@ from browser_use import Browser, Agent
 from browser_use.llm.openai.chat import ChatOpenAI
 
 async def main():
-    llm = ChatOpenAI(api_key="your-api-key")
-    browser = Browser()
-    await browser.start()
+llm = ChatOpenAI(api_key="your-api-key")
+browser = Browser()
+await browser.start()
 
-    # 1. Actor: Precise navigation and element interactions
-    page = await browser.new_page("https://github.com/login")
-    email_input = await page.must_get_element_by_prompt("username field", llm=llm)
-    await email_input.fill("your-username")
+# 1. Actor: Precise navigation and element interactions
+page = await browser.new_page("https://github.com/login")
+email_input = await page.must_get_element_by_prompt("username field", llm=llm)
+await email_input.fill("your-username")
 
-    # 2. Agent: AI-driven complex tasks
-    agent = Agent(browser=browser, llm=llm)
-    await agent.run("Complete login and navigate to my repositories")
+# 2. Agent: AI-driven complex tasks
+agent = Agent(browser=browser, llm=llm)
+await agent.run("Complete login and navigate to my repositories")
 
-    await browser.stop()
+await browser.stop()
 ```
 
 ## Important Notes
@@ -2750,13 +2750,13 @@ await button.click()
 
 # Extract structured data
 class ProductInfo(BaseModel):
-    name: str
-    price: float
+name: str
+price: float
 
 product = await page.extract_content(
-    "Extract product name and price",
-    ProductInfo,
-    llm=llm
+"Extract product name and price",
+ProductInfo,
+llm=llm
 )
 ```
 
@@ -2771,8 +2771,8 @@ result = await page.evaluate('(x, y) => x + y', 10, 20)
 
 # Complex operations
 stats = await page.evaluate('''() => ({
-    url: location.href,
-    links: document.querySelectorAll('a').length
+url: location.href,
+links: document.querySelectorAll('a').length
 })''')
 ```
 
@@ -2906,8 +2906,8 @@ from browser_use.agent.service import Agent
 
 @sandbox()
 async def my_task(browser: Browser):
-    agent = Agent(task="Find the top HN post", browser=browser, llm=ChatBrowserUse())
-    await agent.run()
+agent = Agent(task="Find the top HN post", browser=browser, llm=ChatBrowserUse())
+await agent.run()
 
 await my_task()
 ```
@@ -2916,13 +2916,13 @@ await my_task()
 
 ```python
 @sandbox(
-    cloud_profile_id='your-profile-id',      # Use saved cookies/auth
-    cloud_proxy_country_code='us',           # Bypass captchas, cloudflare, geo-restrictions
-    cloud_timeout=60,                        # Max session time (minutes)
+cloud_profile_id='your-profile-id',      # Use saved cookies/auth
+cloud_proxy_country_code='us',           # Bypass captchas, cloudflare, geo-restrictions
+cloud_timeout=60,                        # Max session time (minutes)
 )
 async def task(browser: Browser, url: str):
-    agent = Agent(task=f"Visit {url}", browser=browser, llm=ChatBrowserUse())
-    await agent.run()
+agent = Agent(task=f"Visit {url}", browser=browser, llm=ChatBrowserUse())
+await agent.run()
 
 await task(url="https://example.com")
 ```
@@ -2946,8 +2946,8 @@ Source: https://docs.browser-use.com/open-source/legacy/sandbox/events
 ```python
 @sandbox(on_browser_created=lambda data: print(f'👁️  {data.live_url}'))
 async def task(browser: Browser):
-    agent = Agent(task="your task", browser=browser, llm=ChatBrowserUse())
-    await agent.run()
+agent = Agent(task="your task", browser=browser, llm=ChatBrowserUse())
+await agent.run()
 ```
 
 ## All Events
@@ -2956,13 +2956,13 @@ async def task(browser: Browser):
 from browser_use.sandbox import BrowserCreatedData, LogData, ResultData, ErrorData
 
 @sandbox(
-    on_browser_created=lambda data: print(f'Live: {data.live_url}'),
-    on_log=lambda log: print(f'{log.level}: {log.message}'),
-    on_result=lambda result: print('Done!'),
-    on_error=lambda error: print(f'Error: {error.error}'),
+on_browser_created=lambda data: print(f'Live: {data.live_url}'),
+on_log=lambda log: print(f'{log.level}: {log.message}'),
+on_result=lambda result: print('Done!'),
+on_error=lambda error: print(f'Error: {error.error}'),
 )
 async def task(browser: Browser):
-    # Your code
+# Your code
 ```
 
 All callbacks can be sync or async.
@@ -2989,14 +2989,14 @@ Source: https://docs.browser-use.com/open-source/legacy/sandbox/all-parameters
 
 ```python
 @sandbox(
-    cloud_profile_id='550e8400-e29b-41d4-a716-446655440000',
-    cloud_proxy_country_code='us',
-    cloud_timeout=60,
-    on_browser_created=lambda data: print(f'Live: {data.live_url}'),
+cloud_profile_id='550e8400-e29b-41d4-a716-446655440000',
+cloud_proxy_country_code='us',
+cloud_timeout=60,
+on_browser_created=lambda data: print(f'Live: {data.live_url}'),
 )
 async def task(browser: Browser):
-    agent = Agent(task="your task", browser=browser, llm=ChatBrowserUse())
-    await agent.run()
+agent = Agent(task="your task", browser=browser, llm=ChatBrowserUse())
+await agent.run()
 ```
 
 
@@ -3043,7 +3043,7 @@ async def main():
 	task = """
 	1. Go to reddit https://www.reddit.com/search/?q=browser+agent&type=communities 
 	2. Click directly on the first 5 communities to open each in new tabs
-    3. Find out what the latest post is about, and switch directly to the next tab
+3. Find out what the latest post is about, and switch directly to the next tab
 	4. Return the latest post summary for each page
 	"""
 
@@ -3079,19 +3079,19 @@ llm = ChatGoogle(model='gemini-flash-lite-latest')
 ### 2. Browser Optimizations
 ```python
 browser_profile = BrowserProfile(
-    minimum_wait_page_load_time=0.1,    # Reduce wait time
-    wait_between_actions=0.1,           # Faster action execution
-    headless=True,                      # No GUI overhead
+minimum_wait_page_load_time=0.1,    # Reduce wait time
+wait_between_actions=0.1,           # Faster action execution
+headless=True,                      # No GUI overhead
 )
 ```
 
 ### 3. Agent Optimizations
 ```python
 agent = Agent(
-    task=task,
-    llm=llm,
-    flash_mode=True,                    # Skip LLM thinking process
-    extend_system_message=SPEED_PROMPT, # Optimize LLM behavior
+task=task,
+llm=llm,
+flash_mode=True,                    # Skip LLM thinking process
+extend_system_message=SPEED_PROMPT, # Optimize LLM behavior
 )
 ```
 
@@ -3279,15 +3279,15 @@ async def start_chrome_with_debug_port(port: int = 9222):
 	for path in chrome_paths:
 		if os.path.exists(path) or path in ['chrome', 'chromium']:
 			try:
-				# Test if executable works
-				test_proc = await asyncio.create_subprocess_exec(
-					path, '--version', stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
-				)
-				await test_proc.wait()
-				chrome_exe = path
-				break
+# Test if executable works
+test_proc = await asyncio.create_subprocess_exec(
+	path, '--version', stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+)
+await test_proc.wait()
+chrome_exe = path
+break
 			except Exception:
-				continue
+continue
 
 	if not chrome_exe:
 		raise RuntimeError('❌ Chrome not found. Please install Chrome or Chromium.')
@@ -3311,12 +3311,12 @@ async def start_chrome_with_debug_port(port: int = 9222):
 	for _ in range(20):  # 20 second timeout
 		try:
 			async with aiohttp.ClientSession() as session:
-				async with session.get(
-					f'http://localhost:{port}/json/version', timeout=aiohttp.ClientTimeout(total=1)
-				) as response:
-					if response.status == 200:
-						cdp_ready = True
-						break
+async with session.get(
+	f'http://localhost:{port}/json/version', timeout=aiohttp.ClientTimeout(total=1)
+) as response:
+	if response.status == 200:
+		cdp_ready = True
+		break
 		except Exception:
 			pass
 		await asyncio.sleep(1)
@@ -3399,9 +3399,9 @@ async def playwright_fill_form(params: PlaywrightFillFormAction, browser_session
 			# For radio buttons, find the checked one
 			checked_radio = playwright_page.locator('input[name="size"]:checked')
 			if await checked_radio.count() > 0:
-				form_data['size'] = await checked_radio.get_attribute('value')
+form_data['size'] = await checked_radio.get_attribute('value')
 			else:
-				form_data['size'] = 'none selected'
+form_data['size'] = 'none selected'
 
 		success_msg = f'✅ Form filled successfully with Playwright: {form_data}'
 
@@ -3466,19 +3466,19 @@ async def playwright_get_text(params: PlaywrightGetTextAction, browser_session: 
 			# Use page.title() for title element
 			text_content = await playwright_page.title()
 			result_data = {
-				'selector': 'title',
-				'text_content': text_content,
-				'inner_text': text_content,
-				'tag_name': 'TITLE',
-				'is_visible': True,
+'selector': 'title',
+'text_content': text_content,
+'inner_text': text_content,
+'tag_name': 'TITLE',
+'is_visible': True,
 			}
 		else:
 			# Use Playwright's robust element selection and text extraction
 			element = playwright_page.locator(params.selector).first
 
 			if await element.count() == 0:
-				error_msg = f'❌ No element found with selector: {params.selector}'
-				return ActionResult(error=error_msg)
+error_msg = f'❌ No element found with selector: {params.selector}'
+return ActionResult(error=error_msg)
 
 			text_content = await element.text_content()
 			inner_text = await element.inner_text()
@@ -3488,11 +3488,11 @@ async def playwright_get_text(params: PlaywrightGetTextAction, browser_session: 
 			is_visible = await element.is_visible()
 
 			result_data = {
-				'selector': params.selector,
-				'text_content': text_content,
-				'inner_text': inner_text,
-				'tag_name': tag_name,
-				'is_visible': is_visible,
+'selector': params.selector,
+'text_content': text_content,
+'inner_text': inner_text,
+'tag_name': tag_name,
+'is_visible': is_visible,
 			}
 
 		success_msg = f'✅ Extracted text using Playwright: {result_data}'
@@ -3533,10 +3533,10 @@ async def main():
 			
 			1. First, navigate to https://httpbin.org/forms/post
 			2. Use the 'playwright_fill_form' action to fill the form with these details:
-			   - Customer name: "Alice Johnson"
-			   - Phone: "555-9876"
-			   - Email: "alice@demo.com"
-			   - Size: "large"
+  - Customer name: "Alice Johnson"
+  - Phone: "555-9876"
+  - Email: "alice@demo.com"
+  - Size: "large"
 			3. Take a screenshot using the 'playwright_screenshot' action and save it as "form_demo.png"
 			4. Extract the title of the page using 'playwright_get_text' action with selector "title"
 			5. Finally, submit the form and tell me what happened
@@ -3572,9 +3572,9 @@ async def main():
 		if chrome_process:
 			chrome_process.terminate()
 			try:
-				await asyncio.wait_for(chrome_process.wait(), 5)
+await asyncio.wait_for(chrome_process.wait(), 5)
 			except TimeoutError:
-				chrome_process.kill()
+chrome_process.kill()
 
 		print('✅ Cleanup complete')
 
@@ -3612,13 +3612,13 @@ sensitive_data = company_credentials
 
 
 agent = Agent(
-    task='Log into example.com with username x_user and password x_pass',
-    sensitive_data=sensitive_data,
-    use_vision=False,  #  Disable vision to prevent LLM seeing sensitive data in screenshots
-    llm=ChatOpenAI(model='gpt-4.1-mini'),
+task='Log into example.com with username x_user and password x_pass',
+sensitive_data=sensitive_data,
+use_vision=False,  #  Disable vision to prevent LLM seeing sensitive data in screenshots
+llm=ChatOpenAI(model='gpt-4.1-mini'),
 )
 async def main():
-    await agent.run()
+await agent.run()
 ```
 
 ## How it Works
@@ -3654,8 +3654,8 @@ llm = ChatAzureOpenAI(model='gpt-4.1-mini', api_key=api_key, azure_endpoint=azur
 
 # Secure browser configuration
 browser_profile = BrowserProfile(
-    allowed_domains=['*google.com', 'browser-use.com'], 
-    enable_default_extensions=False
+allowed_domains=['*google.com', 'browser-use.com'], 
+enable_default_extensions=False
 )
 
 # Sensitive data filtering
@@ -3663,14 +3663,14 @@ sensitive_data = {'company_name': 'browser-use'}
 
 # Create secure agent
 agent = Agent(
-    task='Find the founders of the sensitive company_name',
-    llm=llm,
-    browser_profile=browser_profile,
-    sensitive_data=sensitive_data
+task='Find the founders of the sensitive company_name',
+llm=llm,
+browser_profile=browser_profile,
+sensitive_data=sensitive_data
 )
 
 async def main():
-    await agent.run(max_steps=10)
+await agent.run(max_steps=10)
 
 asyncio.run(main())
 ```
@@ -3776,11 +3776,11 @@ import asyncio
 from ad_generator import create_ad_from_landing_page
 
 async def main():
-    results = await create_ad_from_landing_page(
-        url="https://your-landing-page.com",
-        debug=False
-    )
-    print(f"Generated ads: {results}")
+results = await create_ad_from_landing_page(
+    url="https://your-landing-page.com",
+    debug=False
+)
+print(f"Generated ads: {results}")
 
 asyncio.run(main())
 ```
@@ -3857,12 +3857,12 @@ claude mcp add vibetest /full/path/to/vibetest-use/.venv/bin/vibetest-mcp \
 ```json
 {
   "mcpServers": {
-    "vibetest": {
-      "command": "/full/path/to/vibetest-use/.venv/bin/vibetest-mcp",
-      "env": {
-        "GOOGLE_API_KEY": "your_api_key"
-      }
-    }
+"vibetest": {
+  "command": "/full/path/to/vibetest-use/.venv/bin/vibetest-mcp",
+  "env": {
+    "GOOGLE_API_KEY": "your_api_key"
+  }
+}
   }
 }
 ```
@@ -3968,12 +3968,12 @@ All extracted articles are saved to `news_data.json` with complete metadata:
   "hash": "a1b2c3d4...",
   "pulled_at": "2025-09-11T02:49:21Z",
   "data": {
-    "title": "Klarna's IPO pops, raising $1.4B",
-    "url": "https://techcrunch.com/2025/09/11/klarna-ipo/",
-    "posting_time": "12:11 PM PDT · September 10, 2025",
-    "short_summary": "Klarna's IPO raises $1.4B, benefiting existing investors like Sequoia.",
-    "long_summary": "Fintech Klarna successfully IPO'd on the NYSE...",
-    "sentiment": "positive"
+"title": "Klarna's IPO pops, raising $1.4B",
+"url": "https://techcrunch.com/2025/09/11/klarna-ipo/",
+"posting_time": "12:11 PM PDT · September 10, 2025",
+"short_summary": "Klarna's IPO raises $1.4B, benefiting existing investors like Sequoia.",
+"long_summary": "Fintech Klarna successfully IPO'd on the NYSE...",
+"sentiment": "positive"
   }
 }
 ```
@@ -3985,17 +3985,17 @@ import asyncio
 from news_monitor import extract_latest_article
 
 async def main():
-    # Extract latest article from any news site
-    result = await extract_latest_article(
-        site_url="https://techcrunch.com",
-        debug=False
-    )
-    
-    if result["status"] == "success":
-        article = result["data"]
-        print(f"📰 {article['title']}")
-        print(f"😊 Sentiment: {article['sentiment']}")
-        print(f"📝 Summary: {article['short_summary']}")
+# Extract latest article from any news site
+result = await extract_latest_article(
+    site_url="https://techcrunch.com",
+    debug=False
+)
+
+if result["status"] == "success":
+    article = result["data"]
+    print(f"📰 {article['title']}")
+    print(f"😊 Sentiment: {article['sentiment']}")
+    print(f"📝 Summary: {article['short_summary']}")
 
 asyncio.run(main())
 ```
@@ -4005,14 +4005,14 @@ asyncio.run(main())
 ```python
 # Custom monitoring with filters
 async def monitor_with_filters():
-    while True:
-        result = await extract_latest_article("https://bloomberg.com")
-        if result["status"] == "success":
-            article = result["data"]
-            # Only alert on negative market news
-            if article["sentiment"] == "negative" and "market" in article["title"].lower():
-                send_alert(article)
-        await asyncio.sleep(300)  # Check every 5 minutes
+while True:
+    result = await extract_latest_article("https://bloomberg.com")
+    if result["status"] == "success":
+        article = result["data"]
+        # Only alert on negative market news
+        if article["sentiment"] == "negative" and "market" in article["title"].lower():
+            send_alert(article)
+    await asyncio.sleep(300)  # Check every 5 minutes
 ```
 
 ## Source Code
@@ -4100,11 +4100,11 @@ import asyncio
 from scheduler import schedule_messages
 
 async def main():
-    messages = [
-        "Send hello to John at 15:30",
-        "Remind Sarah about meeting tomorrow at 9am"
-    ]
-    await schedule_messages(messages, debug=False)
+messages = [
+    "Send hello to John at 15:30",
+    "Remind Sarah about meeting tomorrow at 9am"
+]
+await schedule_messages(messages, debug=False)
 
 asyncio.run(main())
 ```
@@ -4116,22 +4116,22 @@ The scheduler processes natural language and outputs structured results:
 ```json
 [
   {
-    "contact": "Magnus",
-    "original_message": "Hi",
-    "composed_message": "Hi",
-    "scheduled_time": "2025-06-13 18:15"
+"contact": "Magnus",
+"original_message": "Hi",
+"composed_message": "Hi",
+"scheduled_time": "2025-06-13 18:15"
   },
   {
-    "contact": "Camila", 
-    "original_message": "I miss her",
-    "composed_message": "I miss you ❤️",
-    "scheduled_time": "2025-06-14 20:00"
+"contact": "Camila", 
+"original_message": "I miss her",
+"composed_message": "I miss you ❤️",
+"scheduled_time": "2025-06-14 20:00"
   },
   {
-    "contact": "sister",
-    "original_message": "happy birthday message", 
-    "composed_message": "Happy birthday! 🎉 Wishing you an amazing day, sis! Hope you have the best birthday ever! ❤️🎂🎈",
-    "scheduled_time": "2025-06-15 09:00"
+"contact": "sister",
+"original_message": "happy birthday message", 
+"composed_message": "Happy birthday! 🎉 Wishing you an amazing day, sis! Hope you have the best birthday ever! ❤️🎂🎈",
+"scheduled_time": "2025-06-15 09:00"
   }
 ]
 ```
@@ -4380,11 +4380,11 @@ import os
 Laminar.initialize(project_api_key=os.getenv('LMNR_PROJECT_API_KEY'))
 
 async def main():
-    agent = Agent(
-        task="go to ycombinator.com, summarize 3 startups from the latest batch",
-        llm=ChatGoogle(model="gemini-2.5-flash"),
-    )
-    await agent.run()
+agent = Agent(
+    task="go to ycombinator.com, summarize 3 startups from the latest batch",
+    llm=ChatGoogle(model="gemini-2.5-flash"),
+)
+await agent.run()
 
 asyncio.run(main())
 ```
@@ -4616,9 +4616,9 @@ To track token usage and costs, enable cost calculation:
 from browser_use import Agent, ChatBrowserUse
 
 agent = Agent(
-    task="Search for latest news about AI",
-    llm=ChatBrowserUse(),
-    calculate_cost=True  # Enable cost tracking
+task="Search for latest news about AI",
+llm=ChatBrowserUse(),
+calculate_cost=True  # Enable cost tracking
 )
 
 history = await agent.run()


### PR DESCRIPTION
## Summary

Merges docs audit R2 fixes with new fixes from comprehensive 12-agent docs review.

### New fixes (this branch)
- **Python SDK**: Use `_UNSET` sentinel for `proxy_country_code` so `None` sends JSON `null` (disabling proxies) instead of omitting the field
- **TS SDK**: Change `Browsers.create()` param to `Partial<CreateBrowserSessionRequest>` — 5 doc snippets now type-check
- **Docs**: Fix cURL auth header from `Authorization: Bearer` to `X-Browser-Use-API-Key` in agent/quickstart.mdx. Regenerated all llms-full.txt files
- **OpenAPI**: Add `hidden` boolean field to `MessageResponse` schema. Regenerated TS + Python types. Fixes chat-ui-example build error
- Includes comprehensive docs audit report (12 agents, 5 personas)

### Merged from R2 fixes
- Fix dead browser-use-cli repo link
- Fix legacy docs auth header + property names
- Fix Python legacy snippets (presigned_url → url/download_url)
- Fix legacy docs upload method description (PUT → POST)
- SDK version bump

## Test plan
- [ ] Verify `proxy_country_code=None` sends `{"proxyCountryCode": null}` in request body
- [ ] Verify TS `client.browsers.create({ proxyCountryCode: "de" })` compiles
- [ ] Verify curl example uses `X-Browser-Use-API-Key` header
- [ ] Verify chat-ui-example builds with updated SDK types (`hidden` field)
- [ ] Run `task check` for both SDKs

🤖 Generated with [Claude Code](https://claude.com/claude-code)