### PR TITLE
fix: add task cancel docs + fix async client indent bug

### DIFF
--- a/browser-use-python/src/browser_use_sdk/v3/client.py
+++ b/browser-use-python/src/browser_use_sdk/v3/client.py
@@ -385,7 +385,7 @@ class AsyncBrowserUse:
                 output_schema=schema_dict,
                 workspace_id=workspace_id,
                 enable_recording=enable_recording,
-                    cache_script=cache_script,
+                cache_script=cache_script,
                 **extra,
             )
 

--- a/docs/cloud/agent/streaming.mdx
+++ b/docs/cloud/agent/streaming.mdx
@@ -45,6 +45,27 @@ console.log(run.result.output);
 [tool] Done Autonomous: The top story on Hacker News is "Coding Agents Could Make Free Software Matter Again"
 ```
 
+## Cancel a running task
+
+Use `stop(strategy="task")` to cancel the current task without destroying the session. The session goes back to `idle` and can accept a new task.
+
+<CodeGroup>
+```python Python
+# Cancel the task mid-stream
+await client.sessions.stop(session.id, strategy="task")
+# Session is now idle — send a different task or close it
+```
+```typescript TypeScript
+// Cancel the task mid-stream
+await client.sessions.stop(session.id, { strategy: "task" });
+// Session is now idle — send a different task or close it
+```
+</CodeGroup>
+
+<Warning>
+  `run.result` is only available **after** the iterator finishes (all messages consumed or task completes). If you break early from `async for` / `for await`, the task may still be running — call `stop(strategy="task")` to cancel it before sending a follow-up.
+</Warning>
+
 ## Manual polling
 
 If you need full control over the polling loop (e.g. custom interval, filtering):

--- a/docs/cloud/agent/streaming.mdx
+++ b/docs/cloud/agent/streaming.mdx
@@ -62,7 +62,7 @@ async for msg in run:
 const run = client.run("Find the top story on Hacker News");
 for await (const msg of run) {
   if (shouldCancel()) {
-    await client.sessions.stop(run.sessionId, { strategy: "task" });
+    await client.sessions.stop(run.sessionId!, { strategy: "task" });
     break;
   }
 }

--- a/docs/cloud/agent/streaming.mdx
+++ b/docs/cloud/agent/streaming.mdx
@@ -51,13 +51,21 @@ Use `stop(strategy="task")` to cancel the current task without destroying the se
 
 <CodeGroup>
 ```python Python
-# Cancel the task mid-stream
-await client.sessions.stop(session.id, strategy="task")
+run = client.run("Find the top story on Hacker News")
+async for msg in run:
+    if should_cancel():
+        await client.sessions.stop(run.session_id, strategy="task")
+        break
 # Session is now idle — send a different task or close it
 ```
 ```typescript TypeScript
-// Cancel the task mid-stream
-await client.sessions.stop(session.id, { strategy: "task" });
+const run = client.run("Find the top story on Hacker News");
+for await (const msg of run) {
+  if (shouldCancel()) {
+    await client.sessions.stop(run.sessionId, { strategy: "task" });
+    break;
+  }
+}
 // Session is now idle — send a different task or close it
 ```
 </CodeGroup>

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -309,13 +309,21 @@ console.log(run.result.output);
 Use `stop(strategy="task")` to cancel the current task without destroying the session. The session goes back to `idle` and can accept a new task.
 
 ```python Python
-# Cancel the task mid-stream
-await client.sessions.stop(session.id, strategy="task")
+run = client.run("Find the top story on Hacker News")
+async for msg in run:
+if should_cancel():
+    await client.sessions.stop(run.session_id, strategy="task")
+    break
 # Session is now idle — send a different task or close it
 ```
 ```typescript TypeScript
-// Cancel the task mid-stream
-await client.sessions.stop(session.id, { strategy: "task" });
+const run = client.run("Find the top story on Hacker News");
+for await (const msg of run) {
+  if (shouldCancel()) {
+await client.sessions.stop(run.sessionId, { strategy: "task" });
+break;
+  }
+}
 // Session is now idle — send a different task or close it
 ```
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -320,7 +320,7 @@ if should_cancel():
 const run = client.run("Find the top story on Hacker News");
 for await (const msg of run) {
   if (shouldCancel()) {
-await client.sessions.stop(run.sessionId, { strategy: "task" });
+await client.sessions.stop(run.sessionId!, { strategy: "task" });
 break;
   }
 }

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -304,6 +304,23 @@ console.log(run.result.output);
 [tool] Done Autonomous: The top story on Hacker News is "Coding Agents Could Make Free Software Matter Again"
 ```
 
+## Cancel a running task
+
+Use `stop(strategy="task")` to cancel the current task without destroying the session. The session goes back to `idle` and can accept a new task.
+
+```python Python
+# Cancel the task mid-stream
+await client.sessions.stop(session.id, strategy="task")
+# Session is now idle — send a different task or close it
+```
+```typescript TypeScript
+// Cancel the task mid-stream
+await client.sessions.stop(session.id, { strategy: "task" });
+// Session is now idle — send a different task or close it
+```
+
+  `run.result` is only available **after** the iterator finishes (all messages consumed or task completes). If you break early from `async for` / `for await`, the task may still be running — call `stop(strategy="task")` to cancel it before sending a follow-up.
+
 ## Manual polling
 
 If you need full control over the polling loop (e.g. custom interval, filtering):

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -309,13 +309,21 @@ console.log(run.result.output);
 Use `stop(strategy="task")` to cancel the current task without destroying the session. The session goes back to `idle` and can accept a new task.
 
 ```python Python
-# Cancel the task mid-stream
-await client.sessions.stop(session.id, strategy="task")
+run = client.run("Find the top story on Hacker News")
+async for msg in run:
+if should_cancel():
+    await client.sessions.stop(run.session_id, strategy="task")
+    break
 # Session is now idle — send a different task or close it
 ```
 ```typescript TypeScript
-// Cancel the task mid-stream
-await client.sessions.stop(session.id, { strategy: "task" });
+const run = client.run("Find the top story on Hacker News");
+for await (const msg of run) {
+  if (shouldCancel()) {
+await client.sessions.stop(run.sessionId, { strategy: "task" });
+break;
+  }
+}
 // Session is now idle — send a different task or close it
 ```
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -320,7 +320,7 @@ if should_cancel():
 const run = client.run("Find the top story on Hacker News");
 for await (const msg of run) {
   if (shouldCancel()) {
-await client.sessions.stop(run.sessionId, { strategy: "task" });
+await client.sessions.stop(run.sessionId!, { strategy: "task" });
 break;
   }
 }

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -304,6 +304,23 @@ console.log(run.result.output);
 [tool] Done Autonomous: The top story on Hacker News is "Coding Agents Could Make Free Software Matter Again"
 ```
 
+## Cancel a running task
+
+Use `stop(strategy="task")` to cancel the current task without destroying the session. The session goes back to `idle` and can accept a new task.
+
+```python Python
+# Cancel the task mid-stream
+await client.sessions.stop(session.id, strategy="task")
+# Session is now idle — send a different task or close it
+```
+```typescript TypeScript
+// Cancel the task mid-stream
+await client.sessions.stop(session.id, { strategy: "task" });
+// Session is now idle — send a different task or close it
+```
+
+  `run.result` is only available **after** the iterator finishes (all messages consumed or task completes). If you break early from `async for` / `for await`, the task may still be running — call `stop(strategy="task")` to cancel it before sending a follow-up.
+
 ## Manual polling
 
 If you need full control over the polling loop (e.g. custom interval, filtering):


### PR DESCRIPTION
## Summary
- **Add "Cancel a running task" section** to streaming.mdx — documents `stop(strategy="task")` to cancel without destroying the session
- **Add warning** that `run.result` is only available after the iterator finishes
- **Fix indentation bug** in Python async client (`cache_script` had extra indent after `custom_proxy` removal in #118)

## Context
From the 10-persona docs audit: sub-agent embedders need to cancel tasks mid-stream but this wasn't documented anywhere except the chat-ui tutorial. The `stop(strategy="task")` pattern is the correct way — tested live: task stops, session goes `idle`, follow-up tasks work.

## Test plan
- [x] Python type-check passes (0 errors)
- [x] Live tested: `stop(strategy="task")` → status becomes `idle` → follow-up task works
- [ ] Verify docs render on Mintlify preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Cancel a running task” section showing `stop(strategy="task")` to cancel mid-stream without destroying the session. Clarifies that `run.result` is only available after the iterator completes and updates examples to use `run.session_id` / `run.sessionId!`.

- **Bug Fixes**
  - Python async client: fix stray indent for `cache_script` in `create_fn`.

<sup>Written for commit cf744a4340197d75e95d120e44d98dff9f1f2449. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

