### PR TITLE
docs: add model selection page and promote FAQ in nav

### DIFF
--- a/docs/cloud/agent/models.mdx
+++ b/docs/cloud/agent/models.mdx
@@ -10,9 +10,7 @@ Pass `model` to select a model:
 | ----- | ---------- | --------------------- | ---------------------- |
 | Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$3.60 | \$18.00 |
 | Claude Opus 4.6 | `claude-opus-4-6` | \$6.00 | \$30.00 |
-| Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$3.60 | \$18.00 |
 | Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.60 | \$3.60 |
-| Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$2.40 | \$14.40 |
 
 <Tip>
   We recommend **Claude Sonnet 4.6** (`claude-sonnet-4-6`). It's the model we optimize for the most right now.

--- a/docs/cloud/agent/models.mdx
+++ b/docs/cloud/agent/models.mdx
@@ -1,0 +1,75 @@
+---
+title: Models
+description: "Choose the right model for your task."
+icon: microchip
+---
+
+## Available models
+
+| Model | API String | Best for |
+| ----- | ---------- | -------- |
+| **bu-ultra** | `bu-ultra` | Hardest tasks that need maximum accuracy |
+| **bu-max** (default) | `bu-max` | Complex multi-step workflows — best balance of capability and cost |
+| **bu-mini** | `bu-mini` | Simple tasks — faster and cheaper |
+
+Pass `model` to select a model:
+
+<CodeGroup>
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+result = await client.run(
+    "List the top 20 posts on Hacker News today with their points",
+    model="bu-ultra",
+)
+print(result.output)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+
+const client = new BrowserUse();
+const result = await client.run(
+  "List the top 20 posts on Hacker News today with their points",
+  { model: "bu-ultra" },
+);
+console.log(result.output);
+```
+```bash curl
+curl -X POST https://api.browser-use.com/api/v3/sessions \
+  -H "X-Browser-Use-API-Key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"task": "List the top 20 posts on Hacker News", "model": "bu-ultra"}'
+```
+</CodeGroup>
+
+## Third-party models
+
+You can also pass a third-party model directly:
+
+| Model | API String | Cost per Step |
+| ----- | ---------- | ------------- |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$0.05 |
+| Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$0.05 |
+| Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$0.03 |
+| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.01 |
+| O3 | `o3` | \$0.03 |
+
+<CodeGroup>
+```python Python
+result = await client.run(
+    "Extract all product prices from this page",
+    model="claude-sonnet-4-6",
+)
+```
+```typescript TypeScript
+const result = await client.run(
+  "Extract all product prices from this page",
+  { model: "claude-sonnet-4-6" },
+);
+```
+</CodeGroup>
+
+<Tip>
+  We recommend **Claude Sonnet 4.6** (`claude-sonnet-4-6`) if you want to use a third-party model directly. It's the model we optimize for the most right now.
+</Tip>

--- a/docs/cloud/agent/models.mdx
+++ b/docs/cloud/agent/models.mdx
@@ -4,15 +4,20 @@ description: "Choose the right model for your task."
 icon: microchip
 ---
 
-## Available models
-
-| Model | API String | Best for |
-| ----- | ---------- | -------- |
-| **bu-ultra** | `bu-ultra` | Hardest tasks that need maximum accuracy |
-| **bu-max** (default) | `bu-max` | Complex multi-step workflows — best balance of capability and cost |
-| **bu-mini** | `bu-mini` | Simple tasks — faster and cheaper |
-
 Pass `model` to select a model:
+
+| Model | API String | Cost per Step |
+| ----- | ---------- | ------------- |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$0.05 |
+| Claude Opus 4.6 | `claude-opus-4-6` | \$0.05 |
+| Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$0.05 |
+| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.01 |
+| Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$0.03 |
+| O3 | `o3` | \$0.03 |
+
+<Tip>
+  We recommend **Claude Sonnet 4.6** (`claude-sonnet-4-6`). It's the model we optimize for the most right now.
+</Tip>
 
 <CodeGroup>
 ```python Python
@@ -21,7 +26,7 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 client = AsyncBrowserUse()
 result = await client.run(
     "List the top 20 posts on Hacker News today with their points",
-    model="bu-ultra",
+    model="claude-sonnet-4-6",
 )
 print(result.output)
 ```
@@ -31,7 +36,7 @@ import { BrowserUse } from "browser-use-sdk/v3";
 const client = new BrowserUse();
 const result = await client.run(
   "List the top 20 posts on Hacker News today with their points",
-  { model: "bu-ultra" },
+  { model: "claude-sonnet-4-6" },
 );
 console.log(result.output);
 ```
@@ -39,37 +44,6 @@ console.log(result.output);
 curl -X POST https://api.browser-use.com/api/v3/sessions \
   -H "X-Browser-Use-API-Key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"task": "List the top 20 posts on Hacker News", "model": "bu-ultra"}'
+  -d '{"task": "List the top 20 posts on Hacker News", "model": "claude-sonnet-4-6"}'
 ```
 </CodeGroup>
-
-## Third-party models
-
-You can also pass a third-party model directly:
-
-| Model | API String | Cost per Step |
-| ----- | ---------- | ------------- |
-| Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$0.05 |
-| Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$0.05 |
-| Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$0.03 |
-| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.01 |
-| O3 | `o3` | \$0.03 |
-
-<CodeGroup>
-```python Python
-result = await client.run(
-    "Extract all product prices from this page",
-    model="claude-sonnet-4-6",
-)
-```
-```typescript TypeScript
-const result = await client.run(
-  "Extract all product prices from this page",
-  { model: "claude-sonnet-4-6" },
-);
-```
-</CodeGroup>
-
-<Tip>
-  We recommend **Claude Sonnet 4.6** (`claude-sonnet-4-6`) if you want to use a third-party model directly. It's the model we optimize for the most right now.
-</Tip>

--- a/docs/cloud/agent/models.mdx
+++ b/docs/cloud/agent/models.mdx
@@ -6,14 +6,13 @@ icon: microchip
 
 Pass `model` to select a model:
 
-| Model | API String | Cost per Step |
-| ----- | ---------- | ------------- |
-| Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$0.05 |
-| Claude Opus 4.6 | `claude-opus-4-6` | \$0.05 |
-| Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$0.05 |
-| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.01 |
-| Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$0.03 |
-| O3 | `o3` | \$0.03 |
+| Model | API String | Input (per 1M tokens) | Output (per 1M tokens) |
+| ----- | ---------- | --------------------- | ---------------------- |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$3.60 | \$18.00 |
+| Claude Opus 4.6 | `claude-opus-4-6` | \$6.00 | \$30.00 |
+| Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$3.60 | \$18.00 |
+| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.60 | \$3.60 |
+| Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$2.40 | \$14.40 |
 
 <Tip>
   We recommend **Claude Sonnet 4.6** (`claude-sonnet-4-6`). It's the model we optimize for the most right now.

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -126,14 +126,13 @@ Source: https://docs.browser-use.com/cloud/agent/models
 
 Pass `model` to select a model:
 
-| Model | API String | Cost per Step |
-| ----- | ---------- | ------------- |
-| Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$0.05 |
-| Claude Opus 4.6 | `claude-opus-4-6` | \$0.05 |
-| Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$0.05 |
-| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.01 |
-| Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$0.03 |
-| O3 | `o3` | \$0.03 |
+| Model | API String | Input (per 1M tokens) | Output (per 1M tokens) |
+| ----- | ---------- | --------------------- | ---------------------- |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$3.60 | \$18.00 |
+| Claude Opus 4.6 | `claude-opus-4-6` | \$6.00 | \$30.00 |
+| Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$3.60 | \$18.00 |
+| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.60 | \$3.60 |
+| Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$2.40 | \$14.40 |
 
   We recommend **Claude Sonnet 4.6** (`claude-sonnet-4-6`). It's the model we optimize for the most right now.
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -130,9 +130,7 @@ Pass `model` to select a model:
 | ----- | ---------- | --------------------- | ---------------------- |
 | Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$3.60 | \$18.00 |
 | Claude Opus 4.6 | `claude-opus-4-6` | \$6.00 | \$30.00 |
-| Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$3.60 | \$18.00 |
 | Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.60 | \$3.60 |
-| Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$2.40 | \$14.40 |
 
   We recommend **Claude Sonnet 4.6** (`claude-sonnet-4-6`). It's the model we optimize for the most right now.
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -520,7 +520,7 @@ await client.workspaces.delete_file(workspace.id, path="old-report.pdf")
 
 # Check workspace storage usage
 size = await client.workspaces.size(workspace.id)
-print(f"Used: {size}")
+print(f"Used: {size.used_bytes} bytes")
 ```
 ```typescript TypeScript
 // List all files
@@ -531,9 +531,13 @@ for (const f of files.files) {
 
 // Delete a single file
 await client.workspaces.deleteFile(workspace.id, "old-report.pdf");
+
+// Check workspace storage usage
+const size = await client.workspaces.size(workspace.id);
+console.log(`Used: ${size.usedBytes} bytes`);
 ```
 
-## Manage workspaces
+## Cloud dashboard
 
 You can also manage workspaces from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=workspaces).
 
@@ -781,6 +785,8 @@ Source: https://docs.browser-use.com/cloud/agent/human-in-the-loop
 - Human navigates a complex auth flow, then hands back to agent
 - Human reviews what the agent did before the agent continues
 
+  Sessions time out after 15 minutes of inactivity. The maximum session duration is 4 hours. If the human needs more time, send a lightweight follow-up task (e.g. "wait") to reset the inactivity timer.
+
 ## Flow
 
 1. Create a session — it stays alive automatically when you pass `session_id` to `run()`
@@ -993,7 +999,7 @@ Useful for human interaction or to see live what's happening.
 
 ```html
 <iframe
-  src="{live_url}"
+  src="{LIVE_URL}"
   width="1280"
   height="720"
   allow="autoplay"
@@ -1011,7 +1017,7 @@ For responsive sizing, use CSS instead of fixed dimensions:
 
 ```html
 <iframe
-  src="{live_url}"
+  src="{LIVE_URL}"
   style="width: 100%; aspect-ratio: 16/9; border: none; border-radius: 8px;"
   allow="autoplay"
 ></iframe>
@@ -1253,6 +1259,9 @@ profile = await client.profiles.create(name="user-id-1")
 session = await client.sessions.create(profile_id=profile.id)
 result = await client.run("Check browser-use github stars", session_id=session.id)
 print(result.output)
+
+# Always stop the session to persist profile state
+await client.sessions.stop(session.id)
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
@@ -1266,6 +1275,9 @@ const result = await client.run("Check browser-use github stars", {
   sessionId: session.id,
 });
 console.log(result.output);
+
+// Always stop the session to persist profile state
+await client.sessions.stop(session.id);
 ```
 
 View your profile IDs at [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=profiles).
@@ -1322,7 +1334,7 @@ await client.profiles.delete(profileId);
 
 - **Per-user profiles:** Create one profile per end-user. Query by name to get the profile ID, or store a mapping between your users and their profile IDs in your database.
 
-  Profile state is only saved when the session ends. Always call `sessions.stop()` when you are done — if a session is left open or times out, changes may not be persisted.
+  Profile state is only saved when the session ends. Always call `sessions.stop()` when you are done — if a session is left open or times out, changes may not be persisted. Every code path that uses a profile must stop the session, including error handlers.
 
 
 # Sync local and cloud cookies

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -120,6 +120,51 @@ The best SOTA browser agent — see our [online Mind2Web benchmark](https://brow
 If you are an LLM, read/include [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs.
 
 
+# Models
+Source: https://docs.browser-use.com/cloud/agent/models
+
+
+Pass `model` to select a model:
+
+| Model | API String | Cost per Step |
+| ----- | ---------- | ------------- |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$0.05 |
+| Claude Opus 4.6 | `claude-opus-4-6` | \$0.05 |
+| Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$0.05 |
+| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.01 |
+| Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$0.03 |
+| O3 | `o3` | \$0.03 |
+
+  We recommend **Claude Sonnet 4.6** (`claude-sonnet-4-6`). It's the model we optimize for the most right now.
+
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+result = await client.run(
+"List the top 20 posts on Hacker News today with their points",
+model="claude-sonnet-4-6",
+)
+print(result.output)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+
+const client = new BrowserUse();
+const result = await client.run(
+  "List the top 20 posts on Hacker News today with their points",
+  { model: "claude-sonnet-4-6" },
+);
+console.log(result.output);
+```
+```bash curl
+curl -X POST https://api.browser-use.com/api/v3/sessions \
+  -H "X-Browser-Use-API-Key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"task": "List the top 20 posts on Hacker News", "model": "claude-sonnet-4-6"}'
+```
+
+
 # Structured output
 Source: https://docs.browser-use.com/cloud/agent/structured-output
 

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -5,7 +5,6 @@
 - Dashboard: https://cloud.browser-use.com
 - Create API key: https://cloud.browser-use.com/settings?tab=api-keys&new=1
 - Docs: https://docs.browser-use.com
-- Full SDK reference (all code examples): https://docs.browser-use.com/cloud/llms-full.txt
 - OpenAPI spec (v3): https://docs.browser-use.com/cloud/openapi/v3.json
 - Chat UI example: https://docs.browser-use.com/cloud/tutorials/chat-ui — Full end-to-end example with live browser, streaming, auth. Best starting point to build a prototype.
 - Open-source repo: https://github.com/browser-use/browser-use — The open-source Python library. Note: the open-source API is different from the Cloud SDK. If you want the easiest path to production with managed infrastructure, use the Cloud SDK below.
@@ -21,27 +20,6 @@ Set API key (starts with `bu_`). If the user doesn't have one yet, they can crea
 export BROWSER_USE_API_KEY=bu_your_key_here
 ```
 
-## Quick start
-
-```python
-import asyncio
-from browser_use_sdk.v3 import AsyncBrowserUse
-
-async def main():
-    client = AsyncBrowserUse()
-    result = await client.run("List the top 20 posts on Hacker News today with their points")
-    print(result.output)
-
-asyncio.run(main())
-```
-
-```typescript
-import { BrowserUse } from "browser-use-sdk/v3";
-
-const client = new BrowserUse();
-const result = await client.run("List the top 20 posts on Hacker News today with their points");
-console.log(result.output);
-```
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.
@@ -69,6 +47,7 @@ console.log(result.output);
 - [2FA](https://docs.browser-use.com/cloud/guides/2fa): Best practices for handling two-factor authentication in automated browser sessions.
 
 ## More
+- [FAQ](https://docs.browser-use.com/cloud/faq): Common questions and solutions.
 
 ## Integrations
 - [OpenClaw](https://docs.browser-use.com/cloud/tutorials/integrations/openclaw): Give OpenClaw agents browser automation with Browser Use — via CDP or the CLI skill.
@@ -78,7 +57,6 @@ console.log(result.output);
 
 ## Tutorials
 - [Chat UI](https://docs.browser-use.com/cloud/tutorials/chat-ui): Full end-to-end example. Build a chat UI with live browser preview, follow-up tasks, recording, and streaming messages.
-- [FAQ](https://docs.browser-use.com/cloud/faq): Common questions and solutions.
 
 ## Legacy (v2)
 - [Agent (v2)](https://docs.browser-use.com/cloud/legacy/agent): V2 agent models and file handling.

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -49,6 +49,7 @@ console.log(result.output);
 
 ## Agent
 - [Introduction](https://docs.browser-use.com/cloud/agent/quickstart): Easiest way to automate the web. Tell this agent in natural language what it should do, and it can interact with the web like a human.
+- [Models](https://docs.browser-use.com/cloud/agent/models): Choose the right model for your task.
 - [Structured output](https://docs.browser-use.com/cloud/agent/structured-output): Get validated, typed data back from agent tasks.
 - [Follow-up tasks](https://docs.browser-use.com/cloud/agent/follow-up-tasks): Run multiple tasks in the same browser session.
 - [Live messages](https://docs.browser-use.com/cloud/agent/streaming): Stream the agent's messages in real time to build custom UIs or monitor progress.
@@ -66,6 +67,8 @@ console.log(result.output);
 - [Profiles](https://docs.browser-use.com/cloud/guides/authentication): Persistent browser state — cookies, localStorage, saved passwords. Login once, reuse across sessions.
 - [Sync local and cloud cookies](https://docs.browser-use.com/cloud/guides/profile-sync): Sync your local browser cookies to the cloud — instantly authenticate without managing credentials.
 - [2FA](https://docs.browser-use.com/cloud/guides/2fa): Best practices for handling two-factor authentication in automated browser sessions.
+
+## More
 
 ## Integrations
 - [OpenClaw](https://docs.browser-use.com/cloud/tutorials/integrations/openclaw): Give OpenClaw agents browser automation with Browser Use — via CDP or the CLI skill.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -65,6 +65,7 @@
                     "icon": "robot",
                     "pages": [
                       "cloud/agent/quickstart",
+                      "cloud/agent/models",
                       "cloud/agent/structured-output",
                       "cloud/agent/follow-up-tasks",
                       "cloud/agent/streaming",
@@ -111,10 +112,10 @@
                     "group": "Tutorials",
                     "icon": "graduation-cap",
                     "pages": [
-                      "cloud/tutorials/chat-ui",
-                      "cloud/faq"
+                      "cloud/tutorials/chat-ui"
                     ]
                   },
+                  "cloud/faq",
                   {
                     "group": "Legacy (v2)",
                     "icon": "box-archive",

--- a/docs/generate-llms-txt.sh
+++ b/docs/generate-llms-txt.sh
@@ -101,7 +101,12 @@ def process_group(group, indent=0):
             elif not any(isinstance(p, dict) and 'openapi' in p for p in group.get('pages', [])):
                 # Sub-group container (like Pillars) — skip header but process children
                 pass
-        for page in group.get('pages', []):
+        # Process direct page slugs first, then sub-groups
+        direct = [p for p in group.get('pages', []) if isinstance(p, str)]
+        subgroups = [p for p in group.get('pages', []) if isinstance(p, dict)]
+        for page in direct:
+            lines.extend(process_group(page, indent+1))
+        for page in subgroups:
             lines.extend(process_group(page, indent+1))
     return lines
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -126,14 +126,13 @@ Source: https://docs.browser-use.com/cloud/agent/models
 
 Pass `model` to select a model:
 
-| Model | API String | Cost per Step |
-| ----- | ---------- | ------------- |
-| Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$0.05 |
-| Claude Opus 4.6 | `claude-opus-4-6` | \$0.05 |
-| Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$0.05 |
-| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.01 |
-| Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$0.03 |
-| O3 | `o3` | \$0.03 |
+| Model | API String | Input (per 1M tokens) | Output (per 1M tokens) |
+| ----- | ---------- | --------------------- | ---------------------- |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$3.60 | \$18.00 |
+| Claude Opus 4.6 | `claude-opus-4-6` | \$6.00 | \$30.00 |
+| Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$3.60 | \$18.00 |
+| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.60 | \$3.60 |
+| Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$2.40 | \$14.40 |
 
   We recommend **Claude Sonnet 4.6** (`claude-sonnet-4-6`). It's the model we optimize for the most right now.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -130,9 +130,7 @@ Pass `model` to select a model:
 | ----- | ---------- | --------------------- | ---------------------- |
 | Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$3.60 | \$18.00 |
 | Claude Opus 4.6 | `claude-opus-4-6` | \$6.00 | \$30.00 |
-| Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$3.60 | \$18.00 |
 | Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.60 | \$3.60 |
-| Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$2.40 | \$14.40 |
 
   We recommend **Claude Sonnet 4.6** (`claude-sonnet-4-6`). It's the model we optimize for the most right now.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -520,7 +520,7 @@ await client.workspaces.delete_file(workspace.id, path="old-report.pdf")
 
 # Check workspace storage usage
 size = await client.workspaces.size(workspace.id)
-print(f"Used: {size}")
+print(f"Used: {size.used_bytes} bytes")
 ```
 ```typescript TypeScript
 // List all files
@@ -531,9 +531,13 @@ for (const f of files.files) {
 
 // Delete a single file
 await client.workspaces.deleteFile(workspace.id, "old-report.pdf");
+
+// Check workspace storage usage
+const size = await client.workspaces.size(workspace.id);
+console.log(`Used: ${size.usedBytes} bytes`);
 ```
 
-## Manage workspaces
+## Cloud dashboard
 
 You can also manage workspaces from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=workspaces).
 
@@ -781,6 +785,8 @@ Source: https://docs.browser-use.com/cloud/agent/human-in-the-loop
 - Human navigates a complex auth flow, then hands back to agent
 - Human reviews what the agent did before the agent continues
 
+  Sessions time out after 15 minutes of inactivity. The maximum session duration is 4 hours. If the human needs more time, send a lightweight follow-up task (e.g. "wait") to reset the inactivity timer.
+
 ## Flow
 
 1. Create a session — it stays alive automatically when you pass `session_id` to `run()`
@@ -993,7 +999,7 @@ Useful for human interaction or to see live what's happening.
 
 ```html
 <iframe
-  src="{live_url}"
+  src="{LIVE_URL}"
   width="1280"
   height="720"
   allow="autoplay"
@@ -1011,7 +1017,7 @@ For responsive sizing, use CSS instead of fixed dimensions:
 
 ```html
 <iframe
-  src="{live_url}"
+  src="{LIVE_URL}"
   style="width: 100%; aspect-ratio: 16/9; border: none; border-radius: 8px;"
   allow="autoplay"
 ></iframe>
@@ -1253,6 +1259,9 @@ profile = await client.profiles.create(name="user-id-1")
 session = await client.sessions.create(profile_id=profile.id)
 result = await client.run("Check browser-use github stars", session_id=session.id)
 print(result.output)
+
+# Always stop the session to persist profile state
+await client.sessions.stop(session.id)
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
@@ -1266,6 +1275,9 @@ const result = await client.run("Check browser-use github stars", {
   sessionId: session.id,
 });
 console.log(result.output);
+
+// Always stop the session to persist profile state
+await client.sessions.stop(session.id);
 ```
 
 View your profile IDs at [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=profiles).
@@ -1322,7 +1334,7 @@ await client.profiles.delete(profileId);
 
 - **Per-user profiles:** Create one profile per end-user. Query by name to get the profile ID, or store a mapping between your users and their profile IDs in your database.
 
-  Profile state is only saved when the session ends. Always call `sessions.stop()` when you are done — if a session is left open or times out, changes may not be persisted.
+  Profile state is only saved when the session ends. Always call `sessions.stop()` when you are done — if a session is left open or times out, changes may not be persisted. Every code path that uses a profile must stop the session, including error handlers.
 
 
 # Sync local and cloud cookies

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -120,6 +120,51 @@ The best SOTA browser agent — see our [online Mind2Web benchmark](https://brow
 If you are an LLM, read/include [docs.browser-use.com/llms-full.txt](https://docs.browser-use.com/llms-full.txt) — it contains the complete SDK reference with all code examples in a single file optimized for LLMs.
 
 
+# Models
+Source: https://docs.browser-use.com/cloud/agent/models
+
+
+Pass `model` to select a model:
+
+| Model | API String | Cost per Step |
+| ----- | ---------- | ------------- |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$0.05 |
+| Claude Opus 4.6 | `claude-opus-4-6` | \$0.05 |
+| Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$0.05 |
+| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.01 |
+| Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$0.03 |
+| O3 | `o3` | \$0.03 |
+
+  We recommend **Claude Sonnet 4.6** (`claude-sonnet-4-6`). It's the model we optimize for the most right now.
+
+```python Python
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+result = await client.run(
+"List the top 20 posts on Hacker News today with their points",
+model="claude-sonnet-4-6",
+)
+print(result.output)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v3";
+
+const client = new BrowserUse();
+const result = await client.run(
+  "List the top 20 posts on Hacker News today with their points",
+  { model: "claude-sonnet-4-6" },
+);
+console.log(result.output);
+```
+```bash curl
+curl -X POST https://api.browser-use.com/api/v3/sessions \
+  -H "X-Browser-Use-API-Key: YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"task": "List the top 20 posts on Hacker News", "model": "claude-sonnet-4-6"}'
+```
+
+
 # Structured output
 Source: https://docs.browser-use.com/cloud/agent/structured-output
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -47,6 +47,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 - [2FA](https://docs.browser-use.com/cloud/guides/2fa): Best practices for handling two-factor authentication in automated browser sessions.
 
 ## More
+- [FAQ](https://docs.browser-use.com/cloud/faq): Common questions and solutions.
 
 ## Integrations
 - [OpenClaw](https://docs.browser-use.com/cloud/tutorials/integrations/openclaw): Give OpenClaw agents browser automation with Browser Use — via CDP or the CLI skill.
@@ -56,7 +57,6 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Tutorials
 - [Chat UI](https://docs.browser-use.com/cloud/tutorials/chat-ui): Full end-to-end example. Build a chat UI with live browser preview, follow-up tasks, recording, and streaming messages.
-- [FAQ](https://docs.browser-use.com/cloud/faq): Common questions and solutions.
 
 ## Legacy (v2)
 - [Agent (v2)](https://docs.browser-use.com/cloud/legacy/agent): V2 agent models and file handling.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -27,6 +27,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Agent
 - [Introduction](https://docs.browser-use.com/cloud/agent/quickstart): Easiest way to automate the web. Tell this agent in natural language what it should do, and it can interact with the web like a human.
+- [Models](https://docs.browser-use.com/cloud/agent/models): Choose the right model for your task.
 - [Structured output](https://docs.browser-use.com/cloud/agent/structured-output): Get validated, typed data back from agent tasks.
 - [Follow-up tasks](https://docs.browser-use.com/cloud/agent/follow-up-tasks): Run multiple tasks in the same browser session.
 - [Live messages](https://docs.browser-use.com/cloud/agent/streaming): Stream the agent's messages in real time to build custom UIs or monitor progress.
@@ -44,6 +45,8 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 - [Profiles](https://docs.browser-use.com/cloud/guides/authentication): Persistent browser state — cookies, localStorage, saved passwords. Login once, reuse across sessions.
 - [Sync local and cloud cookies](https://docs.browser-use.com/cloud/guides/profile-sync): Sync your local browser cookies to the cloud — instantly authenticate without managing credentials.
 - [2FA](https://docs.browser-use.com/cloud/guides/2fa): Best practices for handling two-factor authentication in automated browser sessions.
+
+## More
 
 ## Integrations
 - [OpenClaw](https://docs.browser-use.com/cloud/tutorials/integrations/openclaw): Give OpenClaw agents browser automation with Browser Use — via CDP or the CLI skill.


### PR DESCRIPTION
## Summary
- Add new **Models** doc page under Agent (`cloud/agent/models.mdx`) with bu-mini/bu-max/bu-ultra tiers, third-party model options (Claude Sonnet 4.6, Gemini 3 Flash, etc.), and code examples in Python/TypeScript/curl
- Recommend Claude Sonnet 4.6 as the most optimized third-party model
- Move FAQ from nested inside Tutorials to the same level as Legacy (v2) in the "More" nav group

## Test plan
- [ ] Verify models page renders correctly on Mintlify preview
- [ ] Confirm FAQ appears at the same level as Legacy (v2) in sidebar
- [ ] Check all code examples have correct syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new “Models” page under Agent with a flat table of supported models (Claude Sonnet 4.6, Opus 4.6, Gemini 3 Flash), API strings, per‑1M‑token pricing, and Python/TypeScript/curl examples for selecting a model. Moves FAQ to the “More” group, recommends `claude-sonnet-4-6`, drops O3, regenerates `llms.txt`/`llms-full.txt` (cloud and root) to include the Models section and link, and fixes the `llms.txt` generator to place standalone pages before sub‑groups so FAQ correctly appears under More.

<sup>Written for commit 6db869c1ab41255af58431b33dd566bb7798b8de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

