### PR TITLE
Fix broken Selenium example and wrong cdp_url comments in CDP docs

### DIFF
--- a/docs/cloud/browser/playwright-puppeteer-selenium.mdx
+++ b/docs/cloud/browser/playwright-puppeteer-selenium.mdx
@@ -90,13 +90,15 @@ with sync_playwright() as p:
 
 Create a browser via the SDK, get a `cdp_url`, and connect with Playwright or Puppeteer.
 
+### Playwright
+
 <CodeGroup>
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
 from playwright.async_api import async_playwright
 
 client = AsyncBrowserUse()
-browser = await client.browsers.create(proxy_country_code="us")
+browser = await client.browsers.create()
 print(browser.cdp_url)   # https://uuid.cdpN.browser-use.com
 print(browser.live_url)  # https://live.browser-use.com?wss=...
 
@@ -114,7 +116,7 @@ import { BrowserUse } from "browser-use-sdk/v3";
 import { chromium } from "playwright";
 
 const client = new BrowserUse();
-const browser = await client.browsers.create({ proxyCountryCode: "us" });
+const browser = await client.browsers.create();
 console.log(browser.cdpUrl);  // https://uuid.cdpN.browser-use.com
 console.log(browser.liveUrl); // https://live.browser-use.com?wss=...
 
@@ -127,6 +129,28 @@ await pwBrowser.close();
 await client.browsers.stop(browser.id);
 ```
 </CodeGroup>
+
+### Puppeteer
+
+```typescript
+import { BrowserUse } from "browser-use-sdk/v3";
+import puppeteer from "puppeteer-core";
+
+const client = new BrowserUse();
+const browser = await client.browsers.create();
+
+// Puppeteer needs the WebSocket URL from /json/version
+const resp = await fetch(`${browser.cdpUrl}/json/version`);
+const { webSocketDebuggerUrl } = await resp.json();
+
+const pwBrowser = await puppeteer.connect({ browserWSEndpoint: webSocketDebuggerUrl });
+const [page] = await pwBrowser.pages();
+await page.goto("https://example.com");
+console.log(await page.title());
+await pwBrowser.close();
+
+await client.browsers.stop(browser.id);
+```
 
 <Warning>
   Always stop browser sessions when done. Sessions left running will continue to incur charges until the timeout expires.

--- a/docs/cloud/browser/playwright-puppeteer-selenium.mdx
+++ b/docs/cloud/browser/playwright-puppeteer-selenium.mdx
@@ -56,23 +56,24 @@ await browser.close();
 
 ### Selenium
 
+Selenium requires a local WebSocket proxy to connect to Browser Use's remote CDP endpoint. Use [selenium-wire](https://github.com/wkeeling/selenium-wire) or connect through Playwright's CDP bridge instead:
+
 ```python
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-from browser_use_sdk.v3 import AsyncBrowserUse
+from playwright.sync_api import sync_playwright
 
-client = AsyncBrowserUse()
-browser = await client.browsers.create()
+WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us"
 
-options = Options()
-options.debugger_address = browser.cdp_url.replace("ws://", "").replace("/devtools/browser/", "")
-driver = webdriver.Chrome(options=options)
-driver.get("https://example.com")
-print(driver.title)
-driver.quit()
-
-await client.browsers.stop(browser.id)
+with sync_playwright() as p:
+    browser = p.chromium.connect_over_cdp(WSS_URL)
+    page = browser.contexts[0].pages[0]
+    page.goto("https://example.com")
+    print(page.title())
+    browser.close()
 ```
+
+<Note>
+  Selenium's `debugger_address` only supports local `host:port` connections. For remote CDP over WebSocket, use Playwright or Puppeteer instead.
+</Note>
 
 ## Query parameters
 
@@ -87,24 +88,43 @@ await client.browsers.stop(browser.id)
 
 ## Option 2: SDK
 
-Create a browser via the SDK, get a `cdp_url`, connect with your framework.
+Create a browser via the SDK, get a `cdp_url`, and connect with Playwright or Puppeteer.
 
 <CodeGroup>
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
+from playwright.async_api import async_playwright
 
 client = AsyncBrowserUse()
 browser = await client.browsers.create(proxy_country_code="us")
-print(browser.cdp_url)   # ws://...
-print(browser.live_url)  # debug view
+print(browser.cdp_url)   # https://uuid.cdpN.browser-use.com
+print(browser.live_url)  # https://live.browser-use.com?wss=...
+
+async with async_playwright() as p:
+    pw_browser = await p.chromium.connect_over_cdp(browser.cdp_url)
+    page = pw_browser.contexts[0].pages[0]
+    await page.goto("https://example.com")
+    print(await page.title())
+    await pw_browser.close()
+
+await client.browsers.stop(browser.id)
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
+import { chromium } from "playwright";
 
 const client = new BrowserUse();
 const browser = await client.browsers.create({ proxyCountryCode: "us" });
-console.log(browser.cdpUrl);
-console.log(browser.liveUrl);
+console.log(browser.cdpUrl);  // https://uuid.cdpN.browser-use.com
+console.log(browser.liveUrl); // https://live.browser-use.com?wss=...
+
+const pwBrowser = await chromium.connectOverCDP(browser.cdpUrl);
+const page = pwBrowser.contexts()[0].pages()[0];
+await page.goto("https://example.com");
+console.log(await page.title());
+await pwBrowser.close();
+
+await client.browsers.stop(browser.id);
 ```
 </CodeGroup>
 


### PR DESCRIPTION
- Selenium example used `ws://` string replacements that are no-ops since `cdp_url` returns `https://` format. Selenium's `debugger_address` also only supports local `host:port` — it cannot connect to remote CDP endpoints. Replaced with Playwright sync bridge + note explaining the limitation.
- Fixed `cdp_url` comment from `# ws://...` to actual `# https://uuid.cdpN.browser-use.com`
- Added complete Playwright connection examples to Option 2 (SDK) — previously only showed `browsers.create()` without demonstrating how to connect.
- Added `live_url` comment showing actual URL format.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken Selenium example and incorrect `cdp_url`/`live_url` comments in the CDP docs. Replaces the remote Selenium CDP flow with a `playwright` CDP bridge and adds complete `playwright` and `puppeteer` connection examples.

- **Bug Fixes**
  - Replaced Selenium example with `playwright` CDP bridge; note that Selenium `debugger_address` only supports local `host:port`.
  - Corrected comments to show `cdp_url` as `https://uuid.cdpN.browser-use.com` and `live_url` as `https://live.browser-use.com?wss=...`.
  - Added full `playwright` SDK examples (Python `connect_over_cdp`, TypeScript `connectOverCDP`) with cleanup.
  - Added `puppeteer` SDK example using `/json/version` to get `webSocketDebuggerUrl`.

<sup>Written for commit b6f01c74c80026e3d6a508175b9f11cd11da8ed4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

