### PR TITLE
Fix Python v3 broken by BuModel enum, auto-lowercase proxy codes, bump 3.4.0

### DIFF
--- a/browser-use-node/package.json
+++ b/browser-use-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-use-sdk",
-  "version": "3.3.2",
+  "version": "3.4.0",
   "description": "Official TypeScript SDK for the Browser Use API",
   "author": "Browser Use",
   "license": "MIT",

--- a/browser-use-node/src/generated/v3/types.ts
+++ b/browser-use-node/src/generated/v3/types.ts
@@ -1138,7 +1138,8 @@ export interface components {
              */
             id: string;
             status: components["schemas"]["BuAgentSessionStatus"];
-            model: components["schemas"]["BuModel"];
+            /** The model used. May be a BuModel alias or a resolved model name. */
+            model: string;
             /** Title */
             title?: string | null;
             /** Output */

--- a/browser-use-node/src/v3/client.ts
+++ b/browser-use-node/src/v3/client.ts
@@ -72,6 +72,9 @@ export class BrowserUse {
   run(task: string, options?: RunSessionOptions): SessionRun<any> {
     const { schema, timeout, interval, ...rest } = options ?? {};
     const body = { task, ...rest } as RunTaskRequest;
+    if (body.proxyCountryCode) {
+      body.proxyCountryCode = body.proxyCountryCode.toLowerCase() as any;
+    }
     if (schema) {
       body.outputSchema = z.toJSONSchema(schema) as Record<string, unknown>;
     }

--- a/browser-use-node/src/v3/resources/browsers.ts
+++ b/browser-use-node/src/v3/resources/browsers.ts
@@ -17,6 +17,9 @@ export class Browsers {
 
   /** Create a standalone browser session. */
   create(body: Partial<CreateBrowserSessionRequest> = {}): Promise<BrowserSessionItemView> {
+    if (body.proxyCountryCode) {
+      body = { ...body, proxyCountryCode: body.proxyCountryCode.toLowerCase() as any };
+    }
     return this.http.post<BrowserSessionItemView>("/browsers", body);
   }
 

--- a/browser-use-python/pyproject.toml
+++ b/browser-use-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "browser-use-sdk"
-version = "3.3.2"
+version = "3.4.0"
 description = "Python SDK for the Browser Use cloud API"
 readme = "README.md"
 license = "MIT"

--- a/browser-use-python/src/browser_use_sdk/generated/v3/models.py
+++ b/browser-use-python/src/browser_use_sdk/generated/v3/models.py
@@ -668,7 +668,7 @@ class SessionResponse(BaseModel):
     )
     id: UUID = Field(..., title='Id')
     status: BuAgentSessionStatus
-    model: BuModel
+    model: str
     title: str | None = Field(None, title='Title')
     output: Any = Field(None, title='Output')
     output_schema: dict[str, Any] | None = Field(

--- a/browser-use-python/src/browser_use_sdk/v3/resources/browsers.py
+++ b/browser-use-python/src/browser_use_sdk/v3/resources/browsers.py
@@ -35,7 +35,7 @@ class Browsers:
         if profile_id is not None:
             body["profileId"] = profile_id
         if proxy_country_code is not _UNSET:
-            body["proxyCountryCode"] = proxy_country_code
+            body["proxyCountryCode"] = proxy_country_code.lower() if isinstance(proxy_country_code, str) else proxy_country_code
         if timeout is not None:
             body["timeout"] = timeout
         if browser_screen_width is not None:
@@ -106,7 +106,7 @@ class AsyncBrowsers:
         if profile_id is not None:
             body["profileId"] = profile_id
         if proxy_country_code is not _UNSET:
-            body["proxyCountryCode"] = proxy_country_code
+            body["proxyCountryCode"] = proxy_country_code.lower() if isinstance(proxy_country_code, str) else proxy_country_code
         if timeout is not None:
             body["timeout"] = timeout
         if browser_screen_width is not None:

--- a/browser-use-python/src/browser_use_sdk/v3/resources/sessions.py
+++ b/browser-use-python/src/browser_use_sdk/v3/resources/sessions.py
@@ -55,7 +55,7 @@ class Sessions:
         if profile_id is not None:
             body["profileId"] = profile_id
         if proxy_country_code is not _UNSET:
-            body["proxyCountryCode"] = proxy_country_code
+            body["proxyCountryCode"] = proxy_country_code.lower() if isinstance(proxy_country_code, str) else proxy_country_code
         if output_schema is not None:
             body["outputSchema"] = output_schema
         if workspace_id is not None:
@@ -232,7 +232,7 @@ class AsyncSessions:
         if profile_id is not None:
             body["profileId"] = profile_id
         if proxy_country_code is not _UNSET:
-            body["proxyCountryCode"] = proxy_country_code
+            body["proxyCountryCode"] = proxy_country_code.lower() if isinstance(proxy_country_code, str) else proxy_country_code
         if output_schema is not None:
             body["outputSchema"] = output_schema
         if workspace_id is not None:

--- a/docs/cloud/browser/live-preview.mdx
+++ b/docs/cloud/browser/live-preview.mdx
@@ -88,6 +88,10 @@ https://live.browser-use.com?wss=...&ui=false
 
 ## Recording
 
+<Note>
+  `waitForRecording` / `wait_for_recording` requires the **v3 SDK** (`from browser_use_sdk.v3 import AsyncBrowserUse` / `import { BrowserUse } from "browser-use-sdk/v3"`).
+</Note>
+
 Enable recording to get an MP4 video of the browser session. Only available when the agent actually opens a browser — tasks answered without browsing produce no recording. If you run multiple tasks in the same session (with `keep_alive`), you may get multiple recordings.
 
 <CodeGroup>


### PR DESCRIPTION
## Summary

### P0: Python v3 SDK completely broken
The `BuModel` enum on `SessionResponse.model` only accepts `bu-mini`/`bu-max`/`bu-ultra`, but the API now returns resolved model names like `claude-sonnet-4.6`. Pydantic rejects these, breaking **every** Python v3 session call (`run()`, `sessions.create()`, `sessions.get()`, streaming, polling).

**Fix:** Changed `model` field on `SessionResponse` from `BuModel` enum to `str` in both Python and TS SDKs. Request types still use `BuModel` for input validation.

**Root cause:** Backend started returning resolved model names instead of aliases. This is an API-level change that the SDK enum didn't account for.

### P1: proxyCountryCode rejects uppercase
API requires lowercase ISO codes (`us`) but users naturally pass uppercase (`US`). Both SDKs now auto-lowercase in `sessions.create()`, `browsers.create()`, and `client.run()`.

### Docs: waitForRecording is v3-only
Added note to live-preview recording section.

### Version bump: 3.3.2 → 3.4.0

## Test plan
- [ ] Python v3: `client.run()` no longer throws ValidationError
- [ ] Python v3: `sessions.create()` works
- [ ] TS: `client.run({ proxyCountryCode: "US" })` auto-lowercases
- [ ] Python: `client.run(proxy_country_code="US")` auto-lowercases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a P0 that broke all Python v3 sessions by changing `SessionResponse.model` from `BuModel` enum to a string so it accepts resolved model names. Also auto-lowercases `proxyCountryCode`, clarifies recording helpers are v3-only, and bumps `browser-use-sdk` to `3.4.0`.

- **Bug Fixes**
  - `SessionResponse.model` is now `string` (TS) / `str` (Python) on responses to allow names like `claude-sonnet-4.6`; request inputs still validate `BuModel`.
  - Auto-lowercase `proxyCountryCode` in `client.run()`, `sessions.create()`, and `browsers.create()` (TS and Python).

<sup>Written for commit 11c4a6aa18fa90de5e3036826fee0d2ffbc7bd2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

