### PR TITLE
Fix delete_file docs: path is keyword-only in Python SDK

### DIFF
--- a/docs/cloud/agent/workspaces.mdx
+++ b/docs/cloud/agent/workspaces.mdx
@@ -167,7 +167,7 @@ for f in files.files:
     print(f.path, f.size)
 
 # Delete a single file
-await client.workspaces.delete_file(workspace.id, "old-report.pdf")
+await client.workspaces.delete_file(workspace.id, path="old-report.pdf")
 
 # Check workspace storage usage
 size = await client.workspaces.size(workspace.id)


### PR DESCRIPTION
Python SDK defines `delete_file(workspace_id, *, path)` with `path` as keyword-only, but docs showed `delete_file(workspace.id, "old-report.pdf")` (positional). Fixed to `delete_file(workspace.id, path="old-report.pdf")`.

Last remaining snippet failure from Round 5 docs audit (20/21 → 21/21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Python SDK docs for `delete_file`: `path` is keyword-only. Updated the example to use `path="old-report.pdf"` to prevent a TypeError when copy-pasted.

<sup>Written for commit 568e987309d4fbc9ce4f74ce9309087da7e3bb13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

