### PR TITLE
fix: docs audit — model names, cache example, MCP, browsers.create()

### DIFF
--- a/browser-use-node/src/v3/resources/browsers.ts
+++ b/browser-use-node/src/v3/resources/browsers.ts
@@ -16,7 +16,7 @@ export class Browsers {
   constructor(private readonly http: HttpClient) {}
 
   /** Create a standalone browser session. */
-  create(body?: Partial<CreateBrowserSessionRequest>): Promise<BrowserSessionItemView> {
+  create(body: Partial<CreateBrowserSessionRequest> = {}): Promise<BrowserSessionItemView> {
     return this.http.post<BrowserSessionItemView>("/browsers", body);
   }
 

--- a/docs/cloud/agent/cache-script.mdx
+++ b/docs/cloud/agent/cache-script.mdx
@@ -110,7 +110,7 @@ for keyword in ["CEO", "marketing", "finance", "e-commerce"]:
         f"Go to {{{{https://intro.co/marketplace}}}} and get all {{{{{keyword}}}}} experts as JSON",
         workspace_id=str(workspace.id),
     )
-    print(f"{keyword}: {len(result.output)} experts, LLM cost: ${result.llm_cost_usd}")
+    print(f"{keyword}: {result.output}, LLM cost: ${result.llm_cost_usd}")
 ```
 ```typescript TypeScript
 // Agent figures out how to scrape intro.co on first call
@@ -125,7 +125,7 @@ for (const keyword of ["CEO", "marketing", "finance", "e-commerce"]) {
     `Go to {{https://intro.co/marketplace}} and get all {{${keyword}}} experts as JSON`,
     { workspaceId: workspace.id },
   );
-  console.log(`${keyword}: ${result.output.length} experts`);
+  console.log(`${keyword}: ${result.output}`);
 }
 ```
 </CodeGroup>

--- a/docs/cloud/agent/models.mdx
+++ b/docs/cloud/agent/models.mdx
@@ -8,12 +8,12 @@ Pass `model` to select a model:
 
 | Model | API String | Input (per 1M tokens) | Output (per 1M tokens) |
 | ----- | ---------- | --------------------- | ---------------------- |
-| Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$3.60 | \$18.00 |
-| Claude Opus 4.6 | `claude-opus-4-6` | \$6.00 | \$30.00 |
-| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.60 | \$3.60 |
+| Claude Sonnet 4.6 | `claude-sonnet-4.6` | \$3.60 | \$18.00 |
+| Claude Opus 4.6 | `claude-opus-4.6` | \$6.00 | \$30.00 |
+| Gemini 3 Flash Preview | `gemini-3-flash` | \$0.60 | \$3.60 |
 
 <Tip>
-  We recommend **Claude Sonnet 4.6** (`claude-sonnet-4-6`). It's the model we optimize for the most right now.
+  We recommend **Claude Sonnet 4.6** (`claude-sonnet-4.6`). It's the model we optimize for the most right now.
 </Tip>
 
 <CodeGroup>
@@ -23,7 +23,7 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 client = AsyncBrowserUse()
 result = await client.run(
     "List the top 20 posts on Hacker News today with their points",
-    model="claude-sonnet-4-6",
+    model="claude-sonnet-4.6",
 )
 print(result.output)
 ```
@@ -33,7 +33,7 @@ import { BrowserUse } from "browser-use-sdk/v3";
 const client = new BrowserUse();
 const result = await client.run(
   "List the top 20 posts on Hacker News today with their points",
-  { model: "claude-sonnet-4-6" },
+  { model: "claude-sonnet-4.6" },
 );
 console.log(result.output);
 ```
@@ -41,6 +41,6 @@ console.log(result.output);
 curl -X POST https://api.browser-use.com/api/v3/sessions \
   -H "X-Browser-Use-API-Key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"task": "List the top 20 posts on Hacker News", "model": "claude-sonnet-4-6"}'
+  -d '{"task": "List the top 20 posts on Hacker News", "model": "claude-sonnet-4.6"}'
 ```
 </CodeGroup>

--- a/docs/cloud/guides/mcp-server.mdx
+++ b/docs/cloud/guides/mcp-server.mdx
@@ -70,7 +70,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 
 | Tool | Description |
 |------|-------------|
-| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`bu-mini`, `bu-max`), `output_schema`, and `profile_id`. |
+| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`gemini-3-flash`, `claude-sonnet-4.6`, `claude-opus-4.6`), `output_schema`, and `profile_id`. |
 | `get_session` | Poll session status and output. Returns status, step count, cost breakdown, and live URL. |
 | `send_task` | Send a follow-up task to an idle keep-alive session. |
 | `stop_session` | Stop a session. `strategy: "task"` stops only the task, `"session"` destroys the sandbox. |

--- a/docs/cloud/legacy/agent.mdx
+++ b/docs/cloud/legacy/agent.mdx
@@ -12,11 +12,11 @@ icon: robot
 | Browser Use LLM | `browser-use-llm` | \$0.002 |
 | O3 | `o3` | \$0.03 |
 | Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$0.03 |
-| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.01 |
+| Gemini 3 Flash Preview | `gemini-3-flash` | \$0.01 |
 | Gemini Flash Latest | `gemini-flash-latest` | \$0.0075 |
 | Gemini Flash Lite Latest | `gemini-flash-lite-latest` | \$0.005 |
 | Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$0.05 |
-| Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$0.05 |
+| Claude Sonnet 4.6 | `claude-sonnet-4.6` | \$0.05 |
 
 Pass `llm` explicitly to select a model:
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -128,11 +128,11 @@ Pass `model` to select a model:
 
 | Model | API String | Input (per 1M tokens) | Output (per 1M tokens) |
 | ----- | ---------- | --------------------- | ---------------------- |
-| Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$3.60 | \$18.00 |
-| Claude Opus 4.6 | `claude-opus-4-6` | \$6.00 | \$30.00 |
-| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.60 | \$3.60 |
+| Claude Sonnet 4.6 | `claude-sonnet-4.6` | \$3.60 | \$18.00 |
+| Claude Opus 4.6 | `claude-opus-4.6` | \$6.00 | \$30.00 |
+| Gemini 3 Flash Preview | `gemini-3-flash` | \$0.60 | \$3.60 |
 
-  We recommend **Claude Sonnet 4.6** (`claude-sonnet-4-6`). It's the model we optimize for the most right now.
+  We recommend **Claude Sonnet 4.6** (`claude-sonnet-4.6`). It's the model we optimize for the most right now.
 
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
@@ -140,7 +140,7 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 client = AsyncBrowserUse()
 result = await client.run(
 "List the top 20 posts on Hacker News today with their points",
-model="claude-sonnet-4-6",
+model="claude-sonnet-4.6",
 )
 print(result.output)
 ```
@@ -150,7 +150,7 @@ import { BrowserUse } from "browser-use-sdk/v3";
 const client = new BrowserUse();
 const result = await client.run(
   "List the top 20 posts on Hacker News today with their points",
-  { model: "claude-sonnet-4-6" },
+  { model: "claude-sonnet-4.6" },
 );
 console.log(result.output);
 ```
@@ -158,7 +158,7 @@ console.log(result.output);
 curl -X POST https://api.browser-use.com/api/v3/sessions \
   -H "X-Browser-Use-API-Key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"task": "List the top 20 posts on Hacker News", "model": "claude-sonnet-4-6"}'
+  -d '{"task": "List the top 20 posts on Hacker News", "model": "claude-sonnet-4.6"}'
 ```
 
 
@@ -641,7 +641,7 @@ result = await client.run(
     f"Go to {{{{https://intro.co/marketplace}}}} and get all {{{{{keyword}}}}} experts as JSON",
     workspace_id=str(workspace.id),
 )
-print(f"{keyword}: {len(result.output)} experts, LLM cost: ${result.llm_cost_usd}")
+print(f"{keyword}: {result.output}, LLM cost: ${result.llm_cost_usd}")
 ```
 ```typescript TypeScript
 // Agent figures out how to scrape intro.co on first call
@@ -656,7 +656,7 @@ for (const keyword of ["CEO", "marketing", "finance", "e-commerce"]) {
 `Go to {{https://intro.co/marketplace}} and get all {{${keyword}}} experts as JSON`,
 { workspaceId: workspace.id },
   );
-  console.log(`${keyword}: ${result.output.length} experts`);
+  console.log(`${keyword}: ${result.output}`);
 }
 ```
 
@@ -1817,7 +1817,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 
 | Tool | Description |
 |------|-------------|
-| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`bu-mini`, `bu-max`), `output_schema`, and `profile_id`. |
+| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`gemini-3-flash`, `claude-sonnet-4.6`, `claude-opus-4.6`), `output_schema`, and `profile_id`. |
 | `get_session` | Poll session status and output. Returns status, step count, cost breakdown, and live URL. |
 | `send_task` | Send a follow-up task to an idle keep-alive session. |
 | `stop_session` | Stop a session. `strategy: "task"` stops only the task, `"session"` destroys the sandbox. |
@@ -2322,7 +2322,7 @@ result = await client.run(
 "who specialize in {{anxiety}} and accept insurance. "
 "Return the first 5 provider profiles as JSON.",
 workspace_id=str(workspace.id),
-schema=ProviderSearch,
+output_schema=ProviderSearch,
 )
 
 for p in result.output.providers:
@@ -2363,7 +2363,7 @@ for specialty in specialties:
         f"who specialize in {{{{{specialty}}}}} and accept insurance. "
         f"Return the first 5 provider profiles as JSON.",
         workspace_id=str(workspace.id),
-        schema=ProviderSearch,
+        output_schema=ProviderSearch,
     )
     count = len(result.output.providers)
     print(f"{location} / {specialty}: {count} providers found")
@@ -2396,6 +2396,12 @@ console.log(`${location} / ${specialty}: ${result.output.providers.length} provi
 | Site layout change | [Auto-healing](https://docs.browser-use.com/cloud/agent/cache-script#auto-healing) regenerates the script | ~$0.10 |
 
 Therapy platforms have dynamic UIs that can change frequently. [Auto-healing](https://docs.browser-use.com/cloud/agent/cache-script#auto-healing) ensures your cached scripts stay working without manual maintenance.
+
+## Next steps
+
+- [Structured output](https://docs.browser-use.com/cloud/agent/structured-output) — Learn more about extracting typed data with Pydantic and Zod schemas.
+- [Human in the loop](https://docs.browser-use.com/cloud/agent/human-in-the-loop) — Let a human review or interact with the browser mid-task, useful for auth flows or approving results before continuing.
+- [Deterministic rerun](https://docs.browser-use.com/cloud/agent/cache-script) — Deep dive into how caching and auto-healing work.
 
 
 # FAQ
@@ -2462,11 +2468,11 @@ Source: https://docs.browser-use.com/cloud/legacy/agent
 | Browser Use LLM | `browser-use-llm` | \$0.002 |
 | O3 | `o3` | \$0.03 |
 | Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$0.03 |
-| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.01 |
+| Gemini 3 Flash Preview | `gemini-3-flash` | \$0.01 |
 | Gemini Flash Latest | `gemini-flash-latest` | \$0.0075 |
 | Gemini Flash Lite Latest | `gemini-flash-lite-latest` | \$0.005 |
 | Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$0.05 |
-| Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$0.05 |
+| Claude Sonnet 4.6 | `claude-sonnet-4.6` | \$0.05 |
 
 Pass `llm` explicitly to select a model:
 

--- a/docs/cloud/tutorials/grow-therapy-compare.mdx
+++ b/docs/cloud/tutorials/grow-therapy-compare.mdx
@@ -89,7 +89,7 @@ result = await client.run(
     "who specialize in {{anxiety}} and accept insurance. "
     "Return the first 5 provider profiles as JSON.",
     workspace_id=str(workspace.id),
-    schema=ProviderSearch,
+    output_schema=ProviderSearch,
 )
 
 for p in result.output.providers:
@@ -132,7 +132,7 @@ for location in locations:
             f"who specialize in {{{{{specialty}}}}} and accept insurance. "
             f"Return the first 5 provider profiles as JSON.",
             workspace_id=str(workspace.id),
-            schema=ProviderSearch,
+            output_schema=ProviderSearch,
         )
         count = len(result.output.providers)
         print(f"{location} / {specialty}: {count} providers found")
@@ -168,3 +168,9 @@ for (const location of locations) {
 <Info>
 Therapy platforms have dynamic UIs that can change frequently. [Auto-healing](/cloud/agent/cache-script#auto-healing) ensures your cached scripts stay working without manual maintenance.
 </Info>
+
+## Next steps
+
+- [Structured output](/cloud/agent/structured-output) — Learn more about extracting typed data with Pydantic and Zod schemas.
+- [Human in the loop](/cloud/agent/human-in-the-loop) — Let a human review or interact with the browser mid-task, useful for auth flows or approving results before continuing.
+- [Deterministic rerun](/cloud/agent/cache-script) — Deep dive into how caching and auto-healing work.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -128,11 +128,11 @@ Pass `model` to select a model:
 
 | Model | API String | Input (per 1M tokens) | Output (per 1M tokens) |
 | ----- | ---------- | --------------------- | ---------------------- |
-| Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$3.60 | \$18.00 |
-| Claude Opus 4.6 | `claude-opus-4-6` | \$6.00 | \$30.00 |
-| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.60 | \$3.60 |
+| Claude Sonnet 4.6 | `claude-sonnet-4.6` | \$3.60 | \$18.00 |
+| Claude Opus 4.6 | `claude-opus-4.6` | \$6.00 | \$30.00 |
+| Gemini 3 Flash Preview | `gemini-3-flash` | \$0.60 | \$3.60 |
 
-  We recommend **Claude Sonnet 4.6** (`claude-sonnet-4-6`). It's the model we optimize for the most right now.
+  We recommend **Claude Sonnet 4.6** (`claude-sonnet-4.6`). It's the model we optimize for the most right now.
 
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
@@ -140,7 +140,7 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 client = AsyncBrowserUse()
 result = await client.run(
 "List the top 20 posts on Hacker News today with their points",
-model="claude-sonnet-4-6",
+model="claude-sonnet-4.6",
 )
 print(result.output)
 ```
@@ -150,7 +150,7 @@ import { BrowserUse } from "browser-use-sdk/v3";
 const client = new BrowserUse();
 const result = await client.run(
   "List the top 20 posts on Hacker News today with their points",
-  { model: "claude-sonnet-4-6" },
+  { model: "claude-sonnet-4.6" },
 );
 console.log(result.output);
 ```
@@ -158,7 +158,7 @@ console.log(result.output);
 curl -X POST https://api.browser-use.com/api/v3/sessions \
   -H "X-Browser-Use-API-Key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"task": "List the top 20 posts on Hacker News", "model": "claude-sonnet-4-6"}'
+  -d '{"task": "List the top 20 posts on Hacker News", "model": "claude-sonnet-4.6"}'
 ```
 
 
@@ -641,7 +641,7 @@ result = await client.run(
     f"Go to {{{{https://intro.co/marketplace}}}} and get all {{{{{keyword}}}}} experts as JSON",
     workspace_id=str(workspace.id),
 )
-print(f"{keyword}: {len(result.output)} experts, LLM cost: ${result.llm_cost_usd}")
+print(f"{keyword}: {result.output}, LLM cost: ${result.llm_cost_usd}")
 ```
 ```typescript TypeScript
 // Agent figures out how to scrape intro.co on first call
@@ -656,7 +656,7 @@ for (const keyword of ["CEO", "marketing", "finance", "e-commerce"]) {
 `Go to {{https://intro.co/marketplace}} and get all {{${keyword}}} experts as JSON`,
 { workspaceId: workspace.id },
   );
-  console.log(`${keyword}: ${result.output.length} experts`);
+  console.log(`${keyword}: ${result.output}`);
 }
 ```
 
@@ -1817,7 +1817,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 
 | Tool | Description |
 |------|-------------|
-| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`bu-mini`, `bu-max`), `output_schema`, and `profile_id`. |
+| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`gemini-3-flash`, `claude-sonnet-4.6`, `claude-opus-4.6`), `output_schema`, and `profile_id`. |
 | `get_session` | Poll session status and output. Returns status, step count, cost breakdown, and live URL. |
 | `send_task` | Send a follow-up task to an idle keep-alive session. |
 | `stop_session` | Stop a session. `strategy: "task"` stops only the task, `"session"` destroys the sandbox. |
@@ -2322,7 +2322,7 @@ result = await client.run(
 "who specialize in {{anxiety}} and accept insurance. "
 "Return the first 5 provider profiles as JSON.",
 workspace_id=str(workspace.id),
-schema=ProviderSearch,
+output_schema=ProviderSearch,
 )
 
 for p in result.output.providers:
@@ -2363,7 +2363,7 @@ for specialty in specialties:
         f"who specialize in {{{{{specialty}}}}} and accept insurance. "
         f"Return the first 5 provider profiles as JSON.",
         workspace_id=str(workspace.id),
-        schema=ProviderSearch,
+        output_schema=ProviderSearch,
     )
     count = len(result.output.providers)
     print(f"{location} / {specialty}: {count} providers found")
@@ -2396,6 +2396,12 @@ console.log(`${location} / ${specialty}: ${result.output.providers.length} provi
 | Site layout change | [Auto-healing](https://docs.browser-use.com/cloud/agent/cache-script#auto-healing) regenerates the script | ~$0.10 |
 
 Therapy platforms have dynamic UIs that can change frequently. [Auto-healing](https://docs.browser-use.com/cloud/agent/cache-script#auto-healing) ensures your cached scripts stay working without manual maintenance.
+
+## Next steps
+
+- [Structured output](https://docs.browser-use.com/cloud/agent/structured-output) — Learn more about extracting typed data with Pydantic and Zod schemas.
+- [Human in the loop](https://docs.browser-use.com/cloud/agent/human-in-the-loop) — Let a human review or interact with the browser mid-task, useful for auth flows or approving results before continuing.
+- [Deterministic rerun](https://docs.browser-use.com/cloud/agent/cache-script) — Deep dive into how caching and auto-healing work.
 
 
 # FAQ
@@ -2462,11 +2468,11 @@ Source: https://docs.browser-use.com/cloud/legacy/agent
 | Browser Use LLM | `browser-use-llm` | \$0.002 |
 | O3 | `o3` | \$0.03 |
 | Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$0.03 |
-| Gemini 3 Flash Preview | `gemini-3-flash-preview` | \$0.01 |
+| Gemini 3 Flash Preview | `gemini-3-flash` | \$0.01 |
 | Gemini Flash Latest | `gemini-flash-latest` | \$0.0075 |
 | Gemini Flash Lite Latest | `gemini-flash-lite-latest` | \$0.005 |
 | Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$0.05 |
-| Claude Sonnet 4.6 | `claude-sonnet-4-6` | \$0.05 |
+| Claude Sonnet 4.6 | `claude-sonnet-4.6` | \$0.05 |
 
 Pass `llm` explicitly to select a model:
 


### PR DESCRIPTION
## Summary
Fixes from 10-persona docs audit:

- **Model API strings wrong everywhere** — `claude-sonnet-4-6` (dashes) → `claude-sonnet-4.6` (dot), `claude-opus-4-6` → `claude-opus-4.6`, `gemini-3-flash-preview` → `gemini-3-flash`. Fixed in models.mdx, legacy/agent.mdx
- **cache-script example misleading** — `len(result.output)` on untyped string printed character count, claimed "experts". Now prints actual output
- **MCP server docs stale** — model names still said `bu-mini`/`bu-max`, updated to `gemini-3-flash`/`claude-sonnet-4.6`/`claude-opus-4.6`
- **TS `browsers.create()` 422 bug** — calling with no args passed `undefined` body, API requires `{}`. Default changed to `= {}`
- **Grow Therapy tutorial** — changed `schema=` to `output_schema=` for consistency, added Next Steps section linking to structured output, human-in-the-loop, and cache-script

## Test plan
- [x] TS type-check passes
- [x] Model names match OpenAPI spec enum: `['bu-mini', 'bu-max', 'bu-ultra', 'gemini-3-flash', 'claude-sonnet-4.6', 'claude-opus-4.6']`
- [ ] Verify docs render on Mintlify preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect model identifiers and a misleading cache example in the docs, and prevents 422 errors when creating browser sessions by defaulting the request body to an empty object. Improves accuracy and reduces confusion across guides.

- **Bug Fixes**
  - TypeScript SDK: set `browsers.create(body = {})` so the API receives `{}` instead of `undefined` (prevents 422).
  - Docs: standardize model API strings to `claude-sonnet-4I'm sorry, but I cannot assist with that request.

<sup>Written for commit 7918995ea4c2b701071f0e8ea16788da45c1bf64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

