### PR TITLE
fix: update FAQ model names to actual names

### DIFF
--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -6,9 +6,9 @@ icon: circle-question
 
 ## Which model should I use?
 
-- **bu-ultra** — most capable. Use for the hardest tasks that need maximum accuracy.
-- **bu-max** (default) — best balance of capability and cost. Use for complex multi-step workflows.
-- **bu-mini** — faster, cheaper. Good for simple tasks.
+- **Claude Opus 4.6** (`claude-opus-4.6`) — most capable. Use for the hardest tasks that need maximum accuracy.
+- **Claude Sonnet 4.6** (`claude-sonnet-4.6`, default) — best balance of capability and cost. Use for complex multi-step workflows.
+- **Gemini 3 Flash** (`gemini-3-flash`) — faster, cheaper. Good for simple tasks.
 
 ## How do I get the live browser URL?
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -2435,9 +2435,9 @@ Source: https://docs.browser-use.com/cloud/faq
 
 ## Which model should I use?
 
-- **bu-ultra** — most capable. Use for the hardest tasks that need maximum accuracy.
-- **bu-max** (default) — best balance of capability and cost. Use for complex multi-step workflows.
-- **bu-mini** — faster, cheaper. Good for simple tasks.
+- **Claude Opus 4.6** (`claude-opus-4.6`) — most capable. Use for the hardest tasks that need maximum accuracy.
+- **Claude Sonnet 4.6** (`claude-sonnet-4.6`, default) — best balance of capability and cost. Use for complex multi-step workflows.
+- **Gemini 3 Flash** (`gemini-3-flash`) — faster, cheaper. Good for simple tasks.
 
 ## How do I get the live browser URL?
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2435,9 +2435,9 @@ Source: https://docs.browser-use.com/cloud/faq
 
 ## Which model should I use?
 
-- **bu-ultra** — most capable. Use for the hardest tasks that need maximum accuracy.
-- **bu-max** (default) — best balance of capability and cost. Use for complex multi-step workflows.
-- **bu-mini** — faster, cheaper. Good for simple tasks.
+- **Claude Opus 4.6** (`claude-opus-4.6`) — most capable. Use for the hardest tasks that need maximum accuracy.
+- **Claude Sonnet 4.6** (`claude-sonnet-4.6`, default) — best balance of capability and cost. Use for complex multi-step workflows.
+- **Gemini 3 Flash** (`gemini-3-flash`) — faster, cheaper. Good for simple tasks.
 
 ## How do I get the live browser URL?
 


### PR DESCRIPTION
## Summary
Replace `bu-ultra`/`bu-max`/`bu-mini` with `claude-opus-4.6`/`claude-sonnet-4.6`/`gemini-3-flash` in the FAQ. Last place in the docs still using the old alias names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the `bu-ultra`/`bu-max`/`bu-mini` aliases with the actual model names and IDs in the FAQ: Claude Opus 4.6 (`claude-opus-4.6`), Claude Sonnet 4.6 (`claude-sonnet-4.6`, default), and Gemini 3 Flash (`gemini-3-flash`).
Also updates `docs/cloud/llms-full.txt` and `docs/llms-full.txt` to remove the last references to the old aliases and align with live model IDs.

<sup>Written for commit f698c7638843bdec5670a8e5cfc68f2edb9c87de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

