### PR TITLE
chore: update OpenAPI v3 spec + llms.txt for cache_script

### DIFF
--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -474,7 +474,7 @@ for f in files.files:
 print(f.path, f.size)
 
 # Delete a single file
-await client.workspaces.delete_file(workspace.id, "old-report.pdf")
+await client.workspaces.delete_file(workspace.id, path="old-report.pdf")
 
 # Check workspace storage usage
 size = await client.workspaces.size(workspace.id)
@@ -496,6 +496,238 @@ await client.workspaces.deleteFile(workspace.id, "old-report.pdf");
 You can also manage workspaces from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=workspaces).
 
   Deleting a workspace permanently removes all its files. This cannot be undone.
+
+
+# Deterministic rerun
+Source: https://docs.browser-use.com/cloud/agent/cache-script
+
+
+Deterministic rerun lets you run a browser task once with a full agent, then **re-execute the same task instantly** using a cached script — no LLM, up to 99% cheaper.
+
+## Quick start
+
+Use `{{double brackets}}` around values that can change between runs. The first call runs the full agent. Every subsequent call with the same template uses the cached script.
+
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+workspace = await client.workspaces.create(name="my-scraper")
+
+# First call — agent explores, creates script (~$0.10, ~60s)
+result = await client.run(
+"Get the top {{5}} stories from https://news.ycombinator.com as JSON",
+workspace_id=str(workspace.id),
+)
+
+# Second call — cached script, different param ($0 LLM, ~5s)
+result2 = await client.run(
+"Get the top {{10}} stories from https://news.ycombinator.com as JSON",
+workspace_id=str(workspace.id),
+)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+
+const client = new BrowserUse();
+const workspace = await client.workspaces.create({ name: "my-scraper" });
+
+// First call — agent explores, creates script (~$0.10, ~60s)
+const result = await client.run(
+  "Get the top {{5}} stories from https://news.ycombinator.com as JSON",
+  { workspaceId: workspace.id },
+);
+
+// Second call — cached script, different param ($0 LLM, ~5s)
+const result2 = await client.run(
+  "Get the top {{10}} stories from https://news.ycombinator.com as JSON",
+  { workspaceId: workspace.id },
+);
+```
+
+## How it works
+
+The brackets mark which parts are parameters:
+
+```
+"Get prices from {{example.com}} for {{electronics}}"
+```
+
+- `{{example.com}}` → parameter 1
+- `{{electronics}}` → parameter 2
+
+The system strips the values to create a **template**: `"Get prices from {{}} for {{}}"`.
+Template `"Get prices from {{}} for {{}}"` is hashed to a unique ID like `a7f3b2c1`.
+The system checks the workspace for `scripts/a7f3b2c1.py`.
+If no script exists, the full agent runs your task. After completing it, the agent saves a standalone Python script that reproduces the result deterministically — no AI needed.
+If the script exists, it runs directly with the new parameter values. No agent, no LLM. Just the script in a sandbox with browser and proxy.
+
+## Auto-detection
+
+Caching activates **automatically** when both conditions are met:
+- The task contains `{{` and `}}`
+- A `workspace_id` is provided
+
+No extra flags needed. You can override with `cache_script`:
+
+| Value | Behavior |
+|-------|----------|
+| `None` (default) | Auto-detect from `{{brackets}}` + workspace |
+| `True` | Force-enable, even without brackets |
+| `False` | Force-disable, even if brackets are present |
+
+## Examples
+
+### Parameterized scraping
+
+Run once, then loop over different keywords at $0 LLM each:
+
+```python Python
+# Agent figures out how to scrape intro.co on first call
+result = await client.run(
+"Go to {{https://intro.co/marketplace}} and get all {{logistics}} experts as JSON",
+workspace_id=str(workspace.id),
+)
+
+# Instant reruns with different keywords
+for keyword in ["CEO", "marketing", "finance", "e-commerce"]:
+result = await client.run(
+    f"Go to {{{{https://intro.co/marketplace}}}} and get all {{{{{keyword}}}}} experts as JSON",
+    workspace_id=str(workspace.id),
+)
+print(f"{keyword}: {len(result.output)} experts, LLM cost: ${result.llm_cost_usd}")
+```
+```typescript TypeScript
+// Agent figures out how to scrape intro.co on first call
+let result = await client.run(
+  "Go to {{https://intro.co/marketplace}} and get all {{logistics}} experts as JSON",
+  { workspaceId: workspace.id },
+);
+
+// Instant reruns with different keywords
+for (const keyword of ["CEO", "marketing", "finance", "e-commerce"]) {
+  result = await client.run(
+`Go to {{https://intro.co/marketplace}} and get all {{${keyword}}} experts as JSON`,
+{ workspaceId: workspace.id },
+  );
+  console.log(`${keyword}: ${result.output.length} experts`);
+}
+```
+
+### No parameters — cache the exact task
+
+Append empty brackets `{{}}` to signal "cache this exact task":
+
+```python Python
+result = await client.run(
+"Get the current Bitcoin price from coinmarketcap.com {{}}",
+workspace_id=str(workspace.id),
+)
+
+# Same task again — cached
+result2 = await client.run(
+"Get the current Bitcoin price from coinmarketcap.com {{}}",
+workspace_id=str(workspace.id),
+)
+```
+```typescript TypeScript
+let result = await client.run(
+  "Get the current Bitcoin price from coinmarketcap.com {{}}",
+  { workspaceId: workspace.id },
+);
+
+// Same task again — cached
+result = await client.run(
+  "Get the current Bitcoin price from coinmarketcap.com {{}}",
+  { workspaceId: workspace.id },
+);
+```
+
+### Multiple parameters
+
+```python Python
+result = await client.run(
+"Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{Germany,France,Japan}}",
+workspace_id=str(workspace.id),
+)
+
+# Different countries — cached
+result2 = await client.run(
+"Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{US,UK,Brazil}}",
+workspace_id=str(workspace.id),
+)
+```
+```typescript TypeScript
+let result = await client.run(
+  "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{Germany,France,Japan}}",
+  { workspaceId: workspace.id },
+);
+
+// Different countries — cached
+result = await client.run(
+  "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{US,UK,Brazil}}",
+  { workspaceId: workspace.id },
+);
+```
+
+### Force enable / disable
+
+```python Python
+# Force-enable without brackets
+result = await client.run(
+"Get the top stories from Hacker News",
+workspace_id=str(workspace.id),
+cache_script=True,
+)
+
+# Force-disable even with brackets
+result = await client.run(
+"Explain what {{templates}} means in Jinja",
+workspace_id=str(workspace.id),
+cache_script=False,
+)
+```
+```typescript TypeScript
+// Force-enable without brackets
+let result = await client.run(
+  "Get the top stories from Hacker News",
+  { workspaceId: workspace.id, cacheScript: true },
+);
+
+// Force-disable even with brackets
+result = await client.run(
+  "Explain what {{templates}} means in Jinja",
+  { workspaceId: workspace.id, cacheScript: false },
+);
+```
+
+## Inspecting cached scripts
+
+You can download and inspect the scripts the agent created:
+
+```python Python
+files = await client.workspaces.files(workspace.id, prefix="scripts/")
+for f in files.files:
+print(f"{f.path}  ({f.size} bytes)")
+
+# Download a script to inspect it
+await client.workspaces.download(workspace.id, "scripts/a7f3b2c1.py", to="./my_script.py")
+```
+```typescript TypeScript
+const files = await client.workspaces.files(workspace.id, { prefix: "scripts/" });
+for (const f of files.files) {
+  console.log(`${f.path}  (${f.size} bytes)`);
+}
+```
+
+## Cost comparison
+
+| | LLM cost | Browser + proxy | Time |
+|---|---|---|---|
+| First call (agent) | ~$0.05–1.00 | Yes | ~30–120s |
+| Cached calls | **$0** | Yes | ~3–10s |
+
+The browser and proxy still run for cached calls (the script may need them), so there is a small infrastructure cost per execution. LLM cost drops to zero.
 
 
 # Human in the loop

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -31,6 +31,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 - [Follow-up tasks](https://docs.browser-use.com/cloud/agent/follow-up-tasks): Run multiple tasks in the same browser session.
 - [Live messages](https://docs.browser-use.com/cloud/agent/streaming): Stream the agent's messages in real time to build custom UIs or monitor progress.
 - [Workspaces & files](https://docs.browser-use.com/cloud/agent/workspaces): Upload files for the agent, download files the agent creates.
+- [Deterministic rerun](https://docs.browser-use.com/cloud/agent/cache-script): Run a task once, then re-execute it for $0 LLM cost.
 - [Human in the loop](https://docs.browser-use.com/cloud/agent/human-in-the-loop): Let a human interact with the live browser while the agent is running. Useful for approvals, payments, complex auth flows, or reviewing agent work before continuing.
 
 ## Browser

--- a/docs/cloud/openapi/v3.json
+++ b/docs/cloud/openapi/v3.json
@@ -78,9 +78,11 @@
                         "schema": {
                             "type": "integer",
                             "minimum": 1,
+                            "description": "Page number (1-indexed).",
                             "default": 1,
                             "title": "Page"
-                        }
+                        },
+                        "description": "Page number (1-indexed)."
                     },
                     {
                         "name": "page_size",
@@ -90,9 +92,11 @@
                             "type": "integer",
                             "maximum": 100,
                             "minimum": 1,
+                            "description": "Number of sessions per page (max 100).",
                             "default": 20,
                             "title": "Page Size"
-                        }
+                        },
+                        "description": "Number of sessions per page (max 100)."
                     }
                 ],
                 "responses": {
@@ -344,9 +348,11 @@
                             "type": "integer",
                             "maximum": 100,
                             "minimum": 1,
+                            "description": "Maximum number of messages to return (max 100).",
                             "default": 10,
                             "title": "Limit"
-                        }
+                        },
+                        "description": "Maximum number of messages to return (max 100)."
                     }
                 ],
                 "responses": {
@@ -1479,172 +1485,6 @@
                 }
             }
         },
-        "/sessions/{session_id}/files": {
-            "get": {
-                "tags": [
-                    "Files"
-                ],
-                "summary": "List Session Files",
-                "description": "List files in a session's workspace.\n\nReturns paginated file metadata. Pass includeUrls=true to get\npresigned download URLs (60s expiry) inline with each file.",
-                "operationId": "list_session_files_sessions__session_id__files_get",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "session_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Session Id"
-                        }
-                    },
-                    {
-                        "name": "prefix",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "default": "",
-                            "title": "Prefix"
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "integer",
-                            "maximum": 100,
-                            "minimum": 1,
-                            "default": 50,
-                            "title": "Limit"
-                        }
-                    },
-                    {
-                        "name": "cursor",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "anyOf": [
-                                {
-                                    "type": "string"
-                                },
-                                {
-                                    "type": "null"
-                                }
-                            ],
-                            "title": "Cursor"
-                        }
-                    },
-                    {
-                        "name": "includeUrls",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean",
-                            "default": false,
-                            "title": "Includeurls"
-                        }
-                    },
-                    {
-                        "name": "shallow",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean",
-                            "default": false,
-                            "title": "Shallow"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/FileListResponse"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/sessions/{session_id}/files/upload": {
-            "post": {
-                "tags": [
-                    "Files"
-                ],
-                "summary": "Upload Session Files",
-                "description": "Get presigned PUT URLs for uploading files to a session's workspace.\n\nFiles are placed under ``uploads/`` in the session's S3 prefix. After\nreceiving the URLs, PUT each file directly to S3 using the returned\n``uploadUrl`` with the matching ``Content-Type`` header.",
-                "operationId": "upload_session_files_sessions__session_id__files_upload_post",
-                "security": [
-                    {
-                        "APIKeyHeader": []
-                    }
-                ],
-                "parameters": [
-                    {
-                        "name": "session_id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string",
-                            "format": "uuid",
-                            "title": "Session Id"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/FileUploadRequest"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/FileUploadResponse"
-                                }
-                            }
-                        }
-                    },
-                    "422": {
-                        "description": "Validation Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/HTTPValidationError"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/billing/account": {
             "get": {
                 "tags": [
@@ -2066,16 +1906,21 @@
                     "timed_out",
                     "error"
                 ],
-                "title": "BuAgentSessionStatus"
+                "title": "BuAgentSessionStatus",
+                "description": "Session lifecycle status. Progresses through: created \u2192 idle \u2192 running \u2192 idle \u2192 ... \u2192 stopped / timed_out / error.\n\n- `created`: Sandbox is starting up. The session is not yet ready to accept tasks.\n- `idle`: Sandbox is healthy and waiting for a task. You can dispatch a task or upload files.\n- `running`: A task is currently being executed by the agent.\n- `stopped`: Session was stopped \u2014 either explicitly via the stop endpoint, or automatically after task completion (when `keepAlive` is false).\n- `timed_out`: Session was cleaned up due to inactivity timeout.\n- `error`: Sandbox failed to start or encountered an unrecoverable error."
             },
             "BuModel": {
                 "type": "string",
                 "enum": [
                     "bu-mini",
                     "bu-max",
-                    "bu-ultra"
+                    "bu-ultra",
+                    "gemini-3-flash",
+                    "claude-sonnet-4.6",
+                    "claude-opus-4.6"
                 ],
-                "title": "BuModel"
+                "title": "BuModel",
+                "description": "The model to use for the agent. Each model has different capabilities and pricing.\n\n- `bu-mini` / `gemini-3-flash`: Gemini 3 Flash \u2014 fast and cost-effective. Best for simple, well-defined tasks like form filling or data extraction.\n- `bu-max` / `claude-sonnet-4.6`: Claude Sonnet 4.6 \u2014 balanced performance. Best for multi-step workflows that require reasoning and decision-making.\n- `bu-ultra` / `claude-opus-4.6`: Claude Opus 4.6 \u2014 most capable. Best for complex tasks that require advanced reasoning, long-horizon planning, or handling ambiguous instructions."
             },
             "CreateBrowserSessionRequest": {
                 "properties": {
@@ -2157,7 +2002,7 @@
                             }
                         ],
                         "title": "Custom Proxy",
-                        "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are only available on the Custom Enterprise plan."
+                        "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription."
                     },
                     "enableRecording": {
                         "type": "boolean",
@@ -2227,16 +2072,19 @@
                 "properties": {
                     "path": {
                         "type": "string",
-                        "title": "Path"
+                        "title": "Path",
+                        "description": "File path relative to the session workspace root."
                     },
                     "size": {
                         "type": "integer",
-                        "title": "Size"
+                        "title": "Size",
+                        "description": "File size in bytes."
                     },
                     "lastModified": {
                         "type": "string",
                         "format": "date-time",
-                        "title": "Lastmodified"
+                        "title": "Lastmodified",
+                        "description": "When the file was last modified."
                     },
                     "url": {
                         "anyOf": [
@@ -2247,7 +2095,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Url"
+                        "title": "Url",
+                        "description": "Presigned download URL (60s expiry). Only included when `includeUrls=true`."
                     }
                 },
                 "type": "object",
@@ -2285,11 +2134,13 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Nextcursor"
+                        "title": "Nextcursor",
+                        "description": "Cursor for the next page. Pass as the `cursor` query parameter to fetch the next page."
                     },
                     "hasMore": {
                         "type": "boolean",
                         "title": "Hasmore",
+                        "description": "Whether there are more files beyond this page.",
                         "default": false
                     }
                 },
@@ -2377,16 +2228,18 @@
                 "properties": {
                     "name": {
                         "type": "string",
-                        "title": "Name"
+                        "title": "Name",
+                        "description": "Original filename as requested."
                     },
                     "uploadUrl": {
                         "type": "string",
-                        "title": "Uploadurl"
+                        "title": "Uploadurl",
+                        "description": "Presigned PUT URL. Upload the file by sending a PUT request to this URL with the file content and matching Content-Type header. Expires after 5 minutes."
                     },
                     "path": {
                         "type": "string",
                         "title": "Path",
-                        "description": "S3-relative path, e.g. \"uploads/data.csv\""
+                        "description": "Path where the file will be stored in the workspace, e.g. \"uploads/data.csv\"."
                     }
                 },
                 "type": "object",
@@ -2430,11 +2283,13 @@
                             "$ref": "#/components/schemas/MessageResponse"
                         },
                         "type": "array",
-                        "title": "Messages"
+                        "title": "Messages",
+                        "description": "List of messages in chronological order."
                     },
                     "hasMore": {
                         "type": "boolean",
-                        "title": "Hasmore"
+                        "title": "Hasmore",
+                        "description": "Whether there are more messages available beyond this page. Use cursor-based pagination with the `after` or `before` query parameters to fetch more."
                     }
                 },
                 "type": "object",
@@ -2449,31 +2304,35 @@
                     "id": {
                         "type": "string",
                         "format": "uuid",
-                        "title": "Id"
+                        "title": "Id",
+                        "description": "Unique message identifier."
                     },
                     "sessionId": {
                         "type": "string",
                         "format": "uuid",
-                        "title": "Sessionid"
+                        "title": "Sessionid",
+                        "description": "ID of the session this message belongs to."
                     },
                     "role": {
                         "type": "string",
-                        "title": "Role"
+                        "title": "Role",
+                        "description": "Message role: \"human\" for user-submitted tasks, \"ai\" for agent actions and responses."
                     },
                     "data": {
                         "type": "string",
-                        "title": "Data"
+                        "title": "Data",
+                        "description": "Raw message content. Format depends on the message type \u2014 may be plain text, JSON, or structured action data."
                     },
                     "type": {
                         "type": "string",
                         "title": "Type",
-                        "description": "Coarse category: user_message, assistant_message, browser_action, file_operation, code_execution, integration, planning, completion, browser_action_result, browser_action_error, etc.",
+                        "description": "Message category. Common values: `user_message`, `assistant_message`, `browser_action`, `file_operation`, `code_execution`, `integration`, `planning`, `completion`, `browser_action_result`, `browser_action_error`.",
                         "default": ""
                     },
                     "summary": {
                         "type": "string",
                         "title": "Summary",
-                        "description": "One-liner human-readable description of the message (e.g. \"Navigating to google.com\", \"Clicking element #5\").",
+                        "description": "One-liner human-readable description of the message (e.g. \"Navigating to google.com\", \"Clicking element #5\"). Useful for building activity feeds.",
                         "default": ""
                     },
                     "screenshotUrl": {
@@ -2485,7 +2344,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Screenshoturl"
+                        "title": "Screenshoturl",
+                        "description": "Browser screenshot captured at the time of this message. Presigned URL, expires after 5 minutes."
                     },
                     "hidden": {
                         "type": "boolean",
@@ -2496,7 +2356,8 @@
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "title": "Createdat"
+                        "title": "Createdat",
+                        "description": "When this message was created."
                     }
                 },
                 "type": "object",
@@ -2507,7 +2368,8 @@
                     "data",
                     "createdAt"
                 ],
-                "title": "MessageResponse"
+                "title": "MessageResponse",
+                "description": "A single message from the session's message stream.\n\nMessages represent the agent's actions, observations, and decisions as it executes a task."
             },
             "PlanInfo": {
                 "properties": {
@@ -3036,11 +2898,13 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Task"
+                        "title": "Task",
+                        "description": "The natural-language instruction for the agent to execute (e.g. \"Go to amazon.com and find the best-rated wireless mouse under $50\"). Required when dispatching to an existing session."
                     },
                     "model": {
                         "$ref": "#/components/schemas/BuModel",
-                        "default": "bu-max"
+                        "description": "The model to use. \"gemini-3-flash\" is fast and cheap, \"claude-sonnet-4.6\" is balanced, \"claude-opus-4.6\" is most capable. See BuModel for details.",
+                        "default": "claude-sonnet-4.6"
                     },
                     "sessionId": {
                         "anyOf": [
@@ -3052,11 +2916,13 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Sessionid"
+                        "title": "Sessionid",
+                        "description": "ID of an existing idle session to dispatch the task to. If omitted, a new session is created."
                     },
                     "keepAlive": {
                         "type": "boolean",
                         "title": "Keepalive",
+                        "description": "If true, the session stays alive in idle state after the task completes instead of automatically stopping. This lets you dispatch follow-up tasks to the same session, preserving browser state and files.",
                         "default": false
                     },
                     "maxCostUsd": {
@@ -3072,7 +2938,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Maxcostusd"
+                        "title": "Maxcostusd",
+                        "description": "Maximum total cost in USD allowed for this session. The task will be stopped if this limit is reached. If omitted, a default limit applies (capped by your available balance)."
                     },
                     "profileId": {
                         "anyOf": [
@@ -3084,7 +2951,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Profileid"
+                        "title": "Profileid",
+                        "description": "ID of a browser profile to load into the session. Profiles persist cookies, local storage, and other browser state across sessions. Create profiles via the Profiles API."
                     },
                     "workspaceId": {
                         "anyOf": [
@@ -3096,7 +2964,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Workspaceid"
+                        "title": "Workspaceid",
+                        "description": "ID of a workspace to attach to the session. Workspaces provide persistent file storage that carries across sessions. Create workspaces via the Workspaces API."
                     },
                     "proxyCountryCode": {
                         "anyOf": [
@@ -3107,6 +2976,7 @@
                                 "type": "null"
                             }
                         ],
+                        "description": "Country code for the browser proxy (e.g. \"US\", \"DE\", \"JP\"). Set to null to disable the proxy. The proxy routes browser traffic through the specified country, useful for accessing geo-restricted content.",
                         "default": "us"
                     },
                     "outputSchema": {
@@ -3119,32 +2989,49 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Outputschema"
+                        "title": "Outputschema",
+                        "description": "A JSON Schema that the agent's final output must conform to. When set, the agent will return structured data matching this schema in the `output` field of the response. Example: {\"type\": \"object\", \"properties\": {\"price\": {\"type\": \"number\"}, \"title\": {\"type\": \"string\"}}}."
                     },
                     "enableScheduledTasks": {
                         "type": "boolean",
                         "title": "Enablescheduledtasks",
+                        "description": "If true, the agent can create scheduled tasks that run on a recurring basis (e.g. \"every Monday morning, check my inbox and summarize new emails\"). Scheduled tasks are tied to your project and persist beyond the session. Note: all scheduled tasks are visible project-wide, so avoid enabling this in multi-user setups where task isolation is needed.",
                         "default": false
                     },
                     "enableRecording": {
                         "type": "boolean",
                         "title": "Enablerecording",
+                        "description": "If true, records a video of the browser session. The recording URLs will be available in the `recordingUrls` field of the session response after the task completes.",
                         "default": false
                     },
                     "skills": {
                         "type": "boolean",
                         "title": "Skills",
+                        "description": "If true, enables built-in agent skills like Google Sheets integration and file management. Set to false to restrict the agent to browser-only actions.",
                         "default": true
                     },
                     "agentmail": {
                         "type": "boolean",
                         "title": "Agentmail",
+                        "description": "If true, provisions a temporary email inbox (via AgentMail) for the session. The email address is available in the `agentmailEmail` field of the session response. Useful for tasks that require email verification or sign-ups.",
                         "default": true
+                    },
+                    "cacheScript": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cachescript",
+                        "description": "Controls deterministic script caching. `null` (default): auto-detected \u2014 enabled when the task contains `{{value}}` brackets and a workspace is attached. `true`: force-enable script caching even without brackets (caches the exact task). `false`: force-disable, even if brackets are present. When active, the first call runs the full agent and saves a reusable script. Subsequent calls with the same task template execute the cached script with $0 LLM cost. Requires workspace_id when enabled. Example: \"Get prices from {{https://example.com}} for {{electronics}}\"."
                     }
                 },
                 "type": "object",
                 "title": "RunTaskRequest",
-                "description": "Unified request for creating a session or dispatching a task.\n\n- Without session_id + without task: creates a new idle session (for file uploads, etc.)\n- Without session_id + with task: creates a new session and dispatches the task\n- With session_id + with task: dispatches the task to an existing idle session\n- With session_id + without task: 422 (task required when dispatching to existing session)"
+                "description": "Create a new session, dispatch a task, or both.\n\n- **No `sessionId` + no `task`**: creates an idle session (useful for uploading files before running a task).\n- **No `sessionId` + `task`**: creates a new session and immediately runs the task.\n- **`sessionId` + `task`**: dispatches the task to an existing idle session.\n- **`sessionId` + no `task`**: returns 422 \u2014 a task is required when targeting an existing session."
             },
             "SessionListResponse": {
                 "properties": {
@@ -3153,19 +3040,23 @@
                             "$ref": "#/components/schemas/SessionResponse"
                         },
                         "type": "array",
-                        "title": "Sessions"
+                        "title": "Sessions",
+                        "description": "List of sessions."
                     },
                     "total": {
                         "type": "integer",
-                        "title": "Total"
+                        "title": "Total",
+                        "description": "Total number of sessions matching the query."
                     },
                     "page": {
                         "type": "integer",
-                        "title": "Page"
+                        "title": "Page",
+                        "description": "Current page number (1-indexed)."
                     },
                     "pageSize": {
                         "type": "integer",
-                        "title": "Pagesize"
+                        "title": "Pagesize",
+                        "description": "Number of sessions per page."
                     }
                 },
                 "type": "object",
@@ -3194,13 +3085,16 @@
                     "id": {
                         "type": "string",
                         "format": "uuid",
-                        "title": "Id"
+                        "title": "Id",
+                        "description": "Unique session identifier."
                     },
                     "status": {
-                        "$ref": "#/components/schemas/BuAgentSessionStatus"
+                        "$ref": "#/components/schemas/BuAgentSessionStatus",
+                        "description": "Current session lifecycle status. Progresses through: `created` (sandbox starting) \u2192 `idle` (ready, waiting for task) \u2192 `running` (task executing) \u2192 `stopped` / `timed_out` / `error`. Poll this field to track progress."
                     },
                     "model": {
-                        "$ref": "#/components/schemas/BuModel"
+                        "$ref": "#/components/schemas/BuModel",
+                        "description": "The model tier used for this session."
                     },
                     "title": {
                         "anyOf": [
@@ -3211,7 +3105,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Title"
+                        "title": "Title",
+                        "description": "Auto-generated short title summarizing the task. Available after the task starts running."
                     },
                     "output": {
                         "anyOf": [
@@ -3220,7 +3115,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Output"
+                        "title": "Output",
+                        "description": "The agent's final output. If `outputSchema` was provided, this will be structured data conforming to that schema. Otherwise it may be a free-form string or null. Populated once the task completes, regardless of whether `isTaskSuccessful` is true or false."
                     },
                     "outputSchema": {
                         "anyOf": [
@@ -3232,11 +3128,13 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Outputschema"
+                        "title": "Outputschema",
+                        "description": "The JSON Schema that was requested for structured output, if any."
                     },
                     "stepCount": {
                         "type": "integer",
                         "title": "Stepcount",
+                        "description": "Number of steps the agent has executed so far.",
                         "default": 0
                     },
                     "lastStepSummary": {
@@ -3248,7 +3146,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Laststepsummary"
+                        "title": "Laststepsummary",
+                        "description": "Human-readable summary of the most recent agent step (e.g. \"Clicking the Submit button\"). Useful for showing real-time progress."
                     },
                     "isTaskSuccessful": {
                         "anyOf": [
@@ -3259,7 +3158,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Istasksuccessful"
+                        "title": "Istasksuccessful",
+                        "description": "Whether the task completed successfully. `true` if the agent achieved the goal, `false` if it failed or gave up, `null` if the task is still running or no task was dispatched."
                     },
                     "liveUrl": {
                         "anyOf": [
@@ -3270,7 +3170,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Liveurl"
+                        "title": "Liveurl",
+                        "description": "URL to view the live browser session. Available immediately on session creation \u2014 can be embedded in an iframe to show the browser in real time."
                     },
                     "recordingUrls": {
                         "items": {
@@ -3278,6 +3179,7 @@
                         },
                         "type": "array",
                         "title": "Recordingurls",
+                        "description": "URLs to download session recordings. Only populated if `enableRecording` was set to true and the task has completed.",
                         "default": []
                     },
                     "profileId": {
@@ -3290,7 +3192,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Profileid"
+                        "title": "Profileid",
+                        "description": "ID of the browser profile loaded in this session, if any."
                     },
                     "workspaceId": {
                         "anyOf": [
@@ -3302,7 +3205,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Workspaceid"
+                        "title": "Workspaceid",
+                        "description": "ID of the workspace attached to this session, if any."
                     },
                     "proxyCountryCode": {
                         "anyOf": [
@@ -3312,7 +3216,8 @@
                             {
                                 "type": "null"
                             }
-                        ]
+                        ],
+                        "description": "Country code of the proxy used for this session, or null if no proxy."
                     },
                     "maxCostUsd": {
                         "anyOf": [
@@ -3324,46 +3229,54 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Maxcostusd"
+                        "title": "Maxcostusd",
+                        "description": "Maximum cost limit in USD set for this session."
                     },
                     "totalInputTokens": {
                         "type": "integer",
                         "title": "Totalinputtokens",
+                        "description": "Total LLM input tokens consumed by this session.",
                         "default": 0
                     },
                     "totalOutputTokens": {
                         "type": "integer",
                         "title": "Totaloutputtokens",
+                        "description": "Total LLM output tokens consumed by this session.",
                         "default": 0
                     },
                     "proxyUsedMb": {
                         "type": "string",
                         "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                         "title": "Proxyusedmb",
+                        "description": "Proxy bandwidth used in megabytes.",
                         "default": "0"
                     },
                     "llmCostUsd": {
                         "type": "string",
                         "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                         "title": "Llmcostusd",
+                        "description": "Cost of LLM usage in USD.",
                         "default": "0"
                     },
                     "proxyCostUsd": {
                         "type": "string",
                         "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                         "title": "Proxycostusd",
+                        "description": "Cost of proxy bandwidth in USD.",
                         "default": "0"
                     },
                     "browserCostUsd": {
                         "type": "string",
                         "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                         "title": "Browsercostusd",
+                        "description": "Cost of browser compute time in USD.",
                         "default": "0"
                     },
                     "totalCostUsd": {
                         "type": "string",
                         "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
                         "title": "Totalcostusd",
+                        "description": "Total session cost in USD (LLM + proxy + browser).",
                         "default": "0"
                     },
                     "screenshotUrl": {
@@ -3375,7 +3288,8 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Screenshoturl"
+                        "title": "Screenshoturl",
+                        "description": "URL of the latest browser screenshot. This is a presigned URL that expires after 5 minutes. A new URL is generated each time you fetch the session."
                     },
                     "agentmailEmail": {
                         "anyOf": [
@@ -3386,17 +3300,20 @@
                                 "type": "null"
                             }
                         ],
-                        "title": "Agentmailemail"
+                        "title": "Agentmailemail",
+                        "description": "Temporary email address provisioned for this session (via AgentMail). Only present if `agentmail` was enabled."
                     },
                     "createdAt": {
                         "type": "string",
                         "format": "date-time",
-                        "title": "Createdat"
+                        "title": "Createdat",
+                        "description": "When the session was created."
                     },
                     "updatedAt": {
                         "type": "string",
                         "format": "date-time",
-                        "title": "Updatedat"
+                        "title": "Updatedat",
+                        "description": "When the session was last updated."
                     }
                 },
                 "type": "object",
@@ -3407,7 +3324,8 @@
                     "createdAt",
                     "updatedAt"
                 ],
-                "title": "SessionResponse"
+                "title": "SessionResponse",
+                "description": "Represents a session and its current state.\n\nPoll this endpoint to track task progress. The `status` field indicates the session lifecycle stage,\nand `output` contains the agent's structured result once the task completes."
             },
             "SessionTimeoutLimitExceededError": {
                 "properties": {
@@ -3425,6 +3343,7 @@
                 "properties": {
                     "strategy": {
                         "$ref": "#/components/schemas/StopStrategy",
+                        "description": "How to stop the session. Use \"task\" to stop only the current task and keep the session alive, or \"session\" to destroy the sandbox entirely.",
                         "default": "session"
                     }
                 },
@@ -3437,7 +3356,8 @@
                     "task",
                     "session"
                 ],
-                "title": "StopStrategy"
+                "title": "StopStrategy",
+                "description": "Strategy for stopping a session.\n\n- `task`: Stop the currently running task but keep the session alive in idle state. You can dispatch another task to the same session afterwards.\n- `session`: Stop the session entirely and destroy the sandbox. The session cannot be reused after this."
             },
             "TooManyConcurrentActiveSessionsError": {
                 "properties": {
@@ -3625,25 +3545,5 @@
                 "name": "X-Browser-Use-API-Key"
             }
         }
-    },
-    "tags": [
-        {
-            "name": "Sessions"
-        },
-        {
-            "name": "Browsers"
-        },
-        {
-            "name": "Profiles"
-        },
-        {
-            "name": "Workspaces"
-        },
-        {
-            "name": "Files"
-        },
-        {
-            "name": "Billing"
-        }
-    ]
+    }
 }

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -474,7 +474,7 @@ for f in files.files:
 print(f.path, f.size)
 
 # Delete a single file
-await client.workspaces.delete_file(workspace.id, "old-report.pdf")
+await client.workspaces.delete_file(workspace.id, path="old-report.pdf")
 
 # Check workspace storage usage
 size = await client.workspaces.size(workspace.id)
@@ -496,6 +496,238 @@ await client.workspaces.deleteFile(workspace.id, "old-report.pdf");
 You can also manage workspaces from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=workspaces).
 
   Deleting a workspace permanently removes all its files. This cannot be undone.
+
+
+# Deterministic rerun
+Source: https://docs.browser-use.com/cloud/agent/cache-script
+
+
+Deterministic rerun lets you run a browser task once with a full agent, then **re-execute the same task instantly** using a cached script — no LLM, up to 99% cheaper.
+
+## Quick start
+
+Use `{{double brackets}}` around values that can change between runs. The first call runs the full agent. Every subsequent call with the same template uses the cached script.
+
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+workspace = await client.workspaces.create(name="my-scraper")
+
+# First call — agent explores, creates script (~$0.10, ~60s)
+result = await client.run(
+"Get the top {{5}} stories from https://news.ycombinator.com as JSON",
+workspace_id=str(workspace.id),
+)
+
+# Second call — cached script, different param ($0 LLM, ~5s)
+result2 = await client.run(
+"Get the top {{10}} stories from https://news.ycombinator.com as JSON",
+workspace_id=str(workspace.id),
+)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+
+const client = new BrowserUse();
+const workspace = await client.workspaces.create({ name: "my-scraper" });
+
+// First call — agent explores, creates script (~$0.10, ~60s)
+const result = await client.run(
+  "Get the top {{5}} stories from https://news.ycombinator.com as JSON",
+  { workspaceId: workspace.id },
+);
+
+// Second call — cached script, different param ($0 LLM, ~5s)
+const result2 = await client.run(
+  "Get the top {{10}} stories from https://news.ycombinator.com as JSON",
+  { workspaceId: workspace.id },
+);
+```
+
+## How it works
+
+The brackets mark which parts are parameters:
+
+```
+"Get prices from {{example.com}} for {{electronics}}"
+```
+
+- `{{example.com}}` → parameter 1
+- `{{electronics}}` → parameter 2
+
+The system strips the values to create a **template**: `"Get prices from {{}} for {{}}"`.
+Template `"Get prices from {{}} for {{}}"` is hashed to a unique ID like `a7f3b2c1`.
+The system checks the workspace for `scripts/a7f3b2c1.py`.
+If no script exists, the full agent runs your task. After completing it, the agent saves a standalone Python script that reproduces the result deterministically — no AI needed.
+If the script exists, it runs directly with the new parameter values. No agent, no LLM. Just the script in a sandbox with browser and proxy.
+
+## Auto-detection
+
+Caching activates **automatically** when both conditions are met:
+- The task contains `{{` and `}}`
+- A `workspace_id` is provided
+
+No extra flags needed. You can override with `cache_script`:
+
+| Value | Behavior |
+|-------|----------|
+| `None` (default) | Auto-detect from `{{brackets}}` + workspace |
+| `True` | Force-enable, even without brackets |
+| `False` | Force-disable, even if brackets are present |
+
+## Examples
+
+### Parameterized scraping
+
+Run once, then loop over different keywords at $0 LLM each:
+
+```python Python
+# Agent figures out how to scrape intro.co on first call
+result = await client.run(
+"Go to {{https://intro.co/marketplace}} and get all {{logistics}} experts as JSON",
+workspace_id=str(workspace.id),
+)
+
+# Instant reruns with different keywords
+for keyword in ["CEO", "marketing", "finance", "e-commerce"]:
+result = await client.run(
+    f"Go to {{{{https://intro.co/marketplace}}}} and get all {{{{{keyword}}}}} experts as JSON",
+    workspace_id=str(workspace.id),
+)
+print(f"{keyword}: {len(result.output)} experts, LLM cost: ${result.llm_cost_usd}")
+```
+```typescript TypeScript
+// Agent figures out how to scrape intro.co on first call
+let result = await client.run(
+  "Go to {{https://intro.co/marketplace}} and get all {{logistics}} experts as JSON",
+  { workspaceId: workspace.id },
+);
+
+// Instant reruns with different keywords
+for (const keyword of ["CEO", "marketing", "finance", "e-commerce"]) {
+  result = await client.run(
+`Go to {{https://intro.co/marketplace}} and get all {{${keyword}}} experts as JSON`,
+{ workspaceId: workspace.id },
+  );
+  console.log(`${keyword}: ${result.output.length} experts`);
+}
+```
+
+### No parameters — cache the exact task
+
+Append empty brackets `{{}}` to signal "cache this exact task":
+
+```python Python
+result = await client.run(
+"Get the current Bitcoin price from coinmarketcap.com {{}}",
+workspace_id=str(workspace.id),
+)
+
+# Same task again — cached
+result2 = await client.run(
+"Get the current Bitcoin price from coinmarketcap.com {{}}",
+workspace_id=str(workspace.id),
+)
+```
+```typescript TypeScript
+let result = await client.run(
+  "Get the current Bitcoin price from coinmarketcap.com {{}}",
+  { workspaceId: workspace.id },
+);
+
+// Same task again — cached
+result = await client.run(
+  "Get the current Bitcoin price from coinmarketcap.com {{}}",
+  { workspaceId: workspace.id },
+);
+```
+
+### Multiple parameters
+
+```python Python
+result = await client.run(
+"Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{Germany,France,Japan}}",
+workspace_id=str(workspace.id),
+)
+
+# Different countries — cached
+result2 = await client.run(
+"Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{US,UK,Brazil}}",
+workspace_id=str(workspace.id),
+)
+```
+```typescript TypeScript
+let result = await client.run(
+  "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{Germany,France,Japan}}",
+  { workspaceId: workspace.id },
+);
+
+// Different countries — cached
+result = await client.run(
+  "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{US,UK,Brazil}}",
+  { workspaceId: workspace.id },
+);
+```
+
+### Force enable / disable
+
+```python Python
+# Force-enable without brackets
+result = await client.run(
+"Get the top stories from Hacker News",
+workspace_id=str(workspace.id),
+cache_script=True,
+)
+
+# Force-disable even with brackets
+result = await client.run(
+"Explain what {{templates}} means in Jinja",
+workspace_id=str(workspace.id),
+cache_script=False,
+)
+```
+```typescript TypeScript
+// Force-enable without brackets
+let result = await client.run(
+  "Get the top stories from Hacker News",
+  { workspaceId: workspace.id, cacheScript: true },
+);
+
+// Force-disable even with brackets
+result = await client.run(
+  "Explain what {{templates}} means in Jinja",
+  { workspaceId: workspace.id, cacheScript: false },
+);
+```
+
+## Inspecting cached scripts
+
+You can download and inspect the scripts the agent created:
+
+```python Python
+files = await client.workspaces.files(workspace.id, prefix="scripts/")
+for f in files.files:
+print(f"{f.path}  ({f.size} bytes)")
+
+# Download a script to inspect it
+await client.workspaces.download(workspace.id, "scripts/a7f3b2c1.py", to="./my_script.py")
+```
+```typescript TypeScript
+const files = await client.workspaces.files(workspace.id, { prefix: "scripts/" });
+for (const f of files.files) {
+  console.log(`${f.path}  (${f.size} bytes)`);
+}
+```
+
+## Cost comparison
+
+| | LLM cost | Browser + proxy | Time |
+|---|---|---|---|
+| First call (agent) | ~$0.05–1.00 | Yes | ~30–120s |
+| Cached calls | **$0** | Yes | ~3–10s |
+
+The browser and proxy still run for cached calls (the script may need them), so there is a small infrastructure cost per execution. LLM cost drops to zero.
 
 
 # Human in the loop

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -31,6 +31,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 - [Follow-up tasks](https://docs.browser-use.com/cloud/agent/follow-up-tasks): Run multiple tasks in the same browser session.
 - [Live messages](https://docs.browser-use.com/cloud/agent/streaming): Stream the agent's messages in real time to build custom UIs or monitor progress.
 - [Workspaces & files](https://docs.browser-use.com/cloud/agent/workspaces): Upload files for the agent, download files the agent creates.
+- [Deterministic rerun](https://docs.browser-use.com/cloud/agent/cache-script): Run a task once, then re-execute it for $0 LLM cost.
 - [Human in the loop](https://docs.browser-use.com/cloud/agent/human-in-the-loop): Let a human interact with the live browser while the agent is running. Useful for approvals, payments, complex auth flows, or reviewing agent work before continuing.
 
 ## Browser


### PR DESCRIPTION
## Summary
- Updated OpenAPI v3 spec from production (now includes `cacheScript` field on `RunTaskRequest`)
- Regenerated `llms.txt` and `llms-full.txt` (includes new "Deterministic rerun" page)

Follows the merge of browser-use/cloud#3748 and browser-use/sdk#113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the OpenAPI v3 spec and docs to add deterministic reruns via the new `cacheScript` option on `RunTaskRequest`, and include the new "Deterministic rerun" page in `llms.txt`/`llms-full.txt`.

- **New Features**
  - Added `cacheScript` to `RunTaskRequest` for deterministic reruns; auto-detects with `{{brackets}}` + workspace, and supports force on/off.
  - Updated `BuModel` with `gemini-3-flash`, `claude-sonnet-4.6`, `claude-opus-4.6`; default is now `claude-sonnet-4.6`.
  - Enriched schema descriptions and parameter docs (pagination, costs, statuses, messages, recording, proxies).
  - Regenerated `docs/cloud/llms*.txt` and `docs/llms*.txt` to include the "Deterministic rerun" page and fix a snippet to `delete_file(..., path="...")`.

- **Migration**
  - The session file endpoints `/sessions/{session_id}/files` and `/sessions/{session_id}/files/upload` are removed from the spec; use Workspaces file APIs instead.
  - Regenerate SDKs from the updated OpenAPI to get `cacheScript` and model changes.

<sup>Written for commit 193fb1abe791e442c1631d3ab13cc441d9616bfc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

