### PR TITLE
Auto-lowercase proxyCountryCode in v2 SDK

### DIFF
--- a/browser-use-node/src/v2/resources/browsers.ts
+++ b/browser-use-node/src/v2/resources/browsers.ts
@@ -19,6 +19,9 @@ export class Browsers {
 
   /** Create a new browser session. */
   create(body: CreateBrowserBody = {}): Promise<BrowserSessionItemView> {
+    if (body.proxyCountryCode) {
+      body = { ...body, proxyCountryCode: body.proxyCountryCode.toLowerCase() as any };
+    }
     return this.http.post<BrowserSessionItemView>("/browsers", body);
   }
 

--- a/browser-use-node/src/v2/resources/sessions.ts
+++ b/browser-use-node/src/v2/resources/sessions.ts
@@ -20,6 +20,9 @@ export class Sessions {
 
   /** Create a new session. */
   create(body?: CreateSessionBody): Promise<SessionItemView> {
+    if (body?.proxyCountryCode) {
+      body = { ...body, proxyCountryCode: body.proxyCountryCode.toLowerCase() as any };
+    }
     return this.http.post<SessionItemView>("/sessions", body);
   }
 

--- a/browser-use-python/src/browser_use_sdk/v2/resources/browsers.py
+++ b/browser-use-python/src/browser_use_sdk/v2/resources/browsers.py
@@ -27,7 +27,7 @@ def _build_create_body(
     if profile_id is not None:
         body["profileId"] = profile_id
     if proxy_country_code is not None:
-        body["proxyCountryCode"] = proxy_country_code
+        body["proxyCountryCode"] = proxy_country_code.lower() if isinstance(proxy_country_code, str) else proxy_country_code
     if timeout is not None:
         body["timeout"] = timeout
     if browser_screen_width is not None:

--- a/browser-use-python/src/browser_use_sdk/v2/resources/sessions.py
+++ b/browser-use-python/src/browser_use_sdk/v2/resources/sessions.py
@@ -29,7 +29,7 @@ def _build_create_body(
     if profile_id is not None:
         body["profileId"] = profile_id
     if proxy_country_code is not None:
-        body["proxyCountryCode"] = proxy_country_code
+        body["proxyCountryCode"] = proxy_country_code.lower() if isinstance(proxy_country_code, str) else proxy_country_code
     if start_url is not None:
         body["startUrl"] = start_url
     if browser_screen_width is not None:


### PR DESCRIPTION
v3 already auto-lowercases `proxyCountryCode` (PR #107) but v2 was missing it. API requires lowercase ISO codes and returns 422 for uppercase input like `"US"`.

Fixes `sessions.create()` and `browsers.create()` in both TS and Python v2 SDKs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-lowercases `proxyCountryCode` in the v2 Node and Python SDKs to match v3 and prevent 422 errors from uppercase ISO country codes.

- **Bug Fixes**
  - `browser-use-node` v2: lowercases `proxyCountryCode` in `browsers.create()` and `sessions.create()`.
  - `browser-use-python` v2: lowercases `proxyCountryCode` (when string) in create bodies for browsers and sessions.

<sup>Written for commit ba43f1f25686fb3e981622a457a2d6acca18559e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

