### PR TITLE
docs: add Hermes Agent integration page with CLI-based signup flow

### DIFF
--- a/docs/cloud/tutorials/integrations/hermes-agent.mdx
+++ b/docs/cloud/tutorials/integrations/hermes-agent.mdx
@@ -1,0 +1,139 @@
+---
+title: Hermes Agent
+description: Give Hermes Agent cloud browser automation with Browser Use.
+---
+
+[Hermes Agent](https://github.com/nousresearch/hermes-agent) is an open-source, self-improving AI agent by Nous Research. It has built-in browser automation tools that work with local Chromium out of the box. Add Browser Use and those tools run on cloud browsers with anti-detect profiles, residential proxies in 195+ countries, and stealth browsing.
+
+Two ways to set it up: configure Browser Use as Hermes's cloud browser backend, or install the Browser Use CLI and let Hermes drive it directly.
+
+## Option 1: Cloud Browser Backend
+
+Hermes has built-in browser tools (`browser_navigate`, `browser_click`, `browser_snapshot`, etc.) that default to local Chromium. Point them at Browser Use cloud browsers instead — no extra dependencies, same Hermes experience.
+
+### Setup
+
+**1. Get your API key**
+
+Sign up at [cloud.browser-use.com](https://cloud.browser-use.com) and copy your API key from [Settings → API Keys](https://cloud.browser-use.com/settings?tab=api-keys&new=1).
+
+Or let the agent provision one itself — see [Agent Self-Registration](#agent-self-registration) below.
+
+**2. Configure Hermes**
+
+Run the setup wizard:
+
+```bash
+hermes setup tools
+```
+
+Select **Browser Automation**, then **Browser Use**, and paste your API key when prompted.
+
+Or configure manually — add your key to `~/.hermes/.env`:
+
+```bash
+BROWSER_USE_API_KEY=your_key_here
+```
+
+And set the provider in `~/.hermes/config.yaml`:
+
+```yaml
+browser:
+  cloud_provider: browser-use
+```
+
+**3. Use it**
+
+Just chat with Hermes — any browsing tasks automatically route through Browser Use cloud browsers:
+
+```
+> Find the top trending repositories on GitHub today and summarize them
+```
+
+## Option 2: Browser Use CLI
+
+The [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli) is a standalone tool that gives Hermes browser automation through terminal commands. Hermes drives the browser directly via its terminal tool — giving you shared browser sessions across agents, persistent logins and cookies, profile management, and access to Browser Use's full command surface.
+
+### Setup
+
+**1. Install the CLI**
+
+```bash
+curl -fsSL https://browser-use.com/cli/install.sh | bash
+```
+
+**2. Verify the installation**
+
+```bash
+browser-use doctor
+```
+
+**3. Connect to cloud browsers**
+
+Log in with your API key:
+
+```bash
+browser-use cloud login <your-api-key>
+```
+
+Or let the agent provision one itself — see [Agent Self-Registration](#agent-self-registration) below.
+
+**4. Use it**
+
+Hermes can use the CLI commands directly via its terminal tool:
+
+```
+> Use browser-use to open github.com/trending and summarize the top repos
+```
+
+For the complete CLI reference and advanced features like cloud browsers, tunnels, sessions, and Python execution, see the [Browser Use CLI docs](https://docs.browser-use.com/open-source/browser-use-cli).
+
+## Agent Self-Registration
+
+Hermes can provision its own Browser Use API key autonomously — no human interaction needed. This works with both options above.
+
+Install the Browser Use CLI:
+
+```bash
+curl -fsSL https://browser-use.com/cli/install.sh | bash
+```
+
+The agent runs three CLI commands using its terminal tool:
+
+**1. Request a challenge**
+
+```bash
+browser-use cloud signup
+```
+
+Returns a `Challenge ID` and `Challenge` — an obfuscated math problem that requires LLM reasoning to solve.
+
+**2. Solve the challenge and verify**
+
+The agent solves the math problem, then verifies with the answer (a string with 2 decimal places, e.g. `"13.60"`):
+
+```bash
+browser-use cloud signup --verify <challenge-id> <answer>
+```
+
+The CLI saves the API key to `~/.browser-use/config.json` automatically.
+
+**3. Copy the key to Hermes config**
+
+For the cloud browser backend (Option 1):
+
+```bash
+hermes config set BROWSER_USE_API_KEY $(browser-use config get api_key)
+```
+
+For CLI mode (Option 2), the key is already saved — no extra step needed.
+
+### Claim the account (optional)
+
+If the human wants to see the account in the dashboard later:
+
+```bash
+browser-use cloud signup --claim
+```
+
+Returns a claim URL valid for 1 hour. The human can follow the link to sign up and claim the agent-created account.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -103,6 +103,7 @@
                     "icon": "plug",
                     "pages": [
                       "cloud/tutorials/integrations/openclaw",
+                      "cloud/tutorials/integrations/hermes-agent",
                       "cloud/guides/mcp-server",
                       "cloud/guides/webhooks",
                       "cloud/tutorials/integrations/n8n"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Hermes Agent integration guide that shows how to use Browser Use via cloud browser backend or the `browser-use` CLI, including a CLI-based self-signup flow for API keys. Updates the docs navigation to include the new page.

- New Features
  - New integration page covering: Option 1 (configure Hermes to use Browser Use cloud browsers) and Option 2 (drive browsers with the `browser-use` CLI), plus agent self-registration via `browser-use cloud signup` and claim flow.
  - Added `cloud/tutorials/integrations/hermes-agent` to the sidebar.

<sup>Written for commit 28bf785c21a22d96b9dd1d539021144692ae7b7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

