### PR TITLE
fix: use _UNSET sentinel for proxy_country_code in v2 Python SDK

### DIFF
--- a/browser-use-python/src/browser_use_sdk/v2/resources/browsers.py
+++ b/browser-use-python/src/browser_use_sdk/v2/resources/browsers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..._core import _UNSET
 from ..._core.http import AsyncHttpClient, SyncHttpClient
 from ...generated.v2.models import (
     BrowserSessionItemView,
@@ -15,7 +16,7 @@ from ...generated.v2.models import (
 def _build_create_body(
     *,
     profile_id: str | None = None,
-    proxy_country_code: str | None = None,
+    proxy_country_code: str | None = _UNSET,  # type: ignore[assignment]
     timeout: int | None = None,
     browser_screen_width: int | None = None,
     browser_screen_height: int | None = None,
@@ -26,7 +27,7 @@ def _build_create_body(
     body: dict[str, Any] = {}
     if profile_id is not None:
         body["profileId"] = profile_id
-    if proxy_country_code is not None:
+    if proxy_country_code is not _UNSET:
         body["proxyCountryCode"] = proxy_country_code.lower() if isinstance(proxy_country_code, str) else proxy_country_code
     if timeout is not None:
         body["timeout"] = timeout
@@ -50,7 +51,7 @@ class Browsers:
         self,
         *,
         profile_id: str | None = None,
-        proxy_country_code: str | None = None,
+        proxy_country_code: str | None = _UNSET,  # type: ignore[assignment]
         timeout: int | None = None,
         browser_screen_width: int | None = None,
         browser_screen_height: int | None = None,
@@ -119,7 +120,7 @@ class AsyncBrowsers:
         self,
         *,
         profile_id: str | None = None,
-        proxy_country_code: str | None = None,
+        proxy_country_code: str | None = _UNSET,  # type: ignore[assignment]
         timeout: int | None = None,
         browser_screen_width: int | None = None,
         browser_screen_height: int | None = None,

--- a/browser-use-python/src/browser_use_sdk/v2/resources/sessions.py
+++ b/browser-use-python/src/browser_use_sdk/v2/resources/sessions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..._core import _UNSET
 from ..._core.http import AsyncHttpClient, SyncHttpClient
 from ...generated.v2.models import (
     CustomProxy,
@@ -16,7 +17,7 @@ from ...generated.v2.models import (
 def _build_create_body(
     *,
     profile_id: str | None = None,
-    proxy_country_code: str | None = None,
+    proxy_country_code: str | None = _UNSET,  # type: ignore[assignment]
     start_url: str | None = None,
     browser_screen_width: int | None = None,
     browser_screen_height: int | None = None,
@@ -28,7 +29,7 @@ def _build_create_body(
     body: dict[str, Any] = {}
     if profile_id is not None:
         body["profileId"] = profile_id
-    if proxy_country_code is not None:
+    if proxy_country_code is not _UNSET:
         body["proxyCountryCode"] = proxy_country_code.lower() if isinstance(proxy_country_code, str) else proxy_country_code
     if start_url is not None:
         body["startUrl"] = start_url
@@ -54,7 +55,7 @@ class Sessions:
         self,
         *,
         profile_id: str | None = None,
-        proxy_country_code: str | None = None,
+        proxy_country_code: str | None = _UNSET,  # type: ignore[assignment]
         start_url: str | None = None,
         browser_screen_width: int | None = None,
         browser_screen_height: int | None = None,
@@ -158,7 +159,7 @@ class AsyncSessions:
         self,
         *,
         profile_id: str | None = None,
-        proxy_country_code: str | None = None,
+        proxy_country_code: str | None = _UNSET,  # type: ignore[assignment]
         start_url: str | None = None,
         browser_screen_width: int | None = None,
         browser_screen_height: int | None = None,


### PR DESCRIPTION
## Summary
- Backports the `_UNSET` sentinel pattern from v3 to v2 for `proxy_country_code` in both `browsers.py` and `sessions.py`
- Passing `proxy_country_code=None` now correctly sends `null` to the backend (disabling proxy), instead of being silently dropped
- Omitting the param keeps the default proxy behavior (uses `us`)

## Test plan
- [ ] `client.browsers.create(timeout=15)` → body has no `proxyCountryCode` key → backend uses default proxy
- [ ] `client.browsers.create(timeout=15, proxy_country_code=None)` → body has `"proxyCountryCode": null` → no proxy used
- [ ] `client.browsers.create(timeout=15, proxy_country_code="de")` → body has `"proxyCountryCode": "de"`
- [ ] Same behavior for `sessions.create()` and async variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `proxy_country_code` handling in the v2 Python SDK by using the `_UNSET` sentinel. Passing `None` now sends `null` (disables proxy), while omitting the param keeps the default proxy.

- **Bug Fixes**
  - Backported and applied `_UNSET` in `v2/resources/browsers.py` and `v2/resources/sessions.py` for `create()` (sync/async).
  - Only includes `proxyCountryCode` when provided; `proxy_country_code=None` now serializes to `null`.

<sup>Written for commit d65c03ef731d663e006f0b7b5a03e08b10f13a4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

