### PR TITLE
Magnus/fix sdk bugs round2

### DIFF
--- a/browser-use-node/src/core/http.ts
+++ b/browser-use-node/src/core/http.ts
@@ -90,16 +90,20 @@ export class HttpClient {
         } catch {
           /* ignore parse errors */
         }
-        const message =
+        const raw =
           typeof errorBody === "object" && errorBody !== null
-            ? String(
-                "message" in errorBody
-                  ? (errorBody as Record<string, unknown>).message
-                  : "detail" in errorBody
-                    ? (errorBody as Record<string, unknown>).detail
-                    : `HTTP ${response.status}`,
-              )
-            : `HTTP ${response.status}`;
+            ? "message" in errorBody
+              ? (errorBody as Record<string, unknown>).message
+              : "detail" in errorBody
+                ? (errorBody as Record<string, unknown>).detail
+                : undefined
+            : undefined;
+        const message =
+          raw === undefined
+            ? `HTTP ${response.status}`
+            : typeof raw === "string"
+              ? raw
+              : JSON.stringify(raw);
         throw new BrowserUseError(response.status, message, errorBody);
       } catch (error) {
         clearTimeout(timeoutId);

--- a/browser-use-node/src/v3/client.ts
+++ b/browser-use-node/src/v3/client.ts
@@ -79,6 +79,27 @@ export class BrowserUse {
     if (body.sessionId && body.keepAlive === undefined) {
       body.keepAlive = true;
     }
+    // For follow-up runs on an existing session, snapshot the latest message
+    // cursor before creating the new task so the iterator skips old messages.
+    if (body.sessionId) {
+      const sid = body.sessionId;
+      const sessions = this.sessions;
+      let startCursor: string | undefined;
+      const promise = sessions
+        .messages(sid, { limit: 1 })
+        .then((resp) => {
+          const last = resp.messages[resp.messages.length - 1];
+          startCursor = last?.id;
+        })
+        .then(() => sessions.create(body));
+      // startCursor is set before createPromise resolves, so the iterator
+      // (which awaits _ensureSessionId first) will see the correct value.
+      return new SessionRun(promise, this.sessions, schema, {
+        timeout,
+        interval,
+        get _startCursor() { return startCursor; },
+      });
+    }
     const promise = this.sessions.create(body);
     return new SessionRun(promise, this.sessions, schema, { timeout, interval });
   }

--- a/browser-use-node/src/v3/helpers.ts
+++ b/browser-use-node/src/v3/helpers.ts
@@ -12,6 +12,8 @@ export interface RunOptions {
   timeout?: number;
   /** Polling interval in milliseconds. Default: 2_000. */
   interval?: number;
+  /** @internal Starting message cursor for follow-up runs on an existing session. */
+  _startCursor?: string;
 }
 
 /** Session result with typed output. All SessionResponse fields are directly accessible. */
@@ -27,6 +29,7 @@ export class SessionRun<T = string> implements PromiseLike<SessionResult<T>> {
   private readonly _schema?: z.ZodType<T>;
   private readonly _timeout: number;
   private readonly _interval: number;
+  private readonly _options?: RunOptions;
   private _sessionId: string | null = null;
   private _result: SessionResult<T> | null = null;
 
@@ -41,6 +44,7 @@ export class SessionRun<T = string> implements PromiseLike<SessionResult<T>> {
     this._schema = schema;
     this._timeout = options?.timeout ?? 14_400_000;
     this._interval = options?.interval ?? 2_000;
+    this._options = options;
   }
 
   /** The session ID, available after task creation resolves. */
@@ -101,7 +105,7 @@ export class SessionRun<T = string> implements PromiseLike<SessionResult<T>> {
    */
   async *[Symbol.asyncIterator](): AsyncGenerator<MessageResponse> {
     const sessionId = await this._ensureSessionId();
-    let cursor: string | undefined;
+    let cursor: string | undefined = this._options?._startCursor;
     const deadline = Date.now() + this._timeout;
 
     while (Date.now() < deadline) {

--- a/browser-use-node/src/v3/resources/browsers.ts
+++ b/browser-use-node/src/v3/resources/browsers.ts
@@ -16,7 +16,7 @@ export class Browsers {
   constructor(private readonly http: HttpClient) {}
 
   /** Create a standalone browser session. */
-  create(body?: Partial<CreateBrowserSessionRequest>): Promise<BrowserSessionItemView> {
+  create(body: Partial<CreateBrowserSessionRequest> = {}): Promise<BrowserSessionItemView> {
     return this.http.post<BrowserSessionItemView>("/browsers", body);
   }
 

--- a/browser-use-node/src/v3/resources/workspaces.ts
+++ b/browser-use-node/src/v3/resources/workspaces.ts
@@ -126,15 +126,28 @@ export class Workspaces {
    *
    * ```ts
    * await client.workspaces.upload(wsId, "data.csv", "config.json");
+   * await client.workspaces.upload(wsId, "data.csv", { prefix: "uploads/" });
    * ```
    */
-  async upload(workspaceId: string, ...paths: string[]): Promise<string[]> {
+  async upload(workspaceId: string, ...args: (string | { prefix?: string })[]): Promise<string[]> {
+    let prefix: string | undefined;
+    const paths: string[] = [];
+    for (const arg of args) {
+      if (typeof arg === "string") {
+        paths.push(arg);
+      } else if (typeof arg === "object" && arg !== null) {
+        prefix = arg.prefix;
+      }
+    }
+    if (paths.length === 0) {
+      throw new Error("At least one file path is required");
+    }
     const items = paths.map((p) => ({
       name: basename(p),
       contentType: guessContentType(p),
       size: statSync(p).size,
     }));
-    const resp = await this.uploadFiles(workspaceId, { files: items });
+    const resp = await this.uploadFiles(workspaceId, { files: items }, prefix ? { prefix } : undefined);
     for (let i = 0; i < paths.length; i++) {
       const body = readFileSync(paths[i]);
       const res = await fetch(resp.files[i].uploadUrl, {

--- a/browser-use-python/src/browser_use_sdk/_core/http.py
+++ b/browser-use-python/src/browser_use_sdk/_core/http.py
@@ -45,12 +45,18 @@ def _raise_for_status(response: httpx.Response) -> None:
         body = response.json()
     except Exception:
         body = None
-    message = ""
     detail = body
     if isinstance(body, dict):
-        message = body.get("message", body.get("detail", response.reason_phrase or ""))
+        raw = body.get("message", body.get("detail"))
     else:
+        raw = None
+    if raw is None:
         message = response.reason_phrase or str(response.status_code)
+    elif isinstance(raw, str):
+        message = raw
+    else:
+        import json
+        message = json.dumps(raw)
     raise BrowserUseError(response.status_code, message, detail)
 
 

--- a/browser-use-python/src/browser_use_sdk/v3/client.py
+++ b/browser-use-python/src/browser_use_sdk/v3/client.py
@@ -178,6 +178,14 @@ class BrowserUse:
         if session_id is not None and keep_alive is None:
             keep_alive = True
 
+        # For follow-up runs, snapshot the latest message cursor so the
+        # stream skips messages from previous tasks on this session.
+        start_cursor: str | None = None
+        if session_id is not None:
+            resp = self.sessions.messages(session_id, limit=1)
+            if resp.messages:
+                start_cursor = str(resp.messages[-1].id)
+
         data = self.sessions.create(
             task,
             model=model,
@@ -192,7 +200,7 @@ class BrowserUse:
             custom_proxy=custom_proxy,
             **extra,
         )
-        return SessionStream(data, self.sessions, resolved_schema)
+        return SessionStream(data, self.sessions, resolved_schema, _start_cursor=start_cursor)
 
     def close(self) -> None:
         """Close the underlying HTTP client."""
@@ -312,8 +320,17 @@ class AsyncBrowserUse:
         if session_id is not None and keep_alive is None:
             effective_keep_alive = True
 
-        def create_fn() -> Awaitable[SessionResponse]:
-            return self.sessions.create(
+        # For follow-up runs, we need to snapshot the latest message cursor
+        # before creating the task. We wrap create_fn to do this lazily.
+        run_holder: list[AsyncSessionRun[Any]] = []
+
+        async def create_fn() -> SessionResponse:
+            # Snapshot latest message cursor for follow-up runs
+            if session_id is not None and run_holder:
+                resp = await self.sessions.messages(str(session_id), limit=1)
+                if resp.messages:
+                    run_holder[0]._start_cursor = str(resp.messages[-1].id)
+            return await self.sessions.create(
                 task,
                 model=model,
                 session_id=session_id,
@@ -328,7 +345,9 @@ class AsyncBrowserUse:
                 **extra,
             )
 
-        return AsyncSessionRun(create_fn, self.sessions, resolved_schema)
+        run = AsyncSessionRun(create_fn, self.sessions, resolved_schema)
+        run_holder.append(run)
+        return run
 
     async def close(self) -> None:
         """Close the underlying HTTP client."""

--- a/browser-use-python/src/browser_use_sdk/v3/client.py
+++ b/browser-use-python/src/browser_use_sdk/v3/client.py
@@ -320,16 +320,16 @@ class AsyncBrowserUse:
         if session_id is not None and keep_alive is None:
             effective_keep_alive = True
 
-        # For follow-up runs, we need to snapshot the latest message cursor
-        # before creating the task. We wrap create_fn to do this lazily.
-        run_holder: list[AsyncSessionRun[Any]] = []
+        # For follow-up runs, snapshot the latest message cursor so the
+        # iterator skips messages from previous tasks on this session.
+        start_cursor: str | None = None
 
         async def create_fn() -> SessionResponse:
-            # Snapshot latest message cursor for follow-up runs
-            if session_id is not None and run_holder:
+            nonlocal start_cursor
+            if session_id is not None:
                 resp = await self.sessions.messages(str(session_id), limit=1)
                 if resp.messages:
-                    run_holder[0]._start_cursor = str(resp.messages[-1].id)
+                    start_cursor = str(resp.messages[-1].id)
             return await self.sessions.create(
                 task,
                 model=model,
@@ -345,9 +345,7 @@ class AsyncBrowserUse:
                 **extra,
             )
 
-        run = AsyncSessionRun(create_fn, self.sessions, resolved_schema)
-        run_holder.append(run)
-        return run
+        return AsyncSessionRun(create_fn, self.sessions, resolved_schema, _start_cursor_ref=lambda: start_cursor)
 
     async def close(self) -> None:
         """Close the underlying HTTP client."""

--- a/browser-use-python/src/browser_use_sdk/v3/helpers.py
+++ b/browser-use-python/src/browser_use_sdk/v3/helpers.py
@@ -91,6 +91,7 @@ class AsyncSessionRun(Generic[T]):
         timeout: float = 14400,
         interval: float = 2,
         _start_cursor: str | None = None,
+        _start_cursor_ref: Callable[[], str | None] | None = None,
     ) -> None:
         self._create_fn = create_fn
         self._sessions = sessions
@@ -98,6 +99,7 @@ class AsyncSessionRun(Generic[T]):
         self._timeout = timeout
         self._interval = interval
         self._start_cursor = _start_cursor
+        self._start_cursor_ref = _start_cursor_ref
         self.session_id: str | None = None
         self.result: SessionResult[T] | None = None
 
@@ -134,7 +136,8 @@ class AsyncSessionRun(Generic[T]):
         """
         data = await self._create_fn()
         self.session_id = str(data.id)
-        cursor: str | None = self._start_cursor
+        # Resolve cursor: prefer the ref callback (set during create_fn) over static value
+        cursor: str | None = self._start_cursor_ref() if self._start_cursor_ref else self._start_cursor
         deadline = time.monotonic() + self._timeout
 
         while time.monotonic() < deadline:

--- a/browser-use-python/src/browser_use_sdk/v3/helpers.py
+++ b/browser-use-python/src/browser_use_sdk/v3/helpers.py
@@ -90,12 +90,14 @@ class AsyncSessionRun(Generic[T]):
         *,
         timeout: float = 14400,
         interval: float = 2,
+        _start_cursor: str | None = None,
     ) -> None:
         self._create_fn = create_fn
         self._sessions = sessions
         self._output_schema = output_schema
         self._timeout = timeout
         self._interval = interval
+        self._start_cursor = _start_cursor
         self.session_id: str | None = None
         self.result: SessionResult[T] | None = None
 
@@ -132,7 +134,7 @@ class AsyncSessionRun(Generic[T]):
         """
         data = await self._create_fn()
         self.session_id = str(data.id)
-        cursor: str | None = None
+        cursor: str | None = self._start_cursor
         deadline = time.monotonic() + self._timeout
 
         while time.monotonic() < deadline:
@@ -178,12 +180,14 @@ class SessionStream(Generic[T]):
         *,
         timeout: float = 14400,
         interval: float = 2,
+        _start_cursor: str | None = None,
     ) -> None:
         self.session_id = str(session.id)
         self._sessions = sessions
         self._output_schema = output_schema
         self._timeout = timeout
         self._interval = interval
+        self._start_cursor = _start_cursor
         self.result: SessionResult[T] | None = None
 
     @property
@@ -192,7 +196,7 @@ class SessionStream(Generic[T]):
         return self.result.output if self.result else None
 
     def __iter__(self) -> Iterator[MessageResponse]:
-        cursor: str | None = None
+        cursor: str | None = self._start_cursor
         deadline = time.monotonic() + self._timeout
 
         while time.monotonic() < deadline:

--- a/docs/cloud/agent/workspaces.mdx
+++ b/docs/cloud/agent/workspaces.mdx
@@ -136,7 +136,7 @@ await client.workspaces.upload(workspace.id, "report.pdf", prefix="reports/")
 
 # List files in a subdirectory
 files = await client.workspaces.files(workspace.id, prefix="reports/")
-for f in files.items:
+for f in files.files:
     print(f.path, f.size)
 
 # Download only files from a subdirectory
@@ -148,7 +148,7 @@ await client.workspaces.upload(workspace.id, "report.pdf", { prefix: "reports/" 
 
 // List files in a subdirectory
 const files = await client.workspaces.files(workspace.id, { prefix: "reports/" });
-for (const f of files.items) {
+for (const f of files.files) {
   console.log(f.path, f.size);
 }
 
@@ -163,7 +163,7 @@ await client.workspaces.downloadAll(workspace.id, { to: "./output", prefix: "rep
 ```python Python
 # List all files
 files = await client.workspaces.files(workspace.id)
-for f in files.items:
+for f in files.files:
     print(f.path, f.size)
 
 # Delete a single file
@@ -176,7 +176,7 @@ print(f"Used: {size}")
 ```typescript TypeScript
 // List all files
 const files = await client.workspaces.files(workspace.id);
-for (const f of files.items) {
+for (const f of files.files) {
   console.log(f.path, f.size);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes message replay on follow-up tasks and improves error handling in both the TypeScript and Python SDKs. Also makes workspace uploads with a prefix reliable and allows `browsers.create()` to be called without arguments.

- **Bug Fixes**
  - Follow-up runs/streams with a `sessionId` now start from the latest message cursor, so only new messages are emitted (TS and Python).
  - Error messages now serialize non-string details with JSON instead of showing “[object Object]” (TS and Python).
  - `browsers.create()` defaults its body to `{}` to avoid 422 errors when called with no args (TS).
  - `workspaces.upload()` accepts a `{ prefix }` options object alongside file paths and forwards it correctly; requires at least one path (TS).
  - Docs: `workspaces.files()` examples now use `.files` (not `.items`) for both Python and TypeScript.

<sup>Written for commit e06cefadb5d506832bbe8edda19434ac5c644b64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

