### PR TITLE
chore: bump SDK version to 3.5.0

### DIFF
--- a/browser-use-node/package.json
+++ b/browser-use-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-use-sdk",
-  "version": "4.1.0",
+  "version": "3.4.1",
   "description": "Official TypeScript SDK for the Browser Use API",
   "author": "Browser Use",
   "license": "MIT",

--- a/browser-use-node/package.json
+++ b/browser-use-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-use-sdk",
-  "version": "3.5.0",
+  "version": "4.1.0",
   "description": "Official TypeScript SDK for the Browser Use API",
   "author": "Browser Use",
   "license": "MIT",

--- a/browser-use-node/package.json
+++ b/browser-use-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-use-sdk",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Official TypeScript SDK for the Browser Use API",
   "author": "Browser Use",
   "license": "MIT",

--- a/browser-use-python/pyproject.toml
+++ b/browser-use-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "browser-use-sdk"
-version = "3.4.0"
+version = "3.5.0"
 description = "Python SDK for the Browser Use cloud API"
 readme = "README.md"
 license = "MIT"

--- a/browser-use-python/pyproject.toml
+++ b/browser-use-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "browser-use-sdk"
-version = "3.5.0"
+version = "4.1.0"
 description = "Python SDK for the Browser Use cloud API"
 readme = "README.md"
 license = "MIT"

--- a/browser-use-python/pyproject.toml
+++ b/browser-use-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "browser-use-sdk"
-version = "4.1.0"
+version = "3.4.1"
 description = "Python SDK for the Browser Use cloud API"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bumps both TypeScript and Python SDK versions from 3.4.0 to 3.5.0

## Test plan
- [ ] Verify `package.json` version is `3.5.0`
- [ ] Verify `pyproject.toml` version is `3.5.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped `browser-use-sdk` to 3.4.1 across the TypeScript and Python packages for a patch release. Updated versions in `browser-use-node/package.json` and `browser-use-python/pyproject.toml`.

<sup>Written for commit 6d41e00b6bf588cce74368b238d43f18720d357b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

