### PR TITLE
fix: docs audit — 12-persona quality sweep with SDK fixes

### DIFF
--- a/.claude/commands/test-docs.md
+++ b/.claude/commands/test-docs.md
@@ -1,0 +1,170 @@
+# /test-docs — Documentation Quality Audit
+
+You are a documentation quality auditor for Browser Use Cloud. Your job is to send many parallel agents — each simulating a different developer persona — to stress-test the docs end-to-end. Every agent reports back with a structured score and detailed findings.
+
+## Prerequisites
+
+- Read `.env` for `BROWSER_USE_API_KEY` and `BACKEND_URL`
+- Ensure `browser-use-sdk` is installed for both Python and TypeScript (`pip install browser-use-sdk`, `npm install browser-use-sdk`)
+- Read `docs/cloud/llms.txt` and `docs/cloud/llms-full.txt` for the doc surface area
+
+## Agent Fleet
+
+Launch **all** of these agents in parallel. Each agent works in an isolated worktree. Each agent must:
+
+1. Read the docs (llms.txt, llms-full.txt, and/or the raw .mdx files) as their persona would
+2. Attempt to follow the docs to accomplish their goal
+3. Actually run every code snippet they encounter (Python AND TypeScript)
+4. Use the real `BROWSER_USE_API_KEY` from `.env` for live API calls
+5. Report findings in the structured format below
+
+### Persona 1: "Quick Automator" (AI automation startup founder)
+**Goal:** Just wants to automate a simple task ASAP. Reads only llms.txt + quickstart.
+- Start from `docs/cloud/llms.txt` only — can you figure out what to do?
+- Follow quickstart to run first task (both Python and TS)
+- Time how many steps / files it takes to get a working result
+- Test: Does `client.run()` actually return output? Is the output format clear?
+
+### Persona 2: "Full Agent Builder" (building a product with live preview)
+**Goal:** Build a chat UI with embedded live browser, streaming, follow-ups.
+- Clone and set up the chat-ui-example repo from `docs/cloud/tutorials/chat-ui.mdx`
+- Test: Can you `git clone`, `npm install`, add API key, and run it? Does localhost work?
+- Check every code snippet in the chat-ui tutorial — do they match the actual repo?
+- Test streaming with `for await` — does it work as documented?
+- Test follow-up tasks in same session
+- Test recording download
+
+### Persona 3: "Playwright Power User" (wants stealth browsers for existing Playwright scripts)
+**Goal:** Connect Playwright to Browser Use's stealth infrastructure.
+- Read `docs/cloud/browser/playwright-puppeteer-selenium.mdx`
+- Test WebSocket URL approach (Option 1) with real API key
+- Test SDK approach (Option 2) — create browser, get cdp_url, connect Playwright
+- Test both Python and TypeScript variants
+- Verify query parameters (proxyCountryCode, profileId, timeout, screen size)
+- Check: Are the `live_url` / `liveUrl` properties documented and accessible?
+
+### Persona 4: "QA Tester" (wants to do end-to-end testing with natural language)
+**Goal:** Use Browser Use for QA testing of a website.
+- Read structured output docs (`docs/cloud/agent/structured-output.mdx`)
+- Test Pydantic model output (Python) and Zod schema output (TypeScript)
+- Verify Zod v4 requirement is clear and correct
+- Test: Run a structured extraction task with real API
+- Check: Are error messages clear when schema validation fails?
+
+### Persona 5: "Data Extractor" (enterprise, large-scale scraping without login)
+**Goal:** Extract data from public websites at scale.
+- Test basic data extraction with structured output
+- Test follow-up tasks for multi-page scraping
+- Check: Is proxy configuration documented clearly?
+- Read `docs/cloud/browser/proxies.mdx` and `docs/cloud/browser/stealth.mdx`
+- Test: Can you set proxy country? Is the parameter name obvious?
+
+### Persona 6: "File Upload/Download Tester"
+**Goal:** Test the workspace/file system end-to-end.
+- Read `docs/cloud/agent/workspaces.mdx`
+- Create a workspace, upload a CSV file, have agent read it
+- Have agent create a file, download it
+- Test upload of different file types (csv, json, txt, png)
+- Test `download_all` / `downloadAll`
+- Test `delete_file` / `deleteFile`
+- Check: Are all methods documented? Do return types match?
+
+### Persona 7: "Profile Manager"
+**Goal:** Use profiles for persistent browser state.
+- Read `docs/cloud/guides/authentication.mdx`
+- Create a profile, use it in a session, verify it persists
+- Test CRUD operations: create, list, get, update, delete
+- Test `query` parameter for searching profiles
+- Check: Is the warning about session stop clear?
+- Is it intuitive how to find your profile IDs?
+
+### Persona 8: "Sub-Agent Embedder" (wants to embed Browser Use in their main agent)
+**Goal:** Use Browser Use as a sub-agent with embedded browser view.
+- Read llms.txt to understand the API surface
+- Test creating a session with `keepAlive: true`
+- Get `liveUrl` and verify it works (can be embedded in iframe)
+- Test `for await` streaming to pipe into their own agent
+- Check: Is the iframe embedding documented? CSP requirements?
+- Read `docs/cloud/browser/live-preview.mdx`
+
+### Persona 9: "API Type Checker"
+**Goal:** Verify every API endpoint has correct types.
+- Read all code snippets in `docs/cloud/llms-full.txt`
+- For each Python snippet: verify it type-checks with `mypy` or at least runs without `TypeError`
+- For each TypeScript snippet: verify it compiles with `tsc` or at least runs without type errors
+- Check return types: does `result.output` exist? Is `session.live_url` vs `session.liveUrl` consistent across languages?
+- Check input parameter names: `session_id` (Python) vs `sessionId` (TypeScript)
+- Verify all imports are correct (v3 paths, class names)
+
+### Persona 10: "Link Checker & llms.txt Auditor"
+**Goal:** Verify all links work, llms.txt is complete and well-structured.
+- Check every URL in `docs/cloud/llms.txt` — are they all valid (HTTP 200)?
+- Check every URL in `docs/cloud/llms-full.txt` — are they all valid?
+- Check internal links in all `.mdx` files — do the cross-references resolve?
+- Do a web search for "best practices llms.txt" and compare against Browser Use's llms.txt
+- Score: Is the llms.txt easy to navigate? Is the hierarchy clear? Missing sections?
+- Check: Does the llms.txt match the actual docs structure in `docs.json`?
+- Verify the "Always use v3" guidance is prominent enough
+
+### Persona 11: "Deterministic Rerun User" (cache_script)
+**Goal:** Use cache_script for $0 LLM cost reruns.
+- Read `docs/cloud/agent/cache-script.mdx`
+- Test: Run a task, get the cache_script, rerun with it
+- Check: Are the docs clear about what cache_script is and when to use it?
+
+### Persona 12: "Human-in-the-Loop Builder"
+**Goal:** Build a flow where a human can interact with the browser mid-task.
+- Read `docs/cloud/agent/human-in-the-loop.mdx`
+- Test: Create a session, pause for human, resume
+- Check: Is the flow intuitive? Are the SDK methods clear?
+
+## Reporting Format
+
+Each agent MUST produce a report with this structure:
+
+```
+## Persona: [Name]
+### Score: X/10 (intuitiveness for this persona)
+### Time to first success: [steps/files read]
+
+### What worked well
+- ...
+
+### Problems found
+- [BROKEN_LINK] url — HTTP status or error
+- [CODE_ERROR] file:snippet — error message
+- [MISSING_DOCS] what's missing
+- [UNINTUITIVE] what was confusing and why
+- [TYPE_MISMATCH] expected vs actual
+- [STALE] outdated information
+
+### Code snippet results
+For each snippet tested:
+- file.mdx:line — PASS/FAIL — error if FAIL
+
+### Recommendations
+- ...
+```
+
+## Final Synthesis
+
+After all agents complete, produce a unified report:
+
+### Overall Score Card
+| Persona | Score | Time to Success | Critical Issues |
+|---------|-------|-----------------|-----------------|
+
+### Top Issues (sorted by severity)
+1. ...
+
+### llms.txt Assessment
+- Navigation score: X/10
+- Completeness: X/10
+- LLM-friendliness: X/10
+- Specific improvements: ...
+
+### Quick Wins (easy fixes)
+- ...
+
+### Strategic Improvements (bigger changes)
+- ...

--- a/browser-use-node/src/v3/client.ts
+++ b/browser-use-node/src/v3/client.ts
@@ -76,6 +76,12 @@ export class BrowserUse {
       body.proxyCountryCode = body.proxyCountryCode.toLowerCase() as any;
     }
     if (schema) {
+      if (typeof schema !== "object" || !("_zod" in schema || "_def" in schema)) {
+        throw new Error(
+          "schema must be a Zod schema (e.g. z.object({...})). " +
+          "Make sure you are using Zod v4: npm install zod@4"
+        );
+      }
       body.outputSchema = z.toJSONSchema(schema) as Record<string, unknown>;
     }
     // Auto keep_alive when dispatching to an existing session

--- a/browser-use-python/src/browser_use_sdk/v3/client.py
+++ b/browser-use-python/src/browser_use_sdk/v3/client.py
@@ -138,7 +138,12 @@ class BrowserUse:
 
         resolved_schema = schema or output_schema
         schema_dict: dict[str, Any] | None = None
-        if resolved_schema is not None and issubclass(resolved_schema, BaseModel):
+        if resolved_schema is not None:
+            if not issubclass(resolved_schema, BaseModel):
+                raise TypeError(
+                    "output_schema must be a Pydantic BaseModel subclass, "
+                    f"got {resolved_schema!r}"
+                )
             schema_dict = resolved_schema.model_json_schema()
 
         # Auto keep_alive when dispatching to an existing session
@@ -177,6 +182,7 @@ class BrowserUse:
         workspace_id: str | None = None,
         enable_recording: bool | None = None,
         custom_proxy: dict[str, Any] | None = None,
+        cache_script: bool | None = None,
         **extra: Any,
     ) -> SessionStream[Any]:
         """Run a task and yield messages as they happen.
@@ -188,9 +194,17 @@ class BrowserUse:
                 print(f"[{msg.role}] {msg.summary}")
             print(stream.result.output)
         """
+        if cache_script is True and not workspace_id:
+            raise ValueError("workspace_id is required when cache_script=True")
+
         resolved_schema = schema or output_schema
         schema_dict: dict[str, Any] | None = None
-        if resolved_schema is not None and issubclass(resolved_schema, BaseModel):
+        if resolved_schema is not None:
+            if not issubclass(resolved_schema, BaseModel):
+                raise TypeError(
+                    "output_schema must be a Pydantic BaseModel subclass, "
+                    f"got {resolved_schema!r}"
+                )
             schema_dict = resolved_schema.model_json_schema()
 
         if session_id is not None and keep_alive is None:
@@ -216,6 +230,7 @@ class BrowserUse:
             workspace_id=workspace_id,
             enable_recording=enable_recording,
             custom_proxy=custom_proxy,
+            cache_script=cache_script,
             **extra,
         )
         return SessionStream(data, self.sessions, resolved_schema, _start_cursor=start_cursor)
@@ -347,7 +362,12 @@ class AsyncBrowserUse:
 
         resolved_schema = schema or output_schema
         schema_dict: dict[str, Any] | None = None
-        if resolved_schema is not None and issubclass(resolved_schema, BaseModel):
+        if resolved_schema is not None:
+            if not issubclass(resolved_schema, BaseModel):
+                raise TypeError(
+                    "output_schema must be a Pydantic BaseModel subclass, "
+                    f"got {resolved_schema!r}"
+                )
             schema_dict = resolved_schema.model_json_schema()
 
         # Auto keep_alive when dispatching to an existing session

--- a/docs/cloud/agent/human-in-the-loop.mdx
+++ b/docs/cloud/agent/human-in-the-loop.mdx
@@ -9,6 +9,10 @@ icon: hand
 - Human navigates a complex auth flow, then hands back to agent
 - Human reviews what the agent did before the agent continues
 
+<Warning>
+  Sessions time out after 15 minutes of inactivity. The maximum session duration is 4 hours. If the human needs more time, send a lightweight follow-up task (e.g. "wait") to reset the inactivity timer.
+</Warning>
+
 ## Flow
 
 1. Create a session — it stays alive automatically when you pass `session_id` to `run()`

--- a/docs/cloud/agent/workspaces.mdx
+++ b/docs/cloud/agent/workspaces.mdx
@@ -171,7 +171,7 @@ await client.workspaces.delete_file(workspace.id, path="old-report.pdf")
 
 # Check workspace storage usage
 size = await client.workspaces.size(workspace.id)
-print(f"Used: {size}")
+print(f"Used: {size.used_bytes} bytes")
 ```
 ```typescript TypeScript
 // List all files
@@ -182,10 +182,14 @@ for (const f of files.files) {
 
 // Delete a single file
 await client.workspaces.deleteFile(workspace.id, "old-report.pdf");
+
+// Check workspace storage usage
+const size = await client.workspaces.size(workspace.id);
+console.log(`Used: ${size.usedBytes} bytes`);
 ```
 </CodeGroup>
 
-## Manage workspaces
+## Cloud dashboard
 
 You can also manage workspaces from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=workspaces).
 

--- a/docs/cloud/browser/live-preview.mdx
+++ b/docs/cloud/browser/live-preview.mdx
@@ -48,7 +48,7 @@ Useful for human interaction or to see live what's happening.
 
 ```html
 <iframe
-  src="{live_url}"
+  src="{LIVE_URL}"
   width="1280"
   height="720"
   allow="autoplay"
@@ -66,7 +66,7 @@ For responsive sizing, use CSS instead of fixed dimensions:
 
 ```html
 <iframe
-  src="{live_url}"
+  src="{LIVE_URL}"
   style="width: 100%; aspect-ratio: 16/9; border: none; border-radius: 8px;"
   allow="autoplay"
 ></iframe>

--- a/docs/cloud/guides/authentication.mdx
+++ b/docs/cloud/guides/authentication.mdx
@@ -15,6 +15,9 @@ profile = await client.profiles.create(name="user-id-1")
 session = await client.sessions.create(profile_id=profile.id)
 result = await client.run("Check browser-use github stars", session_id=session.id)
 print(result.output)
+
+# Always stop the session to persist profile state
+await client.sessions.stop(session.id)
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
@@ -28,6 +31,9 @@ const result = await client.run("Check browser-use github stars", {
   sessionId: session.id,
 });
 console.log(result.output);
+
+// Always stop the session to persist profile state
+await client.sessions.stop(session.id);
 ```
 </CodeGroup>
 
@@ -88,5 +94,5 @@ await client.profiles.delete(profileId);
 - **Per-user profiles:** Create one profile per end-user. Query by name to get the profile ID, or store a mapping between your users and their profile IDs in your database.
 
 <Warning>
-  Profile state is only saved when the session ends. Always call `sessions.stop()` when you are done — if a session is left open or times out, changes may not be persisted.
+  Profile state is only saved when the session ends. Always call `sessions.stop()` when you are done — if a session is left open or times out, changes may not be persisted. Every code path that uses a profile must stop the session, including error handlers.
 </Warning>

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -5,6 +5,7 @@
 - Dashboard: https://cloud.browser-use.com
 - Create API key: https://cloud.browser-use.com/settings?tab=api-keys&new=1
 - Docs: https://docs.browser-use.com
+- Full SDK reference (all code examples): https://docs.browser-use.com/cloud/llms-full.txt
 - OpenAPI spec (v3): https://docs.browser-use.com/cloud/openapi/v3.json
 - Chat UI example: https://docs.browser-use.com/cloud/tutorials/chat-ui — Full end-to-end example with live browser, streaming, auth. Best starting point to build a prototype.
 - Open-source repo: https://github.com/browser-use/browser-use — The open-source Python library. Note: the open-source API is different from the Cloud SDK. If you want the easiest path to production with managed infrastructure, use the Cloud SDK below.
@@ -20,6 +21,27 @@ Set API key (starts with `bu_`). If the user doesn't have one yet, they can crea
 export BROWSER_USE_API_KEY=bu_your_key_here
 ```
 
+## Quick start
+
+```python
+import asyncio
+from browser_use_sdk.v3 import AsyncBrowserUse
+
+async def main():
+    client = AsyncBrowserUse()
+    result = await client.run("List the top 20 posts on Hacker News today with their points")
+    print(result.output)
+
+asyncio.run(main())
+```
+
+```typescript
+import { BrowserUse } from "browser-use-sdk/v3";
+
+const client = new BrowserUse();
+const result = await client.run("List the top 20 posts on Hacker News today with their points");
+console.log(result.output);
+```
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.


### PR DESCRIPTION
## Summary

Ran a 12-agent parallel documentation quality audit, each simulating a different developer persona (automation startup, enterprise data extractor, Playwright user, QA tester, etc.). **190+ code snippets tested, zero broken links found, average intuitiveness score 7.6/10.**

This PR applies the quick-win fixes identified by the audit:

**Docs fixes:**
- `llms.txt`: add inline quickstart code (Python + TS) so LLM agents without web access can get started immediately. Add cross-link to `llms-full.txt`.
- `authentication.mdx`: add `sessions.stop()` to profile quick-start — without it users silently lose profile state
- `human-in-the-loop.mdx`: add session timeout warning (15 min inactivity, 4 hr max)
- `workspaces.mdx`: add `size()` to TypeScript section, fix Python `size` return type in example, rename duplicate "Manage workspaces" heading
- `live-preview.mdx`: normalize iframe placeholder from `{live_url}` to language-neutral `{LIVE_URL}`

**SDK bug fixes:**
- **Python**: raise `TypeError` when `output_schema`/`schema` is not a Pydantic `BaseModel` subclass (previously silently returned raw string — real bug)
- **Python**: add missing `cache_script` parameter to `stream()` method (was only on `run()`)
- **TypeScript**: validate `schema` is a Zod object before calling `z.toJSONSchema()` (previously: `Cannot read properties of undefined (reading 'def')`)

**New skill:**
- `.claude/commands/test-docs.md` — `/test-docs` skill for repeatable doc quality audits

## Full audit scorecard

| Persona | Score | Snippets | Pass Rate | Top Issue |
|---------|-------|----------|-----------|-----------|
| Quick Automator | 7/10 | 2 | 100% | llms.txt had no code ✅ fixed |
| Chat UI Builder | 6/10 | 3 | 33% | Repo pins stale SDK (separate fix needed) |
| Playwright Power User | 9/10 | 6 | 100% | Minor: no API key setup in SDK examples |
| QA Tester | 7/10 | 5 | 60% | Silent schema failure ✅ fixed |
| Data Extractor | 7/10 | 3 | 100% | No pagination guide (future work) |
| File Upload/Download | 8/10 | 32 | 100% | size() missing from TS docs ✅ fixed |
| Profile Manager | 8/10 | 12 | 100% | Missing sessions.stop() ✅ fixed |
| Sub-Agent Embedder | 8/10 | 8 | 100% | {live_url} inconsistency ✅ fixed |
| API Type Checker | 7/10 | 80+ | 94% | cacheScript missing from generated types |
| Link Checker | 9/10 | 34 URLs | 100% | No llms-full.txt cross-link ✅ fixed |
| Cache Script | 8/10 | 6 | 100% | stream() missing cache_script ✅ fixed |
| Human-in-the-Loop | 7/10 | 2 | 100% | No timeout warning ✅ fixed |

## Not in this PR (follow-up work)

- Chat UI example repo needs lockfile regenerated with `browser-use-sdk@latest`
- `cacheScript`/`customProxy` should be added to OpenAPI spec + regenerated types
- Add pagination/scraping recipe doc
- Add error handling guide
- Add `## Optional` section to llms.txt per spec
- Consider making v3 the default export

## Test plan

- [ ] Verify `llms.txt` renders correctly with inline code blocks
- [ ] Verify Python `TypeError` fires: `client.run("test", output_schema=PlainClass)`
- [ ] Verify TS Zod error fires: `client.run("test", { schema: { name: "string" } })`
- [ ] Verify `stream(cache_script=True, workspace_id=ws_id)` works in Python
- [ ] Verify all docs pages render without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs and SDK quality sweep to improve onboarding and reliability. Adds a repeatable `/test-docs` command, fixes schema validation and cache_script handling in the SDKs, and updates docs with a quickstart and clearer session guidance.

- **Bug Fixes**
  - Python: raise `TypeError` when `output_schema`/`schema` isn’t a Pydantic `BaseModel`; add `cache_script` to `stream()` and require `workspace_id` when `cache_script=True`.
  - TypeScript: validate `schema` is a Zod object before calling `z.toJSONSchema()`, with a clear error message.

- **New Features**
  - `/test-docs` command for a 12‑persona documentation audit.
  - Docs quick fixes: quickstart + cross-link in `llms.txt`; add `sessions.stop()` to auth quickstart; HITL session timeout warning; workspace `size()` examples (TS + Python fix); normalize `{LIVE_URL}` in live preview.

<sup>Written for commit df8685872a5160a9afc5418cce7561d58ca23037. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

