### PR TITLE
docs: update cache_script syntax from {{}} to @{{}}

### DIFF
--- a/docs/cloud/agent/cache-script.mdx
+++ b/docs/cloud/agent/cache-script.mdx
@@ -8,7 +8,7 @@ Deterministic rerun lets you run a browser task once with a full agent, then **r
 
 ## Quick start
 
-Use `{{double brackets}}` around values that can change between runs. The first call runs the full agent. Every subsequent call with the same template uses the cached script.
+Use `@{{double brackets}}` around values that can change between runs. The first call runs the full agent. Every subsequent call with the same template uses the cached script.
 
 <CodeGroup>
 ```python Python
@@ -19,13 +19,13 @@ workspace = await client.workspaces.create(name="my-scraper")
 
 # First call — agent explores, creates script (~$0.10, ~60s)
 result = await client.run(
-    "Get the top {{5}} stories from https://news.ycombinator.com as JSON",
+    "Get the top @{{5}} stories from https://news.ycombinator.com as JSON",
     workspace_id=str(workspace.id),
 )
 
 # Second call — cached script, different param ($0 LLM, ~5s)
 result2 = await client.run(
-    "Get the top {{10}} stories from https://news.ycombinator.com as JSON",
+    "Get the top @{{10}} stories from https://news.ycombinator.com as JSON",
     workspace_id=str(workspace.id),
 )
 ```
@@ -37,13 +37,13 @@ const workspace = await client.workspaces.create({ name: "my-scraper" });
 
 // First call — agent explores, creates script (~$0.10, ~60s)
 const result = await client.run(
-  "Get the top {{5}} stories from https://news.ycombinator.com as JSON",
+  "Get the top @{{5}} stories from https://news.ycombinator.com as JSON",
   { workspaceId: workspace.id },
 );
 
 // Second call — cached script, different param ($0 LLM, ~5s)
 const result2 = await client.run(
-  "Get the top {{10}} stories from https://news.ycombinator.com as JSON",
+  "Get the top @{{10}} stories from https://news.ycombinator.com as JSON",
   { workspaceId: workspace.id },
 );
 ```
@@ -52,20 +52,20 @@ const result2 = await client.run(
 ## How it works
 
 <Steps>
-  <Step title="You send a task with {{brackets}}">
+  <Step title="You send a task with @{{brackets}}">
     The brackets mark which parts are parameters:
 
     ```
-    "Get prices from {{example.com}} for {{electronics}}"
+    "Get prices from @{{example.com}} for @{{electronics}}"
     ```
 
-    - `{{example.com}}` → parameter 1
-    - `{{electronics}}` → parameter 2
+    - `@{{example.com}}` → parameter 1
+    - `@{{electronics}}` → parameter 2
 
-    The system strips the values to create a **template**: `"Get prices from {{}} for {{}}"`.
+    The system strips the values to create a **template**: `"Get prices from @{{}} for @{{}}"`.
   </Step>
   <Step title="System hashes the template">
-    Template `"Get prices from {{}} for {{}}"` is hashed to a unique ID like `a7f3b2c1`.
+    Template `"Get prices from @{{}} for @{{}}"` is hashed to a unique ID like `a7f3b2c1`.
     The system checks the workspace for `scripts/a7f3b2c1.py`.
   </Step>
   <Step title="Cache miss → agent creates script">
@@ -79,14 +79,14 @@ const result2 = await client.run(
 ## Auto-detection
 
 Caching activates **automatically** when both conditions are met:
-- The task contains `{{` and `}}`
+- The task contains `@{{` and `}}`
 - A `workspace_id` is provided
 
 No extra flags needed. You can override with `cache_script`:
 
 | Value | Behavior |
 |-------|----------|
-| `None` (default) | Auto-detect from `{{brackets}}` + workspace |
+| `None` (default) | Auto-detect from `@{{brackets}}` + workspace |
 | `True` | Force-enable, even without brackets |
 | `False` | Force-disable, even if brackets are present |
 
@@ -100,14 +100,14 @@ Run once, then loop over different keywords at $0 LLM each:
 ```python Python
 # Agent figures out how to scrape intro.co on first call
 result = await client.run(
-    "Go to {{https://intro.co/marketplace}} and get all {{logistics}} experts as JSON",
+    "Go to @{{https://intro.co/marketplace}} and get all @{{logistics}} experts as JSON",
     workspace_id=str(workspace.id),
 )
 
 # Instant reruns with different keywords
 for keyword in ["CEO", "marketing", "finance", "e-commerce"]:
     result = await client.run(
-        f"Go to {{{{https://intro.co/marketplace}}}} and get all {{{{{keyword}}}}} experts as JSON",
+        f"Go to @{{{{https://intro.co/marketplace}}}} and get all @{{{{{keyword}}}}} experts as JSON",
         workspace_id=str(workspace.id),
     )
     print(f"{keyword}: {len(result.output)} experts, LLM cost: ${result.llm_cost_usd}")
@@ -115,14 +115,14 @@ for keyword in ["CEO", "marketing", "finance", "e-commerce"]:
 ```typescript TypeScript
 // Agent figures out how to scrape intro.co on first call
 let result = await client.run(
-  "Go to {{https://intro.co/marketplace}} and get all {{logistics}} experts as JSON",
+  "Go to @{{https://intro.co/marketplace}} and get all @{{logistics}} experts as JSON",
   { workspaceId: workspace.id },
 );
 
 // Instant reruns with different keywords
 for (const keyword of ["CEO", "marketing", "finance", "e-commerce"]) {
   result = await client.run(
-    `Go to {{https://intro.co/marketplace}} and get all {{${keyword}}} experts as JSON`,
+    `Go to @{{https://intro.co/marketplace}} and get all @{{${keyword}}} experts as JSON`,
     { workspaceId: workspace.id },
   );
   console.log(`${keyword}: ${result.output.length} experts`);
@@ -132,30 +132,30 @@ for (const keyword of ["CEO", "marketing", "finance", "e-commerce"]) {
 
 ### No parameters — cache the exact task
 
-Append empty brackets `{{}}` to signal "cache this exact task":
+Append empty brackets `@{{}}` to signal "cache this exact task":
 
 <CodeGroup>
 ```python Python
 result = await client.run(
-    "Get the current Bitcoin price from coinmarketcap.com {{}}",
+    "Get the current Bitcoin price from coinmarketcap.com @{{}}",
     workspace_id=str(workspace.id),
 )
 
 # Same task again — cached
 result2 = await client.run(
-    "Get the current Bitcoin price from coinmarketcap.com {{}}",
+    "Get the current Bitcoin price from coinmarketcap.com @{{}}",
     workspace_id=str(workspace.id),
 )
 ```
 ```typescript TypeScript
 let result = await client.run(
-  "Get the current Bitcoin price from coinmarketcap.com {{}}",
+  "Get the current Bitcoin price from coinmarketcap.com @{{}}",
   { workspaceId: workspace.id },
 );
 
 // Same task again — cached
 result = await client.run(
-  "Get the current Bitcoin price from coinmarketcap.com {{}}",
+  "Get the current Bitcoin price from coinmarketcap.com @{{}}",
   { workspaceId: workspace.id },
 );
 ```
@@ -166,25 +166,25 @@ result = await client.run(
 <CodeGroup>
 ```python Python
 result = await client.run(
-    "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{Germany,France,Japan}}",
+    "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for @{{Germany,France,Japan}}",
     workspace_id=str(workspace.id),
 )
 
 # Different countries — cached
 result2 = await client.run(
-    "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{US,UK,Brazil}}",
+    "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for @{{US,UK,Brazil}}",
     workspace_id=str(workspace.id),
 )
 ```
 ```typescript TypeScript
 let result = await client.run(
-  "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{Germany,France,Japan}}",
+  "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for @{{Germany,France,Japan}}",
   { workspaceId: workspace.id },
 );
 
 // Different countries — cached
 result = await client.run(
-  "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{US,UK,Brazil}}",
+  "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for @{{US,UK,Brazil}}",
   { workspaceId: workspace.id },
 );
 ```
@@ -203,7 +203,7 @@ result = await client.run(
 
 # Force-disable even with brackets
 result = await client.run(
-    "Explain what {{templates}} means in Jinja",
+    "Explain what @{{templates}} means in Jinja",
     workspace_id=str(workspace.id),
     cache_script=False,
 )
@@ -217,7 +217,7 @@ let result = await client.run(
 
 // Force-disable even with brackets
 result = await client.run(
-  "Explain what {{templates}} means in Jinja",
+  "Explain what @{{templates}} means in Jinja",
   { workspaceId: workspace.id, cacheScript: false },
 );
 ```

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -552,7 +552,7 @@ Deterministic rerun lets you run a browser task once with a full agent, then **r
 
 ## Quick start
 
-Use `{{double brackets}}` around values that can change between runs. The first call runs the full agent. Every subsequent call with the same template uses the cached script.
+Use `@{{double brackets}}` around values that can change between runs. The first call runs the full agent. Every subsequent call with the same template uses the cached script.
 
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
@@ -562,13 +562,13 @@ workspace = await client.workspaces.create(name="my-scraper")
 
 # First call — agent explores, creates script (~$0.10, ~60s)
 result = await client.run(
-"Get the top {{5}} stories from https://news.ycombinator.com as JSON",
+"Get the top @{{5}} stories from https://news.ycombinator.com as JSON",
 workspace_id=str(workspace.id),
 )
 
 # Second call — cached script, different param ($0 LLM, ~5s)
 result2 = await client.run(
-"Get the top {{10}} stories from https://news.ycombinator.com as JSON",
+"Get the top @{{10}} stories from https://news.ycombinator.com as JSON",
 workspace_id=str(workspace.id),
 )
 ```
@@ -580,13 +580,13 @@ const workspace = await client.workspaces.create({ name: "my-scraper" });
 
 // First call — agent explores, creates script (~$0.10, ~60s)
 const result = await client.run(
-  "Get the top {{5}} stories from https://news.ycombinator.com as JSON",
+  "Get the top @{{5}} stories from https://news.ycombinator.com as JSON",
   { workspaceId: workspace.id },
 );
 
 // Second call — cached script, different param ($0 LLM, ~5s)
 const result2 = await client.run(
-  "Get the top {{10}} stories from https://news.ycombinator.com as JSON",
+  "Get the top @{{10}} stories from https://news.ycombinator.com as JSON",
   { workspaceId: workspace.id },
 );
 ```
@@ -596,14 +596,14 @@ const result2 = await client.run(
 The brackets mark which parts are parameters:
 
 ```
-"Get prices from {{example.com}} for {{electronics}}"
+"Get prices from @{{example.com}} for @{{electronics}}"
 ```
 
-- `{{example.com}}` → parameter 1
-- `{{electronics}}` → parameter 2
+- `@{{example.com}}` → parameter 1
+- `@{{electronics}}` → parameter 2
 
-The system strips the values to create a **template**: `"Get prices from {{}} for {{}}"`.
-Template `"Get prices from {{}} for {{}}"` is hashed to a unique ID like `a7f3b2c1`.
+The system strips the values to create a **template**: `"Get prices from @{{}} for @{{}}"`.
+Template `"Get prices from @{{}} for @{{}}"` is hashed to a unique ID like `a7f3b2c1`.
 The system checks the workspace for `scripts/a7f3b2c1.py`.
 If no script exists, the full agent runs your task. After completing it, the agent saves a standalone Python script that reproduces the result deterministically — no AI needed.
 If the script exists, it runs directly with the new parameter values. No agent, no LLM. Just the script in a sandbox with browser and proxy.
@@ -611,14 +611,14 @@ If the script exists, it runs directly with the new parameter values. No agent, 
 ## Auto-detection
 
 Caching activates **automatically** when both conditions are met:
-- The task contains `{{` and `}}`
+- The task contains `@{{` and `}}`
 - A `workspace_id` is provided
 
 No extra flags needed. You can override with `cache_script`:
 
 | Value | Behavior |
 |-------|----------|
-| `None` (default) | Auto-detect from `{{brackets}}` + workspace |
+| `None` (default) | Auto-detect from `@{{brackets}}` + workspace |
 | `True` | Force-enable, even without brackets |
 | `False` | Force-disable, even if brackets are present |
 
@@ -631,14 +631,14 @@ Run once, then loop over different keywords at $0 LLM each:
 ```python Python
 # Agent figures out how to scrape intro.co on first call
 result = await client.run(
-"Go to {{https://intro.co/marketplace}} and get all {{logistics}} experts as JSON",
+"Go to @{{https://intro.co/marketplace}} and get all @{{logistics}} experts as JSON",
 workspace_id=str(workspace.id),
 )
 
 # Instant reruns with different keywords
 for keyword in ["CEO", "marketing", "finance", "e-commerce"]:
 result = await client.run(
-    f"Go to {{{{https://intro.co/marketplace}}}} and get all {{{{{keyword}}}}} experts as JSON",
+    f"Go to @{{{{https://intro.co/marketplace}}}} and get all @{{{{{keyword}}}}} experts as JSON",
     workspace_id=str(workspace.id),
 )
 print(f"{keyword}: {len(result.output)} experts, LLM cost: ${result.llm_cost_usd}")
@@ -646,14 +646,14 @@ print(f"{keyword}: {len(result.output)} experts, LLM cost: ${result.llm_cost_usd
 ```typescript TypeScript
 // Agent figures out how to scrape intro.co on first call
 let result = await client.run(
-  "Go to {{https://intro.co/marketplace}} and get all {{logistics}} experts as JSON",
+  "Go to @{{https://intro.co/marketplace}} and get all @{{logistics}} experts as JSON",
   { workspaceId: workspace.id },
 );
 
 // Instant reruns with different keywords
 for (const keyword of ["CEO", "marketing", "finance", "e-commerce"]) {
   result = await client.run(
-`Go to {{https://intro.co/marketplace}} and get all {{${keyword}}} experts as JSON`,
+`Go to @{{https://intro.co/marketplace}} and get all @{{${keyword}}} experts as JSON`,
 { workspaceId: workspace.id },
   );
   console.log(`${keyword}: ${result.output.length} experts`);
@@ -662,29 +662,29 @@ for (const keyword of ["CEO", "marketing", "finance", "e-commerce"]) {
 
 ### No parameters — cache the exact task
 
-Append empty brackets `{{}}` to signal "cache this exact task":
+Append empty brackets `@{{}}` to signal "cache this exact task":
 
 ```python Python
 result = await client.run(
-"Get the current Bitcoin price from coinmarketcap.com {{}}",
+"Get the current Bitcoin price from coinmarketcap.com @{{}}",
 workspace_id=str(workspace.id),
 )
 
 # Same task again — cached
 result2 = await client.run(
-"Get the current Bitcoin price from coinmarketcap.com {{}}",
+"Get the current Bitcoin price from coinmarketcap.com @{{}}",
 workspace_id=str(workspace.id),
 )
 ```
 ```typescript TypeScript
 let result = await client.run(
-  "Get the current Bitcoin price from coinmarketcap.com {{}}",
+  "Get the current Bitcoin price from coinmarketcap.com @{{}}",
   { workspaceId: workspace.id },
 );
 
 // Same task again — cached
 result = await client.run(
-  "Get the current Bitcoin price from coinmarketcap.com {{}}",
+  "Get the current Bitcoin price from coinmarketcap.com @{{}}",
   { workspaceId: workspace.id },
 );
 ```
@@ -693,25 +693,25 @@ result = await client.run(
 
 ```python Python
 result = await client.run(
-"Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{Germany,France,Japan}}",
+"Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for @{{Germany,France,Japan}}",
 workspace_id=str(workspace.id),
 )
 
 # Different countries — cached
 result2 = await client.run(
-"Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{US,UK,Brazil}}",
+"Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for @{{US,UK,Brazil}}",
 workspace_id=str(workspace.id),
 )
 ```
 ```typescript TypeScript
 let result = await client.run(
-  "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{Germany,France,Japan}}",
+  "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for @{{Germany,France,Japan}}",
   { workspaceId: workspace.id },
 );
 
 // Different countries — cached
 result = await client.run(
-  "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{US,UK,Brazil}}",
+  "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for @{{US,UK,Brazil}}",
   { workspaceId: workspace.id },
 );
 ```
@@ -728,7 +728,7 @@ cache_script=True,
 
 # Force-disable even with brackets
 result = await client.run(
-"Explain what {{templates}} means in Jinja",
+"Explain what @{{templates}} means in Jinja",
 workspace_id=str(workspace.id),
 cache_script=False,
 )
@@ -742,7 +742,7 @@ let result = await client.run(
 
 // Force-disable even with brackets
 result = await client.run(
-  "Explain what {{templates}} means in Jinja",
+  "Explain what @{{templates}} means in Jinja",
   { workspaceId: workspace.id, cacheScript: false },
 );
 ```

--- a/docs/cloud/openapi/v3.json
+++ b/docs/cloud/openapi/v3.json
@@ -3026,7 +3026,7 @@
                             }
                         ],
                         "title": "Cachescript",
-                        "description": "Controls deterministic script caching. `null` (default): auto-detected \u2014 enabled when the task contains `{{value}}` brackets and a workspace is attached. `true`: force-enable script caching even without brackets (caches the exact task). `false`: force-disable, even if brackets are present. When active, the first call runs the full agent and saves a reusable script. Subsequent calls with the same task template execute the cached script with $0 LLM cost. Requires workspace_id when enabled. Example: \"Get prices from {{https://example.com}} for {{electronics}}\"."
+                        "description": "Controls deterministic script caching. `null` (default): auto-detected \u2014 enabled when the task contains `@{{value}}` brackets and a workspace is attached. `true`: force-enable script caching even without brackets (caches the exact task). `false`: force-disable, even if brackets are present. When active, the first call runs the full agent and saves a reusable script. Subsequent calls with the same task template execute the cached script with $0 LLM cost. Requires workspace_id when enabled. Example: \"Get prices from @{{https://example.com}} for @{{electronics}}\"."
                     }
                 },
                 "type": "object",

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -552,7 +552,7 @@ Deterministic rerun lets you run a browser task once with a full agent, then **r
 
 ## Quick start
 
-Use `{{double brackets}}` around values that can change between runs. The first call runs the full agent. Every subsequent call with the same template uses the cached script.
+Use `@{{double brackets}}` around values that can change between runs. The first call runs the full agent. Every subsequent call with the same template uses the cached script.
 
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
@@ -562,13 +562,13 @@ workspace = await client.workspaces.create(name="my-scraper")
 
 # First call — agent explores, creates script (~$0.10, ~60s)
 result = await client.run(
-"Get the top {{5}} stories from https://news.ycombinator.com as JSON",
+"Get the top @{{5}} stories from https://news.ycombinator.com as JSON",
 workspace_id=str(workspace.id),
 )
 
 # Second call — cached script, different param ($0 LLM, ~5s)
 result2 = await client.run(
-"Get the top {{10}} stories from https://news.ycombinator.com as JSON",
+"Get the top @{{10}} stories from https://news.ycombinator.com as JSON",
 workspace_id=str(workspace.id),
 )
 ```
@@ -580,13 +580,13 @@ const workspace = await client.workspaces.create({ name: "my-scraper" });
 
 // First call — agent explores, creates script (~$0.10, ~60s)
 const result = await client.run(
-  "Get the top {{5}} stories from https://news.ycombinator.com as JSON",
+  "Get the top @{{5}} stories from https://news.ycombinator.com as JSON",
   { workspaceId: workspace.id },
 );
 
 // Second call — cached script, different param ($0 LLM, ~5s)
 const result2 = await client.run(
-  "Get the top {{10}} stories from https://news.ycombinator.com as JSON",
+  "Get the top @{{10}} stories from https://news.ycombinator.com as JSON",
   { workspaceId: workspace.id },
 );
 ```
@@ -596,14 +596,14 @@ const result2 = await client.run(
 The brackets mark which parts are parameters:
 
 ```
-"Get prices from {{example.com}} for {{electronics}}"
+"Get prices from @{{example.com}} for @{{electronics}}"
 ```
 
-- `{{example.com}}` → parameter 1
-- `{{electronics}}` → parameter 2
+- `@{{example.com}}` → parameter 1
+- `@{{electronics}}` → parameter 2
 
-The system strips the values to create a **template**: `"Get prices from {{}} for {{}}"`.
-Template `"Get prices from {{}} for {{}}"` is hashed to a unique ID like `a7f3b2c1`.
+The system strips the values to create a **template**: `"Get prices from @{{}} for @{{}}"`.
+Template `"Get prices from @{{}} for @{{}}"` is hashed to a unique ID like `a7f3b2c1`.
 The system checks the workspace for `scripts/a7f3b2c1.py`.
 If no script exists, the full agent runs your task. After completing it, the agent saves a standalone Python script that reproduces the result deterministically — no AI needed.
 If the script exists, it runs directly with the new parameter values. No agent, no LLM. Just the script in a sandbox with browser and proxy.
@@ -611,14 +611,14 @@ If the script exists, it runs directly with the new parameter values. No agent, 
 ## Auto-detection
 
 Caching activates **automatically** when both conditions are met:
-- The task contains `{{` and `}}`
+- The task contains `@{{` and `}}`
 - A `workspace_id` is provided
 
 No extra flags needed. You can override with `cache_script`:
 
 | Value | Behavior |
 |-------|----------|
-| `None` (default) | Auto-detect from `{{brackets}}` + workspace |
+| `None` (default) | Auto-detect from `@{{brackets}}` + workspace |
 | `True` | Force-enable, even without brackets |
 | `False` | Force-disable, even if brackets are present |
 
@@ -631,14 +631,14 @@ Run once, then loop over different keywords at $0 LLM each:
 ```python Python
 # Agent figures out how to scrape intro.co on first call
 result = await client.run(
-"Go to {{https://intro.co/marketplace}} and get all {{logistics}} experts as JSON",
+"Go to @{{https://intro.co/marketplace}} and get all @{{logistics}} experts as JSON",
 workspace_id=str(workspace.id),
 )
 
 # Instant reruns with different keywords
 for keyword in ["CEO", "marketing", "finance", "e-commerce"]:
 result = await client.run(
-    f"Go to {{{{https://intro.co/marketplace}}}} and get all {{{{{keyword}}}}} experts as JSON",
+    f"Go to @{{{{https://intro.co/marketplace}}}} and get all @{{{{{keyword}}}}} experts as JSON",
     workspace_id=str(workspace.id),
 )
 print(f"{keyword}: {len(result.output)} experts, LLM cost: ${result.llm_cost_usd}")
@@ -646,14 +646,14 @@ print(f"{keyword}: {len(result.output)} experts, LLM cost: ${result.llm_cost_usd
 ```typescript TypeScript
 // Agent figures out how to scrape intro.co on first call
 let result = await client.run(
-  "Go to {{https://intro.co/marketplace}} and get all {{logistics}} experts as JSON",
+  "Go to @{{https://intro.co/marketplace}} and get all @{{logistics}} experts as JSON",
   { workspaceId: workspace.id },
 );
 
 // Instant reruns with different keywords
 for (const keyword of ["CEO", "marketing", "finance", "e-commerce"]) {
   result = await client.run(
-`Go to {{https://intro.co/marketplace}} and get all {{${keyword}}} experts as JSON`,
+`Go to @{{https://intro.co/marketplace}} and get all @{{${keyword}}} experts as JSON`,
 { workspaceId: workspace.id },
   );
   console.log(`${keyword}: ${result.output.length} experts`);
@@ -662,29 +662,29 @@ for (const keyword of ["CEO", "marketing", "finance", "e-commerce"]) {
 
 ### No parameters — cache the exact task
 
-Append empty brackets `{{}}` to signal "cache this exact task":
+Append empty brackets `@{{}}` to signal "cache this exact task":
 
 ```python Python
 result = await client.run(
-"Get the current Bitcoin price from coinmarketcap.com {{}}",
+"Get the current Bitcoin price from coinmarketcap.com @{{}}",
 workspace_id=str(workspace.id),
 )
 
 # Same task again — cached
 result2 = await client.run(
-"Get the current Bitcoin price from coinmarketcap.com {{}}",
+"Get the current Bitcoin price from coinmarketcap.com @{{}}",
 workspace_id=str(workspace.id),
 )
 ```
 ```typescript TypeScript
 let result = await client.run(
-  "Get the current Bitcoin price from coinmarketcap.com {{}}",
+  "Get the current Bitcoin price from coinmarketcap.com @{{}}",
   { workspaceId: workspace.id },
 );
 
 // Same task again — cached
 result = await client.run(
-  "Get the current Bitcoin price from coinmarketcap.com {{}}",
+  "Get the current Bitcoin price from coinmarketcap.com @{{}}",
   { workspaceId: workspace.id },
 );
 ```
@@ -693,25 +693,25 @@ result = await client.run(
 
 ```python Python
 result = await client.run(
-"Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{Germany,France,Japan}}",
+"Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for @{{Germany,France,Japan}}",
 workspace_id=str(workspace.id),
 )
 
 # Different countries — cached
 result2 = await client.run(
-"Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{US,UK,Brazil}}",
+"Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for @{{US,UK,Brazil}}",
 workspace_id=str(workspace.id),
 )
 ```
 ```typescript TypeScript
 let result = await client.run(
-  "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{Germany,France,Japan}}",
+  "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for @{{Germany,France,Japan}}",
   { workspaceId: workspace.id },
 );
 
 // Different countries — cached
 result = await client.run(
-  "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for {{US,UK,Brazil}}",
+  "Go to https://help.netflix.com/en/node/24926/ax and get subscription prices for @{{US,UK,Brazil}}",
   { workspaceId: workspace.id },
 );
 ```
@@ -728,7 +728,7 @@ cache_script=True,
 
 # Force-disable even with brackets
 result = await client.run(
-"Explain what {{templates}} means in Jinja",
+"Explain what @{{templates}} means in Jinja",
 workspace_id=str(workspace.id),
 cache_script=False,
 )
@@ -742,7 +742,7 @@ let result = await client.run(
 
 // Force-disable even with brackets
 result = await client.run(
-  "Explain what {{templates}} means in Jinja",
+  "Explain what @{{templates}} means in Jinja",
   { workspaceId: workspace.id, cacheScript: false },
 );
 ```


### PR DESCRIPTION
## Summary
- Updates all documentation for the deterministic rerun feature to use the new `@{{value}}` syntax instead of `{{value}}`
- Companion PR to browser-use/cloud#3861 which changes the backend detection logic

## Files changed
- `docs/cloud/agent/cache-script.mdx` — main feature documentation page
- `docs/cloud/openapi/v3.json` — OpenAPI spec `cache_script` field description
- `docs/cloud/llms-full.txt` — LLM context file
- `docs/llms-full.txt` — root LLM context file

## Why
The old `{{}}` syntax produced ~4,000 false positive matches across 31 projects because `{{` appears naturally in JSON examples, pipeline variables (n8n/Make.com), and markdown. The `@{{}}` prefix has virtually zero natural collisions.

## Test plan
- [ ] Verify docs site renders correctly with new syntax
- [ ] Verify code examples in Python and TypeScript are syntactically correct
- [ ] Cross-reference with cloud#3861 backend changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update deterministic rerun docs to use the new `@{{...}}` template syntax instead of `{{...}}`, matching backend detection in cloud#3861 and reducing false positives. Also updates the OpenAPI `cache_script` description and LLM context files.

- **Migration**
  - Replace `{{...}}` with `@{{...}}` in tasks and examples; use `@{{}}` to cache an exact task.
  - Auto-detection now requires `@{{` and a `workspace_id`; `cache_script` overrides are unchanged.

<sup>Written for commit 0c4b7a66ffdb58688362c5643d14365e84508430. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

