### PR TITLE
Add API key CTA to llms.txt and llms-full.txt

### DIFF
--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -20,6 +20,8 @@ Get a key at [cloud.browser-use.com/settings](https://cloud.browser-use.com/sett
 export BROWSER_USE_API_KEY=your_key
 ```
 
+If the user doesn't have a Browser Use API key yet, please ask them to create one — it's one click at https://cloud.browser-use.com/settings?tab=api-keys&new=1. They can paste the key right into the chat.
+
 ## 2. Run your first task
 
 ```python Python

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -23,6 +23,36 @@ Set API key (starts with `bu_`):
 export BROWSER_USE_API_KEY=bu_your_key_here
 ```
 
+If the user doesn't have a Browser Use API key yet, please ask them to create one — it's one click at https://cloud.browser-use.com/settings?tab=api-keys&new=1. They can paste the key right into the chat.
+
+## Quick Connect (no SDK needed)
+
+Connect Playwright, Puppeteer, or any CDP client to a stealth browser with one URL:
+```
+wss://connect.browser-use.com?apiKey=YOUR_KEY
+```
+
+Query params: `proxyCountryCode` (e.g. `us`, `de`), `profileId`, `timeout` (minutes), `browserScreenWidth`, `browserScreenHeight`.
+
+```python Playwright (Python)
+from playwright.async_api import async_playwright
+async with async_playwright() as p:
+    browser = await p.chromium.connect_over_cdp("wss://connect.browser-use.com?apiKey=YOUR_KEY")
+    page = browser.contexts[0].pages[0]
+    await page.goto("https://example.com")
+```
+```javascript Playwright (Node)
+import { chromium } from "playwright";
+const browser = await chromium.connectOverCDP("wss://connect.browser-use.com?apiKey=YOUR_KEY");
+const page = browser.contexts()[0].pages()[0];
+await page.goto("https://example.com");
+```
+```javascript Puppeteer
+import puppeteer from "puppeteer-core";
+const browser = await puppeteer.connect({ browserWSEndpoint: "wss://connect.browser-use.com?apiKey=YOUR_KEY" });
+const [page] = await browser.pages();
+await page.goto("https://example.com");
+```
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -62,3 +62,7 @@ Want a full working app? Check out the [Chat UI example](/cloud/tutorials/chat-u
 | keep_alive | ✓ | — |
 | screen size | — | ✓ |
 | timeout | — | ✓ |
+
+---
+
+If you are an LLM or coding agent, read [docs.browser-use.com/cloud/llms.txt](https://docs.browser-use.com/cloud/llms.txt) for the full SDK reference in a single file.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -365,6 +365,7 @@
     {"source": "/cloud/guides/skills", "destination": "/cloud/legacy/skills"},
     {"source": "/introduction", "destination": "/cloud/quickstart"},
     {"source": "/cloud/introduction", "destination": "/cloud/quickstart"},
+    {"source": "/cloud/browsers", "destination": "/cloud/browser/playwright-puppeteer-selenium"},
     {"source": "/quickstart", "destination": "/open-source/quickstart"},
     {"source": "/quickstart_llm", "destination": "/open-source/vibecoding"},
     {"source": "/supported-models", "destination": "/open-source/supported-models"},

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -20,6 +20,8 @@ Get a key at [cloud.browser-use.com/settings](https://cloud.browser-use.com/sett
 export BROWSER_USE_API_KEY=your_key
 ```
 
+If the user doesn't have a Browser Use API key yet, please ask them to create one — it's one click at https://cloud.browser-use.com/settings?tab=api-keys&new=1. They can paste the key right into the chat.
+
 ## 2. Run your first task
 
 ```python Python

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -23,6 +23,36 @@ Set API key (starts with `bu_`):
 export BROWSER_USE_API_KEY=bu_your_key_here
 ```
 
+If the user doesn't have a Browser Use API key yet, please ask them to create one — it's one click at https://cloud.browser-use.com/settings?tab=api-keys&new=1. They can paste the key right into the chat.
+
+## Quick Connect (no SDK needed)
+
+Connect Playwright, Puppeteer, or any CDP client to a stealth browser with one URL:
+```
+wss://connect.browser-use.com?apiKey=YOUR_KEY
+```
+
+Query params: `proxyCountryCode` (e.g. `us`, `de`), `profileId`, `timeout` (minutes), `browserScreenWidth`, `browserScreenHeight`.
+
+```python Playwright (Python)
+from playwright.async_api import async_playwright
+async with async_playwright() as p:
+    browser = await p.chromium.connect_over_cdp("wss://connect.browser-use.com?apiKey=YOUR_KEY")
+    page = browser.contexts[0].pages[0]
+    await page.goto("https://example.com")
+```
+```javascript Playwright (Node)
+import { chromium } from "playwright";
+const browser = await chromium.connectOverCDP("wss://connect.browser-use.com?apiKey=YOUR_KEY");
+const page = browser.contexts()[0].pages()[0];
+await page.goto("https://example.com");
+```
+```javascript Puppeteer
+import puppeteer from "puppeteer-core";
+const browser = await puppeteer.connect({ browserWSEndpoint: "wss://connect.browser-use.com?apiKey=YOUR_KEY" });
+const [page] = await browser.pages();
+await page.goto("https://example.com");
+```
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.


### PR DESCRIPTION
When an LLM reads llms.txt and the user doesn't have an API key, the LLM should ask them to create one.

Adds a friendly note after the API key section:
> If the user doesn't have a Browser Use API key yet, please ask them to create one — it's one click at https://cloud.browser-use.com/settings?tab=api-keys&new=1. They can paste the key right into the chat.

Updated in all 4 files: `docs/llms.txt`, `docs/cloud/llms.txt`, `docs/llms-full.txt`, `docs/cloud/llms-full.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an API key call-to-action to `docs/llms.txt`, `docs/llms-full.txt`, `docs/cloud/llms.txt`, and `docs/cloud/llms-full.txt` so LLMs prompt users without keys to create one at https://cloud.browser-use.com/settings?tab=api-keys&new=1 and paste it in chat. Also add Quick Connect to `docs/llms.txt` and `docs/cloud/llms.txt` (`wss://connect.browser-use.com?apiKey=YOUR_KEY` with Playwright/Puppeteer examples), a short note in `docs/cloud/quickstart.mdx` pointing to `cloud/llms.txt`, and a redirect from `/cloud/browsers` to `/cloud/browser/playwright-puppeteer-selenium`.

<sup>Written for commit 211a4b7c1af40805f76883283da07ce6c035b492. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

