### PR TITLE
docs: add agent self-registration section to cloud llms.txt

### DIFF
--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -72,3 +72,15 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 ## API v2
 - [API key](https://docs.browser-use.com/cloud/api-v2-overview): Set your API key to access the Browser Use v2 REST API.
 
+## Agent Self-Registration
+
+Agents can self-register via a challenge-response flow to obtain an API key programmatically. Base URL: `https://api.browser-use.com`. Never send your API key to any other domain.
+
+1. **Request challenge:** `POST /cloud/signup` → `{ challenge_id, challenge_text }`
+2. **Solve challenge:** Use an LLM (never deterministic code) to solve the obfuscated math problem. Format answer as string with 2 decimal places (e.g. `"144.00"`).
+3. **Verify:** `POST /cloud/signup/verify` with `{ challenge_id, answer }` → `{ api_key }`
+
+**Claim account (optional):** `POST /cloud/signup/claim` (with API key header) → `{ claim_url }` — forward to a human to link the agent account to a user account. Expires after 1 hour.
+
+**Constraints:** Challenges expire after 5 minutes, are single-use, and division always produces clean decimals. Rate limits: 10 challenge requests/hour/IP, 20 verify attempts/hour/IP.
+


### PR DESCRIPTION
## Summary
- Adds a minimal **Agent Self-Registration** section to `docs/cloud/llms.txt`
- Covers the 3-step challenge-response flow (`/cloud/signup` → solve via LLM → `/cloud/signup/verify`)
- Includes account claiming, constraints, and rate limits in compact form

## Test plan
- [ ] Review the new section in `docs/cloud/llms.txt` for accuracy and tone

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Agent Self-Registration section to `docs/cloud/llms.txt` that explains the challenge-response flow for programmatic API key creation. Covers endpoints (`/cloud/signup`, `/cloud/signup/verify`, optional `/cloud/signup/claim`), answer format, expirations, and rate limits.

<sup>Written for commit fc2c2e195ccc26612fbd3662a588cc1d9722ff65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

