### PR TITLE
docs: remove Gemini 3 Flash/Pro model references

### DIFF
--- a/docs/cloud/agent/models.mdx
+++ b/docs/cloud/agent/models.mdx
@@ -10,7 +10,6 @@ Pass `model` to select a model:
 | ----- | ---------- | --------------------- | ---------------------- |
 | Claude Sonnet 4.6 | `claude-sonnet-4.6` | \$3.60 | \$18.00 |
 | Claude Opus 4.6 | `claude-opus-4.6` | \$6.00 | \$30.00 |
-| Gemini 3 Flash Preview | `gemini-3-flash` | \$0.60 | \$3.60 |
 
 <Tip>
   We recommend **Claude Sonnet 4.6** (`claude-sonnet-4.6`). It's the model we optimize for the most right now.

--- a/docs/cloud/agent/models.mdx
+++ b/docs/cloud/agent/models.mdx
@@ -10,6 +10,7 @@ Pass `model` to select a model:
 | ----- | ---------- | --------------------- | ---------------------- |
 | Claude Sonnet 4.6 | `claude-sonnet-4.6` | \$3.60 | \$18.00 |
 | Claude Opus 4.6 | `claude-opus-4.6` | \$6.00 | \$30.00 |
+| GPT-5.4 mini | `gpt-5.4-mini` | \$0.90 | \$5.40 |
 
 <Tip>
   We recommend **Claude Sonnet 4.6** (`claude-sonnet-4.6`). It's the model we optimize for the most right now.

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -8,7 +8,6 @@ icon: circle-question
 
 - **Claude Opus 4.6** (`claude-opus-4.6`) — most capable. Use for the hardest tasks that need maximum accuracy.
 - **Claude Sonnet 4.6** (`claude-sonnet-4.6`, default) — best balance of capability and cost. Use for complex multi-step workflows.
-- **Gemini 3 Flash** (`gemini-3-flash`) — faster, cheaper. Good for simple tasks.
 
 ## How do I get the live browser URL?
 

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -8,6 +8,7 @@ icon: circle-question
 
 - **Claude Opus 4.6** (`claude-opus-4.6`) — most capable. Use for the hardest tasks that need maximum accuracy.
 - **Claude Sonnet 4.6** (`claude-sonnet-4.6`, default) — best balance of capability and cost. Use for complex multi-step workflows.
+- **GPT-5.4 mini** (`gpt-5.4-mini`) — fast and efficient. Good for simple, well-defined tasks.
 
 ## How do I get the live browser URL?
 

--- a/docs/cloud/guides/mcp-server.mdx
+++ b/docs/cloud/guides/mcp-server.mdx
@@ -70,7 +70,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 
 | Tool | Description |
 |------|-------------|
-| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`claude-sonnet-4.6`, `claude-opus-4.6`), `output_schema`, and `profile_id`. |
+| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`claude-sonnet-4.6`, `claude-opus-4.6`, `gpt-5.4-mini`), `output_schema`, and `profile_id`. |
 | `get_session` | Poll session status and output. Returns status, step count, cost breakdown, and live URL. |
 | `send_task` | Send a follow-up task to an idle keep-alive session. |
 | `stop_session` | Stop a session. `strategy: "task"` stops only the task, `"session"` destroys the sandbox. |

--- a/docs/cloud/guides/mcp-server.mdx
+++ b/docs/cloud/guides/mcp-server.mdx
@@ -70,7 +70,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 
 | Tool | Description |
 |------|-------------|
-| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`gemini-3-flash`, `claude-sonnet-4.6`, `claude-opus-4.6`), `output_schema`, and `profile_id`. |
+| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`claude-sonnet-4.6`, `claude-opus-4.6`), `output_schema`, and `profile_id`. |
 | `get_session` | Poll session status and output. Returns status, step count, cost breakdown, and live URL. |
 | `send_task` | Send a follow-up task to an idle keep-alive session. |
 | `stop_session` | Stop a session. `strategy: "task"` stops only the task, `"session"` destroys the sandbox. |

--- a/docs/cloud/legacy/agent.mdx
+++ b/docs/cloud/legacy/agent.mdx
@@ -11,8 +11,6 @@ icon: robot
 | Browser Use 2.0 (default) | `browser-use-2.0` | \$0.006 |
 | Browser Use LLM | `browser-use-llm` | \$0.002 |
 | O3 | `o3` | \$0.03 |
-| Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$0.03 |
-| Gemini 3 Flash Preview | `gemini-3-flash` | \$0.01 |
 | Gemini Flash Latest | `gemini-flash-latest` | \$0.0075 |
 | Gemini Flash Lite Latest | `gemini-flash-lite-latest` | \$0.005 |
 | Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$0.05 |

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -130,6 +130,7 @@ Pass `model` to select a model:
 | ----- | ---------- | --------------------- | ---------------------- |
 | Claude Sonnet 4.6 | `claude-sonnet-4.6` | \$3.60 | \$18.00 |
 | Claude Opus 4.6 | `claude-opus-4.6` | \$6.00 | \$30.00 |
+| GPT-5.4 mini | `gpt-5.4-mini` | \$0.90 | \$5.40 |
 
   We recommend **Claude Sonnet 4.6** (`claude-sonnet-4.6`). It's the model we optimize for the most right now.
 
@@ -1841,7 +1842,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 
 | Tool | Description |
 |------|-------------|
-| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`claude-sonnet-4.6`, `claude-opus-4.6`), `output_schema`, and `profile_id`. |
+| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`claude-sonnet-4.6`, `claude-opus-4.6`, `gpt-5.4-mini`), `output_schema`, and `profile_id`. |
 | `get_session` | Poll session status and output. Returns status, step count, cost breakdown, and live URL. |
 | `send_task` | Send a follow-up task to an idle keep-alive session. |
 | `stop_session` | Stop a session. `strategy: "task"` stops only the task, `"session"` destroys the sandbox. |
@@ -2436,6 +2437,7 @@ Source: https://docs.browser-use.com/cloud/faq
 
 - **Claude Opus 4.6** (`claude-opus-4.6`) — most capable. Use for the hardest tasks that need maximum accuracy.
 - **Claude Sonnet 4.6** (`claude-sonnet-4.6`, default) — best balance of capability and cost. Use for complex multi-step workflows.
+- **GPT-5.4 mini** (`gpt-5.4-mini`) — fast and efficient. Good for simple, well-defined tasks.
 
 ## How do I get the live browser URL?
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -130,7 +130,6 @@ Pass `model` to select a model:
 | ----- | ---------- | --------------------- | ---------------------- |
 | Claude Sonnet 4.6 | `claude-sonnet-4.6` | \$3.60 | \$18.00 |
 | Claude Opus 4.6 | `claude-opus-4.6` | \$6.00 | \$30.00 |
-| Gemini 3 Flash Preview | `gemini-3-flash` | \$0.60 | \$3.60 |
 
   We recommend **Claude Sonnet 4.6** (`claude-sonnet-4.6`). It's the model we optimize for the most right now.
 
@@ -1842,7 +1841,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 
 | Tool | Description |
 |------|-------------|
-| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`gemini-3-flash`, `claude-sonnet-4.6`, `claude-opus-4.6`), `output_schema`, and `profile_id`. |
+| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`claude-sonnet-4.6`, `claude-opus-4.6`), `output_schema`, and `profile_id`. |
 | `get_session` | Poll session status and output. Returns status, step count, cost breakdown, and live URL. |
 | `send_task` | Send a follow-up task to an idle keep-alive session. |
 | `stop_session` | Stop a session. `strategy: "task"` stops only the task, `"session"` destroys the sandbox. |
@@ -2437,7 +2436,6 @@ Source: https://docs.browser-use.com/cloud/faq
 
 - **Claude Opus 4.6** (`claude-opus-4.6`) — most capable. Use for the hardest tasks that need maximum accuracy.
 - **Claude Sonnet 4.6** (`claude-sonnet-4.6`, default) — best balance of capability and cost. Use for complex multi-step workflows.
-- **Gemini 3 Flash** (`gemini-3-flash`) — faster, cheaper. Good for simple tasks.
 
 ## How do I get the live browser URL?
 
@@ -2492,8 +2490,6 @@ Source: https://docs.browser-use.com/cloud/legacy/agent
 | Browser Use 2.0 (default) | `browser-use-2.0` | \$0.006 |
 | Browser Use LLM | `browser-use-llm` | \$0.002 |
 | O3 | `o3` | \$0.03 |
-| Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$0.03 |
-| Gemini 3 Flash Preview | `gemini-3-flash` | \$0.01 |
 | Gemini Flash Latest | `gemini-flash-latest` | \$0.0075 |
 | Gemini Flash Lite Latest | `gemini-flash-lite-latest` | \$0.005 |
 | Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$0.05 |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -130,6 +130,7 @@ Pass `model` to select a model:
 | ----- | ---------- | --------------------- | ---------------------- |
 | Claude Sonnet 4.6 | `claude-sonnet-4.6` | \$3.60 | \$18.00 |
 | Claude Opus 4.6 | `claude-opus-4.6` | \$6.00 | \$30.00 |
+| GPT-5.4 mini | `gpt-5.4-mini` | \$0.90 | \$5.40 |
 
   We recommend **Claude Sonnet 4.6** (`claude-sonnet-4.6`). It's the model we optimize for the most right now.
 
@@ -1841,7 +1842,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 
 | Tool | Description |
 |------|-------------|
-| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`claude-sonnet-4.6`, `claude-opus-4.6`), `output_schema`, and `profile_id`. |
+| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`claude-sonnet-4.6`, `claude-opus-4.6`, `gpt-5.4-mini`), `output_schema`, and `profile_id`. |
 | `get_session` | Poll session status and output. Returns status, step count, cost breakdown, and live URL. |
 | `send_task` | Send a follow-up task to an idle keep-alive session. |
 | `stop_session` | Stop a session. `strategy: "task"` stops only the task, `"session"` destroys the sandbox. |
@@ -2436,6 +2437,7 @@ Source: https://docs.browser-use.com/cloud/faq
 
 - **Claude Opus 4.6** (`claude-opus-4.6`) — most capable. Use for the hardest tasks that need maximum accuracy.
 - **Claude Sonnet 4.6** (`claude-sonnet-4.6`, default) — best balance of capability and cost. Use for complex multi-step workflows.
+- **GPT-5.4 mini** (`gpt-5.4-mini`) — fast and efficient. Good for simple, well-defined tasks.
 
 ## How do I get the live browser URL?
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -130,7 +130,6 @@ Pass `model` to select a model:
 | ----- | ---------- | --------------------- | ---------------------- |
 | Claude Sonnet 4.6 | `claude-sonnet-4.6` | \$3.60 | \$18.00 |
 | Claude Opus 4.6 | `claude-opus-4.6` | \$6.00 | \$30.00 |
-| Gemini 3 Flash Preview | `gemini-3-flash` | \$0.60 | \$3.60 |
 
   We recommend **Claude Sonnet 4.6** (`claude-sonnet-4.6`). It's the model we optimize for the most right now.
 
@@ -1842,7 +1841,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 
 | Tool | Description |
 |------|-------------|
-| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`gemini-3-flash`, `claude-sonnet-4.6`, `claude-opus-4.6`), `output_schema`, and `profile_id`. |
+| `run_session` | Create a session and run a task. Supports `keep_alive`, `model` (`claude-sonnet-4.6`, `claude-opus-4.6`), `output_schema`, and `profile_id`. |
 | `get_session` | Poll session status and output. Returns status, step count, cost breakdown, and live URL. |
 | `send_task` | Send a follow-up task to an idle keep-alive session. |
 | `stop_session` | Stop a session. `strategy: "task"` stops only the task, `"session"` destroys the sandbox. |
@@ -2437,7 +2436,6 @@ Source: https://docs.browser-use.com/cloud/faq
 
 - **Claude Opus 4.6** (`claude-opus-4.6`) — most capable. Use for the hardest tasks that need maximum accuracy.
 - **Claude Sonnet 4.6** (`claude-sonnet-4.6`, default) — best balance of capability and cost. Use for complex multi-step workflows.
-- **Gemini 3 Flash** (`gemini-3-flash`) — faster, cheaper. Good for simple tasks.
 
 ## How do I get the live browser URL?
 
@@ -2492,8 +2490,6 @@ Source: https://docs.browser-use.com/cloud/legacy/agent
 | Browser Use 2.0 (default) | `browser-use-2.0` | \$0.006 |
 | Browser Use LLM | `browser-use-llm` | \$0.002 |
 | O3 | `o3` | \$0.03 |
-| Gemini 3 Pro Preview | `gemini-3-pro-preview` | \$0.03 |
-| Gemini 3 Flash Preview | `gemini-3-flash` | \$0.01 |
 | Gemini Flash Latest | `gemini-flash-latest` | \$0.0075 |
 | Gemini Flash Lite Latest | `gemini-flash-lite-latest` | \$0.005 |
 | Claude Sonnet 4.5 | `claude-sonnet-4-5-20250929` | \$0.05 |


### PR DESCRIPTION
## Summary
- Remove Gemini 3 Flash Preview and Gemini 3 Pro Preview from all documentation model tables
- Remove Gemini 3 Flash from FAQ model recommendations and MCP server tool descriptions
- Applies to both `docs/` and `docs/cloud/` llms-full.txt files

Note: OpenAPI spec files (`docs/openapi/v2.json`, `v3.json`) still reference these models — those are generated from the backend and will need a separate backend update to fully remove.

## Test plan
- [ ] Verify docs render correctly without the removed rows
- [ ] Confirm no broken references to gemini-3-flash in remaining docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed all references to Gemini 3 Flash/Pro preview models and added `gpt-5.4-mini` across the docs. Updated v3 model tables, FAQ recommendations, MCP server `run_session` supported models, and `llms-full.txt` in both `docs/` and `docs/cloud/`; OpenAPI `v2.json`/`v3.json` will be updated separately.

<sup>Written for commit 435175597a9d8596b8c36f6a94721ebab4c4cef0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

