### PR TITLE
Add concurrent scraping example with structured output

### DIFF
--- a/docs/cloud/agent/structured-output.mdx
+++ b/docs/cloud/agent/structured-output.mdx
@@ -55,3 +55,75 @@ for (const post of result.output.posts) {
 }
 ```
 </CodeGroup>
+
+## Scrape multiple sites concurrently
+
+Each `client.run()` call creates its own session, so you can run them in parallel with `asyncio.gather` (Python) or `Promise.all` (TypeScript). Every result is fully typed.
+
+<CodeGroup>
+```python Python
+import asyncio
+from browser_use_sdk.v3 import AsyncBrowserUse
+from pydantic import BaseModel
+
+class Product(BaseModel):
+    name: str
+    price: str
+    url: str
+
+class Results(BaseModel):
+    products: list[Product]
+
+async def main():
+    client = AsyncBrowserUse()
+
+    sites = [
+        "Find the top 3 laptops on amazon.com with their prices",
+        "Find the top 3 laptops on bestbuy.com with their prices",
+        "Find the top 3 laptops on newegg.com with their prices",
+    ]
+
+    results = await asyncio.gather(*[
+        client.run(task, output_schema=Results)
+        for task in sites
+    ])
+
+    for result in results:
+        for p in result.output.products:
+            print(f"{p.name} — {p.price}")
+
+asyncio.run(main())
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+import { z } from "zod";
+
+const Product = z.object({
+  name: z.string(),
+  price: z.string(),
+  url: z.string(),
+});
+
+const Results = z.object({
+  products: z.array(Product),
+});
+
+const client = new BrowserUse();
+
+const sites = [
+  "Find the top 3 laptops on amazon.com with their prices",
+  "Find the top 3 laptops on bestbuy.com with their prices",
+  "Find the top 3 laptops on newegg.com with their prices",
+];
+
+const results = await Promise.all(
+  sites.map((task) => client.run(task, { schema: Results }))
+);
+
+for (const result of results) {
+  for (const p of result.output.products) {
+    console.log(`${p.name} — ${p.price}`);
+  }
+}
+```
+</CodeGroup>

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -21,6 +21,19 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 ```
 
 
+Concurrent scraping — each `run()` creates its own session, so run them in parallel:
+```python
+results = await asyncio.gather(*[
+    client.run(task, output_schema=MySchema)
+    for task in ["Scrape site A", "Scrape site B", "Scrape site C"]
+])
+```
+```javascript
+const results = await Promise.all(
+  tasks.map((task) => client.run(task, { schema: MySchema }))
+);
+```
+
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -21,6 +21,19 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 ```
 
 
+Concurrent scraping — each `run()` creates its own session, so run them in parallel:
+```python
+results = await asyncio.gather(*[
+    client.run(task, output_schema=MySchema)
+    for task in ["Scrape site A", "Scrape site B", "Scrape site C"]
+])
+```
+```javascript
+const results = await Promise.all(
+  tasks.map((task) => client.run(task, { schema: MySchema }))
+);
+```
+
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.


### PR DESCRIPTION
5/10 creative test agents needed concurrency patterns but couldn't find any in the docs.

## Changes

**Structured output page** — added a full "Scrape multiple sites concurrently" section with:
- Python: `asyncio.gather` + Pydantic schema (3 sites, typed products)
- TypeScript: `Promise.all` + Zod schema (same pattern)

**llms.txt** (both root + cloud) — added compact concurrency snippet so LLMs discover the pattern immediately.

The example scrapes 3 e-commerce sites for laptop prices concurrently, returning typed `Product` objects. Real, practical, copy-paste ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a concurrent scraping example with structured output in Python and TypeScript. Lets users run multiple `client.run()` sessions in parallel and return typed `Product` results.

- **New Features**
  - Structured-output docs: new “Scrape multiple sites concurrently” example (3 e-commerce sites; typed `Product` list).
  - Python uses `asyncio.gather` with `pydantic`; TypeScript uses `Promise.all` with `zod`.
  - Added compact concurrency snippets to `docs/llms.txt` and `docs/cloud/llms.txt` for quick discovery.

<sup>Written for commit 981afe4678edaff6f0ccf7431d00ef3392f6b61c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

