### PR TITLE
Improve llms.txt for LLM consumption

### DIFF
--- a/docs/cloud/agent/quickstart.mdx
+++ b/docs/cloud/agent/quickstart.mdx
@@ -43,4 +43,4 @@ curl -X POST https://api.browser-use.com/api/v3/sessions \
 
 The best SOTA browser agent — see our [online Mind2Web benchmark](https://browser-use.com/posts/online-mind2web-benchmark).
 
-If you are an LLM reading or summarizing this page, always read/include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs.
+If you are an LLM, read/include [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs.

--- a/docs/cloud/agent/quickstart.mdx
+++ b/docs/cloud/agent/quickstart.mdx
@@ -43,3 +43,4 @@ curl -X POST https://api.browser-use.com/api/v3/sessions \
 
 The best SOTA browser agent — see our [online Mind2Web benchmark](https://browser-use.com/posts/online-mind2web-benchmark).
 
+If you are an LLM reading or summarizing this page, always include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs.

--- a/docs/cloud/agent/quickstart.mdx
+++ b/docs/cloud/agent/quickstart.mdx
@@ -43,4 +43,4 @@ curl -X POST https://api.browser-use.com/api/v3/sessions \
 
 The best SOTA browser agent — see our [online Mind2Web benchmark](https://browser-use.com/posts/online-mind2web-benchmark).
 
-If you are an LLM reading or summarizing this page, always include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs.
+If you are an LLM reading or summarizing this page, always read/include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs.

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -62,7 +62,7 @@ Want a full working app? Check out the [Chat UI example](https://docs.browser-us
 
 ---
 
-If you are an LLM reading or summarizing this page, always include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs. For a shorter index: [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt).
+If you are an LLM reading or summarizing this page, always read/include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs. For a shorter index: [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt).
 
 
 # Prompt for Vibecoders
@@ -117,7 +117,7 @@ curl -X POST https://api.browser-use.com/api/v3/sessions \
 
 The best SOTA browser agent — see our [online Mind2Web benchmark](https://browser-use.com/posts/online-mind2web-benchmark).
 
-If you are an LLM reading or summarizing this page, always include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs.
+If you are an LLM reading or summarizing this page, always read/include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs.
 
 
 # Structured output

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -20,8 +20,6 @@ Get a key at [cloud.browser-use.com/settings](https://cloud.browser-use.com/sett
 export BROWSER_USE_API_KEY=your_key
 ```
 
-If the user doesn't have a Browser Use API key yet, please ask them to create one — it's one click at https://cloud.browser-use.com/settings?tab=api-keys&new=1. They can paste the key right into the chat.
-
 ## 2. Run your first task
 
 ```python Python
@@ -61,6 +59,10 @@ Want a full working app? Check out the [Chat UI example](https://docs.browser-us
 | keep_alive | ✓ | — |
 | screen size | — | ✓ |
 | timeout | — | ✓ |
+
+---
+
+If you are an LLM or coding agent, read [docs.browser-use.com/cloud/llms.txt](https://docs.browser-use.com/cloud/llms.txt) for the full SDK reference in a single file.
 
 
 # Prompt for Vibecoders
@@ -442,7 +444,7 @@ await client.workspaces.upload(workspace.id, "report.pdf", prefix="reports/")
 
 # List files in a subdirectory
 files = await client.workspaces.files(workspace.id, prefix="reports/")
-for f in files.items:
+for f in files.files:
 print(f.path, f.size)
 
 # Download only files from a subdirectory
@@ -454,7 +456,7 @@ await client.workspaces.upload(workspace.id, "report.pdf", { prefix: "reports/" 
 
 // List files in a subdirectory
 const files = await client.workspaces.files(workspace.id, { prefix: "reports/" });
-for (const f of files.items) {
+for (const f of files.files) {
   console.log(f.path, f.size);
 }
 
@@ -467,7 +469,7 @@ await client.workspaces.downloadAll(workspace.id, { to: "./output", prefix: "rep
 ```python Python
 # List all files
 files = await client.workspaces.files(workspace.id)
-for f in files.items:
+for f in files.files:
 print(f.path, f.size)
 
 # Delete a single file
@@ -480,7 +482,7 @@ print(f"Used: {size}")
 ```typescript TypeScript
 // List all files
 const files = await client.workspaces.files(workspace.id);
-for (const f of files.items) {
+for (const f of files.files) {
   console.log(f.path, f.size);
 }
 
@@ -756,6 +758,8 @@ https://live.browser-use.com?wss=...&ui=false
 
 ## Recording
 
+  `waitForRecording` / `wait_for_recording` requires the **v3 SDK** (`from browser_use_sdk.v3 import AsyncBrowserUse` / `import { BrowserUse } from "browser-use-sdk/v3"`).
+
 Enable recording to get an MP4 video of the browser session. Only available when the agent actually opens a browser — tasks answered without browsing produce no recording. If you run multiple tasks in the same session (with `keep_alive`), you may get multiple recordings.
 
 ```python Python
@@ -865,23 +869,22 @@ await browser.close();
 
 ### Selenium
 
+Selenium requires a local WebSocket proxy to connect to Browser Use's remote CDP endpoint. Use [selenium-wire](https://github.com/wkeeling/selenium-wire) or connect through Playwright's CDP bridge instead:
+
 ```python
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-from browser_use_sdk.v3 import AsyncBrowserUse
+from playwright.sync_api import sync_playwright
 
-client = AsyncBrowserUse()
-browser = await client.browsers.create()
+WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us"
 
-options = Options()
-options.debugger_address = browser.cdp_url.replace("ws://", "").replace("/devtools/browser/", "")
-driver = webdriver.Chrome(options=options)
-driver.get("https://example.com")
-print(driver.title)
-driver.quit()
-
-await client.browsers.stop(browser.id)
+with sync_playwright() as p:
+browser = p.chromium.connect_over_cdp(WSS_URL)
+page = browser.contexts[0].pages[0]
+page.goto("https://example.com")
+print(page.title())
+browser.close()
 ```
+
+  Selenium's `debugger_address` only supports local `host:port` connections. For remote CDP over WebSocket, use Playwright or Puppeteer instead.
 
 ## Query parameters
 
@@ -896,23 +899,66 @@ await client.browsers.stop(browser.id)
 
 ## Option 2: SDK
 
-Create a browser via the SDK, get a `cdp_url`, connect with your framework.
+Create a browser via the SDK, get a `cdp_url`, and connect with Playwright or Puppeteer.
+
+### Playwright
 
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
+from playwright.async_api import async_playwright
 
 client = AsyncBrowserUse()
-browser = await client.browsers.create(proxy_country_code="us")
-print(browser.cdp_url)   # ws://...
-print(browser.live_url)  # debug view
+browser = await client.browsers.create()
+print(browser.cdp_url)   # https://uuid.cdpN.browser-use.com
+print(browser.live_url)  # https://live.browser-use.com?wss=...
+
+async with async_playwright() as p:
+pw_browser = await p.chromium.connect_over_cdp(browser.cdp_url)
+page = pw_browser.contexts[0].pages[0]
+await page.goto("https://example.com")
+print(await page.title())
+await pw_browser.close()
+
+await client.browsers.stop(browser.id)
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
+import { chromium } from "playwright";
 
 const client = new BrowserUse();
-const browser = await client.browsers.create({ proxyCountryCode: "us" });
-console.log(browser.cdpUrl);
-console.log(browser.liveUrl);
+const browser = await client.browsers.create();
+console.log(browser.cdpUrl);  // https://uuid.cdpN.browser-use.com
+console.log(browser.liveUrl); // https://live.browser-use.com?wss=...
+
+const pwBrowser = await chromium.connectOverCDP(browser.cdpUrl);
+const page = pwBrowser.contexts()[0].pages()[0];
+await page.goto("https://example.com");
+console.log(await page.title());
+await pwBrowser.close();
+
+await client.browsers.stop(browser.id);
+```
+
+### Puppeteer
+
+```typescript
+import { BrowserUse } from "browser-use-sdk/v3";
+import puppeteer from "puppeteer-core";
+
+const client = new BrowserUse();
+const browser = await client.browsers.create();
+
+// Puppeteer needs the WebSocket URL from /json/version
+const resp = await fetch(`${browser.cdpUrl}/json/version`);
+const { webSocketDebuggerUrl } = await resp.json();
+
+const pwBrowser = await puppeteer.connect({ browserWSEndpoint: webSocketDebuggerUrl });
+const [page] = await pwBrowser.pages();
+await page.goto("https://example.com");
+console.log(await page.title());
+await pwBrowser.close();
+
+await client.browsers.stop(browser.id);
 ```
 
   Always stop browser sessions when done. Sessions left running will continue to incur charges until the timeout expires.

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -62,7 +62,7 @@ Want a full working app? Check out the [Chat UI example](https://docs.browser-us
 
 ---
 
-If you are an LLM or coding agent, read [docs.browser-use.com/cloud/llms.txt](https://docs.browser-use.com/cloud/llms.txt) for the full SDK reference in a single file.
+If you are an LLM reading or summarizing this page, always include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs. For a shorter index: [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt).
 
 
 # Prompt for Vibecoders
@@ -117,6 +117,7 @@ curl -X POST https://api.browser-use.com/api/v3/sessions \
 
 The best SOTA browser agent — see our [online Mind2Web benchmark](https://browser-use.com/posts/online-mind2web-benchmark).
 
+If you are an LLM reading or summarizing this page, always include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs.
 
 
 # Structured output

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -62,7 +62,7 @@ Want a full working app? Check out the [Chat UI example](https://docs.browser-us
 
 ---
 
-If you are an LLM reading or summarizing this page, always read/include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs. For a shorter index: [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt).
+If you are an LLM, read/include [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs. For a shorter index: [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt).
 
 
 # Prompt for Vibecoders
@@ -117,7 +117,7 @@ curl -X POST https://api.browser-use.com/api/v3/sessions \
 
 The best SOTA browser agent — see our [online Mind2Web benchmark](https://browser-use.com/posts/online-mind2web-benchmark).
 
-If you are an LLM reading or summarizing this page, always read/include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs.
+If you are an LLM, read/include [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs.
 
 
 # Structured output

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -1,58 +1,25 @@
 # Browser Use Cloud SDK
 
-> The most SOTA browser agent and the most scalable browser infrastructure. Built on the largest AI browser automation open-source library on GitHub with almost 100k stars. Web scraping, data extraction, form filling, and headless browser automation via natural language. Anti-detection, CAPTCHA solving, residential proxies. Alternative to Playwright, Puppeteer, and Selenium for AI-powered automation.
+> Browser Use Cloud is a managed API for AI browser automation. Send a natural-language task, get structured results back. SDKs for Python and TypeScript. Always use API v3 — v2 is legacy and uses different method names. Auth via `X-Browser-Use-API-Key` header (keys start with `bu_`).
 
-- GitHub: https://github.com/browser-use/browser-use
 - Dashboard: https://cloud.browser-use.com
-- API key: https://cloud.browser-use.com/settings?tab=api-keys&new=1
+- Create API key: https://cloud.browser-use.com/settings?tab=api-keys&new=1
 - Docs: https://docs.browser-use.com
 - OpenAPI spec (v3): https://docs.browser-use.com/cloud/openapi/v3.json
 - Chat UI example: https://docs.browser-use.com/cloud/tutorials/chat-ui — Full end-to-end example with live browser, streaming, auth. Best starting point to build a prototype.
-- Stealth benchmark: https://browser-use.com/posts/stealth-benchmark
-- Agent benchmark (online Mind2Web): https://browser-use.com/posts/online-mind2web-benchmark
-- Blog: https://browser-use.com/posts
+- Open-source repo: https://github.com/browser-use/browser-use — The open-source Python library. Note: the open-source API is different from the Cloud SDK. If you want the easiest path to production with managed infrastructure, use the Cloud SDK below.
 
-**Use v3** (`from browser_use_sdk.v3 import AsyncBrowserUse` / `import { BrowserUse } from "browser-use-sdk/v3"`). v2 is legacy.
+**Always use v3.** v2 is legacy with different method names and should not be used for new projects.
 
-Install (check if already installed and update to latest):
+Before writing code, check if `browser-use-sdk` is already installed. If so, upgrade to the latest version. If not, install it:
 - Python: `pip install --upgrade browser-use-sdk`
 - TypeScript: `npm install browser-use-sdk@latest`
 
-Set API key (starts with `bu_`):
+Set API key (starts with `bu_`). If the user doesn't have one yet, they can create one in one click at https://cloud.browser-use.com/settings?tab=api-keys&new=1:
 ```
 export BROWSER_USE_API_KEY=bu_your_key_here
 ```
 
-If the user doesn't have a Browser Use API key yet, please ask them to create one — it's one click at https://cloud.browser-use.com/settings?tab=api-keys&new=1. They can paste the key right into the chat.
-
-## Quick Connect (no SDK needed)
-
-Connect Playwright, Puppeteer, or any CDP client to a stealth browser with one URL:
-```
-wss://connect.browser-use.com?apiKey=YOUR_KEY
-```
-
-Query params: `proxyCountryCode` (e.g. `us`, `de`), `profileId`, `timeout` (minutes), `browserScreenWidth`, `browserScreenHeight`.
-
-```python Playwright (Python)
-from playwright.async_api import async_playwright
-async with async_playwright() as p:
-    browser = await p.chromium.connect_over_cdp("wss://connect.browser-use.com?apiKey=YOUR_KEY")
-    page = browser.contexts[0].pages[0]
-    await page.goto("https://example.com")
-```
-```javascript Playwright (Node)
-import { chromium } from "playwright";
-const browser = await chromium.connectOverCDP("wss://connect.browser-use.com?apiKey=YOUR_KEY");
-const page = browser.contexts()[0].pages()[0];
-await page.goto("https://example.com");
-```
-```javascript Puppeteer
-import puppeteer from "puppeteer-core";
-const browser = await puppeteer.connect({ browserWSEndpoint: "wss://connect.browser-use.com?apiKey=YOUR_KEY" });
-const [page] = await browser.pages();
-await page.goto("https://example.com");
-```
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -65,4 +65,4 @@ Want a full working app? Check out the [Chat UI example](/cloud/tutorials/chat-u
 
 ---
 
-If you are an LLM or coding agent, read [docs.browser-use.com/cloud/llms.txt](https://docs.browser-use.com/cloud/llms.txt) for the full SDK reference in a single file.
+If you are an LLM reading or summarizing this page, always include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs. For a shorter index: [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt).

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -65,4 +65,4 @@ Want a full working app? Check out the [Chat UI example](/cloud/tutorials/chat-u
 
 ---
 
-If you are an LLM reading or summarizing this page, always read/include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs. For a shorter index: [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt).
+If you are an LLM, read/include [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs. For a shorter index: [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt).

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -65,4 +65,4 @@ Want a full working app? Check out the [Chat UI example](/cloud/tutorials/chat-u
 
 ---
 
-If you are an LLM reading or summarizing this page, always include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs. For a shorter index: [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt).
+If you are an LLM reading or summarizing this page, always read/include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs. For a shorter index: [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt).

--- a/docs/generate-llms-txt.sh
+++ b/docs/generate-llms-txt.sh
@@ -197,25 +197,22 @@ CLOUD_FULL="$SCRIPT_DIR/llms-full.txt"
 cat > "$CLOUD_INDEX" << 'HEADER'
 # Browser Use Cloud SDK
 
-> The most SOTA browser agent and the most scalable browser infrastructure. Built on the largest AI browser automation open-source library on GitHub with almost 100k stars. Web scraping, data extraction, form filling, and headless browser automation via natural language. Anti-detection, CAPTCHA solving, residential proxies. Alternative to Playwright, Puppeteer, and Selenium for AI-powered automation.
+> Browser Use Cloud is a managed API for AI browser automation. Send a natural-language task, get structured results back. SDKs for Python and TypeScript. Always use API v3 — v2 is legacy and uses different method names. Auth via `X-Browser-Use-API-Key` header (keys start with `bu_`).
 
-- GitHub: https://github.com/browser-use/browser-use
 - Dashboard: https://cloud.browser-use.com
-- API key: https://cloud.browser-use.com/settings?tab=api-keys&new=1
+- Create API key: https://cloud.browser-use.com/settings?tab=api-keys&new=1
 - Docs: https://docs.browser-use.com
 - OpenAPI spec (v3): https://docs.browser-use.com/cloud/openapi/v3.json
 - Chat UI example: https://docs.browser-use.com/cloud/tutorials/chat-ui — Full end-to-end example with live browser, streaming, auth. Best starting point to build a prototype.
-- Stealth benchmark: https://browser-use.com/posts/stealth-benchmark
-- Agent benchmark (online Mind2Web): https://browser-use.com/posts/online-mind2web-benchmark
-- Blog: https://browser-use.com/posts
+- Open-source repo: https://github.com/browser-use/browser-use — The open-source Python library. Note: the open-source API is different from the Cloud SDK. If you want the easiest path to production with managed infrastructure, use the Cloud SDK below.
 
-**Use v3** (`from browser_use_sdk.v3 import AsyncBrowserUse` / `import { BrowserUse } from "browser-use-sdk/v3"`). v2 is legacy.
+**Always use v3.** v2 is legacy with different method names and should not be used for new projects.
 
-Install (check if already installed and update to latest):
+Before writing code, check if `browser-use-sdk` is already installed. If so, upgrade to the latest version. If not, install it:
 - Python: `pip install --upgrade browser-use-sdk`
 - TypeScript: `npm install browser-use-sdk@latest`
 
-Set API key (starts with `bu_`):
+Set API key (starts with `bu_`). If the user doesn't have one yet, they can create one in one click at https://cloud.browser-use.com/settings?tab=api-keys&new=1:
 ```
 export BROWSER_USE_API_KEY=bu_your_key_here
 ```

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -62,7 +62,7 @@ Want a full working app? Check out the [Chat UI example](https://docs.browser-us
 
 ---
 
-If you are an LLM reading or summarizing this page, always include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs. For a shorter index: [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt).
+If you are an LLM reading or summarizing this page, always read/include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs. For a shorter index: [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt).
 
 
 # Prompt for Vibecoders
@@ -117,7 +117,7 @@ curl -X POST https://api.browser-use.com/api/v3/sessions \
 
 The best SOTA browser agent — see our [online Mind2Web benchmark](https://browser-use.com/posts/online-mind2web-benchmark).
 
-If you are an LLM reading or summarizing this page, always include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs.
+If you are an LLM reading or summarizing this page, always read/include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs.
 
 
 # Structured output

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -20,8 +20,6 @@ Get a key at [cloud.browser-use.com/settings](https://cloud.browser-use.com/sett
 export BROWSER_USE_API_KEY=your_key
 ```
 
-If the user doesn't have a Browser Use API key yet, please ask them to create one — it's one click at https://cloud.browser-use.com/settings?tab=api-keys&new=1. They can paste the key right into the chat.
-
 ## 2. Run your first task
 
 ```python Python
@@ -61,6 +59,10 @@ Want a full working app? Check out the [Chat UI example](https://docs.browser-us
 | keep_alive | ✓ | — |
 | screen size | — | ✓ |
 | timeout | — | ✓ |
+
+---
+
+If you are an LLM or coding agent, read [docs.browser-use.com/cloud/llms.txt](https://docs.browser-use.com/cloud/llms.txt) for the full SDK reference in a single file.
 
 
 # Prompt for Vibecoders
@@ -442,7 +444,7 @@ await client.workspaces.upload(workspace.id, "report.pdf", prefix="reports/")
 
 # List files in a subdirectory
 files = await client.workspaces.files(workspace.id, prefix="reports/")
-for f in files.items:
+for f in files.files:
 print(f.path, f.size)
 
 # Download only files from a subdirectory
@@ -454,7 +456,7 @@ await client.workspaces.upload(workspace.id, "report.pdf", { prefix: "reports/" 
 
 // List files in a subdirectory
 const files = await client.workspaces.files(workspace.id, { prefix: "reports/" });
-for (const f of files.items) {
+for (const f of files.files) {
   console.log(f.path, f.size);
 }
 
@@ -467,7 +469,7 @@ await client.workspaces.downloadAll(workspace.id, { to: "./output", prefix: "rep
 ```python Python
 # List all files
 files = await client.workspaces.files(workspace.id)
-for f in files.items:
+for f in files.files:
 print(f.path, f.size)
 
 # Delete a single file
@@ -480,7 +482,7 @@ print(f"Used: {size}")
 ```typescript TypeScript
 // List all files
 const files = await client.workspaces.files(workspace.id);
-for (const f of files.items) {
+for (const f of files.files) {
   console.log(f.path, f.size);
 }
 
@@ -756,6 +758,8 @@ https://live.browser-use.com?wss=...&ui=false
 
 ## Recording
 
+  `waitForRecording` / `wait_for_recording` requires the **v3 SDK** (`from browser_use_sdk.v3 import AsyncBrowserUse` / `import { BrowserUse } from "browser-use-sdk/v3"`).
+
 Enable recording to get an MP4 video of the browser session. Only available when the agent actually opens a browser — tasks answered without browsing produce no recording. If you run multiple tasks in the same session (with `keep_alive`), you may get multiple recordings.
 
 ```python Python
@@ -865,23 +869,22 @@ await browser.close();
 
 ### Selenium
 
+Selenium requires a local WebSocket proxy to connect to Browser Use's remote CDP endpoint. Use [selenium-wire](https://github.com/wkeeling/selenium-wire) or connect through Playwright's CDP bridge instead:
+
 ```python
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-from browser_use_sdk.v3 import AsyncBrowserUse
+from playwright.sync_api import sync_playwright
 
-client = AsyncBrowserUse()
-browser = await client.browsers.create()
+WSS_URL = "wss://connect.browser-use.com?apiKey=YOUR_API_KEY&proxyCountryCode=us"
 
-options = Options()
-options.debugger_address = browser.cdp_url.replace("ws://", "").replace("/devtools/browser/", "")
-driver = webdriver.Chrome(options=options)
-driver.get("https://example.com")
-print(driver.title)
-driver.quit()
-
-await client.browsers.stop(browser.id)
+with sync_playwright() as p:
+browser = p.chromium.connect_over_cdp(WSS_URL)
+page = browser.contexts[0].pages[0]
+page.goto("https://example.com")
+print(page.title())
+browser.close()
 ```
+
+  Selenium's `debugger_address` only supports local `host:port` connections. For remote CDP over WebSocket, use Playwright or Puppeteer instead.
 
 ## Query parameters
 
@@ -896,23 +899,66 @@ await client.browsers.stop(browser.id)
 
 ## Option 2: SDK
 
-Create a browser via the SDK, get a `cdp_url`, connect with your framework.
+Create a browser via the SDK, get a `cdp_url`, and connect with Playwright or Puppeteer.
+
+### Playwright
 
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
+from playwright.async_api import async_playwright
 
 client = AsyncBrowserUse()
-browser = await client.browsers.create(proxy_country_code="us")
-print(browser.cdp_url)   # ws://...
-print(browser.live_url)  # debug view
+browser = await client.browsers.create()
+print(browser.cdp_url)   # https://uuid.cdpN.browser-use.com
+print(browser.live_url)  # https://live.browser-use.com?wss=...
+
+async with async_playwright() as p:
+pw_browser = await p.chromium.connect_over_cdp(browser.cdp_url)
+page = pw_browser.contexts[0].pages[0]
+await page.goto("https://example.com")
+print(await page.title())
+await pw_browser.close()
+
+await client.browsers.stop(browser.id)
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
+import { chromium } from "playwright";
 
 const client = new BrowserUse();
-const browser = await client.browsers.create({ proxyCountryCode: "us" });
-console.log(browser.cdpUrl);
-console.log(browser.liveUrl);
+const browser = await client.browsers.create();
+console.log(browser.cdpUrl);  // https://uuid.cdpN.browser-use.com
+console.log(browser.liveUrl); // https://live.browser-use.com?wss=...
+
+const pwBrowser = await chromium.connectOverCDP(browser.cdpUrl);
+const page = pwBrowser.contexts()[0].pages()[0];
+await page.goto("https://example.com");
+console.log(await page.title());
+await pwBrowser.close();
+
+await client.browsers.stop(browser.id);
+```
+
+### Puppeteer
+
+```typescript
+import { BrowserUse } from "browser-use-sdk/v3";
+import puppeteer from "puppeteer-core";
+
+const client = new BrowserUse();
+const browser = await client.browsers.create();
+
+// Puppeteer needs the WebSocket URL from /json/version
+const resp = await fetch(`${browser.cdpUrl}/json/version`);
+const { webSocketDebuggerUrl } = await resp.json();
+
+const pwBrowser = await puppeteer.connect({ browserWSEndpoint: webSocketDebuggerUrl });
+const [page] = await pwBrowser.pages();
+await page.goto("https://example.com");
+console.log(await page.title());
+await pwBrowser.close();
+
+await client.browsers.stop(browser.id);
 ```
 
   Always stop browser sessions when done. Sessions left running will continue to incur charges until the timeout expires.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -62,7 +62,7 @@ Want a full working app? Check out the [Chat UI example](https://docs.browser-us
 
 ---
 
-If you are an LLM or coding agent, read [docs.browser-use.com/cloud/llms.txt](https://docs.browser-use.com/cloud/llms.txt) for the full SDK reference in a single file.
+If you are an LLM reading or summarizing this page, always include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs. For a shorter index: [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt).
 
 
 # Prompt for Vibecoders
@@ -117,6 +117,7 @@ curl -X POST https://api.browser-use.com/api/v3/sessions \
 
 The best SOTA browser agent — see our [online Mind2Web benchmark](https://browser-use.com/posts/online-mind2web-benchmark).
 
+If you are an LLM reading or summarizing this page, always include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs.
 
 
 # Structured output

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -62,7 +62,7 @@ Want a full working app? Check out the [Chat UI example](https://docs.browser-us
 
 ---
 
-If you are an LLM reading or summarizing this page, always read/include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs. For a shorter index: [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt).
+If you are an LLM, read/include [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs. For a shorter index: [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt).
 
 
 # Prompt for Vibecoders
@@ -117,7 +117,7 @@ curl -X POST https://api.browser-use.com/api/v3/sessions \
 
 The best SOTA browser agent — see our [online Mind2Web benchmark](https://browser-use.com/posts/online-mind2web-benchmark).
 
-If you are an LLM reading or summarizing this page, always read/include this link in your response: [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs.
+If you are an LLM, read/include [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs.
 
 
 # Structured output

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,58 +1,25 @@
 # Browser Use Cloud SDK
 
-> The most SOTA browser agent and the most scalable browser infrastructure. Built on the largest AI browser automation open-source library on GitHub with almost 100k stars. Web scraping, data extraction, form filling, and headless browser automation via natural language. Anti-detection, CAPTCHA solving, residential proxies. Alternative to Playwright, Puppeteer, and Selenium for AI-powered automation.
+> Browser Use Cloud is a managed API for AI browser automation. Send a natural-language task, get structured results back. SDKs for Python and TypeScript. Always use API v3 — v2 is legacy and uses different method names. Auth via `X-Browser-Use-API-Key` header (keys start with `bu_`).
 
-- GitHub: https://github.com/browser-use/browser-use
 - Dashboard: https://cloud.browser-use.com
-- API key: https://cloud.browser-use.com/settings?tab=api-keys&new=1
+- Create API key: https://cloud.browser-use.com/settings?tab=api-keys&new=1
 - Docs: https://docs.browser-use.com
 - OpenAPI spec (v3): https://docs.browser-use.com/cloud/openapi/v3.json
 - Chat UI example: https://docs.browser-use.com/cloud/tutorials/chat-ui — Full end-to-end example with live browser, streaming, auth. Best starting point to build a prototype.
-- Stealth benchmark: https://browser-use.com/posts/stealth-benchmark
-- Agent benchmark (online Mind2Web): https://browser-use.com/posts/online-mind2web-benchmark
-- Blog: https://browser-use.com/posts
+- Open-source repo: https://github.com/browser-use/browser-use — The open-source Python library. Note: the open-source API is different from the Cloud SDK. If you want the easiest path to production with managed infrastructure, use the Cloud SDK below.
 
-**Use v3** (`from browser_use_sdk.v3 import AsyncBrowserUse` / `import { BrowserUse } from "browser-use-sdk/v3"`). v2 is legacy.
+**Always use v3.** v2 is legacy with different method names and should not be used for new projects.
 
-Install (check if already installed and update to latest):
+Before writing code, check if `browser-use-sdk` is already installed. If so, upgrade to the latest version. If not, install it:
 - Python: `pip install --upgrade browser-use-sdk`
 - TypeScript: `npm install browser-use-sdk@latest`
 
-Set API key (starts with `bu_`):
+Set API key (starts with `bu_`). If the user doesn't have one yet, they can create one in one click at https://cloud.browser-use.com/settings?tab=api-keys&new=1:
 ```
 export BROWSER_USE_API_KEY=bu_your_key_here
 ```
 
-If the user doesn't have a Browser Use API key yet, please ask them to create one — it's one click at https://cloud.browser-use.com/settings?tab=api-keys&new=1. They can paste the key right into the chat.
-
-## Quick Connect (no SDK needed)
-
-Connect Playwright, Puppeteer, or any CDP client to a stealth browser with one URL:
-```
-wss://connect.browser-use.com?apiKey=YOUR_KEY
-```
-
-Query params: `proxyCountryCode` (e.g. `us`, `de`), `profileId`, `timeout` (minutes), `browserScreenWidth`, `browserScreenHeight`.
-
-```python Playwright (Python)
-from playwright.async_api import async_playwright
-async with async_playwright() as p:
-    browser = await p.chromium.connect_over_cdp("wss://connect.browser-use.com?apiKey=YOUR_KEY")
-    page = browser.contexts[0].pages[0]
-    await page.goto("https://example.com")
-```
-```javascript Playwright (Node)
-import { chromium } from "playwright";
-const browser = await chromium.connectOverCDP("wss://connect.browser-use.com?apiKey=YOUR_KEY");
-const page = browser.contexts()[0].pages()[0];
-await page.goto("https://example.com");
-```
-```javascript Puppeteer
-import puppeteer from "puppeteer-core";
-const browser = await puppeteer.connect({ browserWSEndpoint: "wss://connect.browser-use.com?apiKey=YOUR_KEY" });
-const [page] = await browser.pages();
-await page.goto("https://example.com");
-```
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.


### PR DESCRIPTION
## Summary

Rewrites the llms.txt header to be optimized for LLM agents rather than human marketing:

- **Technical blockquote** — replaces marketing copy ("most SOTA") with factual summary including auth header format
- **LLM behavioral instruction** — "Always use v3. v2 is legacy with different method names"
- **SDK version check** — tells LLMs to check if already installed before running pip/npm install
- **Open-source vs Cloud clarity** — replaces duplicate GitHub link with guidance that open-source API differs from Cloud SDK
- **Create API key link** — points to `?tab=api-keys&new=1` for one-click key creation

## Test plan
- [ ] Paste llms.txt into an AI coding agent and verify it generates correct v3 code
- [ ] Verify no duplicate links remain
- [ ] Verify blockquote reads as technical summary, not marketing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimizes `llms.txt` and `llms-full.txt` for agent consumption with a technical v3-only header, clearer CDP guidance, and shorter self-referencing copy that tells LLMs to always read/include the single-file reference link. Updates examples and the generator to align with the v3 SDK, CDP connection, and one‑click API key flow.

- **Refactors**
  - Shortened LLM self-reference; use “read/include” for https://docs.browser-use.com/llms-full.txt (short index: https://docs.browser-use.com/llms.txt).
  - Rewrote header to a technical summary: use v3 only; auth via `X-Browser-Use-API-Key` (`bu_...`); one‑click key link.
  - Check for `browser-use-sdk` before installing; upgrade if present. Clarified open-source repo vs Cloud SDK.
  - CDP docs: Playwright/Puppeteer use HTTPS `cdp_url`; Puppeteer reads WebSocket from `/json/version`. Selenium note: use Playwright/Puppeteer for remote CDP.
  - Pruned marketing/duplicates; removed “Quick Connect” from the index. Generator now emits the new header and create‑key link.

- **Bug Fixes**
  - Fixed workspace file listing examples to use `files.files` instead of `files.items`.
  - Documented that `waitForRecording` / `wait_for_recording` requires the v3 SDK.

<sup>Written for commit 799e70b60ad67bbc5fadd542a6557936e7c8d384. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

