### PR TITLE
docs: add Claude Code integration page with CLI-based signup flow

### DIFF
--- a/docs/cloud/tutorials/integrations/claude-code.mdx
+++ b/docs/cloud/tutorials/integrations/claude-code.mdx
@@ -1,9 +1,9 @@
 ---
 title: Claude Code
-description: Give Claude Code browser automation with Browser Use — cloud browsers or your own Chrome.
+description: Give Claude Code cloud browser automation with Browser Use.
 ---
 
-[Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) is Anthropic's agentic coding tool that runs in the terminal. Add Browser Use and it can automate any browser — either free cloud browsers with anti-detect profiles, CAPTCHA solving, residential proxies in 195+ countries, and stealth browsing, or your own local Chrome with your existing logins and extensions.
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) is Anthropic's agentic coding tool that runs in the terminal. Add Browser Use and it gets full cloud browser automation — anti-detect profiles, CAPTCHA solving, residential proxies in 195+ countries, persistent profiles, and stealth browsing.
 
 ## Setup
 
@@ -27,15 +27,9 @@ The Browser Use skill teaches Claude Code the full CLI command set. Install it f
 npx skills add https://github.com/browser-use/browser-use --skill browser-use
 ```
 
-**4. Connect a browser**
+**4. Connect to cloud browsers**
 
-Use your own Chrome — Claude Code connects to your running browser with your existing logins and cookies:
-
-```bash
-browser-use connect
-```
-
-Or use a cloud browser instead. Sign up at [cloud.browser-use.com](https://cloud.browser-use.com) and connect:
+Sign up at [cloud.browser-use.com](https://cloud.browser-use.com) and connect:
 
 ```bash
 browser-use cloud login <your-api-key>
@@ -43,8 +37,6 @@ browser-use cloud connect
 ```
 
 Or let Claude Code provision a free API key itself — see [Agent Self-Registration](#agent-self-registration) below.
-
-After either `connect` or `cloud connect`, all subsequent commands go to that browser — no extra flags needed.
 
 **5. Use it**
 

--- a/docs/cloud/tutorials/integrations/claude-code.mdx
+++ b/docs/cloud/tutorials/integrations/claude-code.mdx
@@ -1,0 +1,97 @@
+---
+title: Claude Code
+description: Give Claude Code browser automation with Browser Use — cloud browsers or your own Chrome.
+---
+
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) is Anthropic's agentic coding tool that runs in the terminal. Add Browser Use and it can automate any browser — either free cloud browsers with anti-detect profiles, CAPTCHA solving, residential proxies in 195+ countries, and stealth browsing, or your own local Chrome with your existing logins and extensions.
+
+## Setup
+
+**1. Install the CLI**
+
+```bash
+curl -fsSL https://browser-use.com/cli/install.sh | bash
+```
+
+**2. Verify the installation**
+
+```bash
+browser-use doctor
+```
+
+**3. Install the skill**
+
+The Browser Use skill teaches Claude Code the full CLI command set. Install it from [skills.sh](https://skills.sh/browser-use/browser-use/browser-use):
+
+```bash
+npx skills add https://github.com/browser-use/browser-use --skill browser-use
+```
+
+**4. Connect a browser**
+
+Use your own Chrome — Claude Code connects to your running browser with your existing logins and cookies:
+
+```bash
+browser-use connect
+```
+
+Or use a cloud browser instead. Sign up at [cloud.browser-use.com](https://cloud.browser-use.com) and connect:
+
+```bash
+browser-use cloud login <your-api-key>
+browser-use cloud connect
+```
+
+Or let Claude Code provision a free API key itself — see [Agent Self-Registration](#agent-self-registration) below.
+
+After either `connect` or `cloud connect`, all subsequent commands go to that browser — no extra flags needed.
+
+**5. Use it**
+
+Claude Code uses its bash tool to run CLI commands directly:
+
+```
+> Use browser-use to open github.com/trending and summarize the top repos
+```
+
+For the complete CLI reference and advanced features like sessions, tunnels, and Python execution, see the [Browser Use CLI docs](https://docs.browser-use.com/open-source/browser-use-cli).
+
+## Agent Self-Registration
+
+Claude Code can provision its own Browser Use API key autonomously — no human interaction needed. The free tier includes unlimited browser hours, free proxies in 195+ countries, persistent browser profiles, CAPTCHA solving, and stealth browsing at zero cost.
+
+Install the Browser Use CLI:
+
+```bash
+curl -fsSL https://browser-use.com/cli/install.sh | bash
+```
+
+Claude Code runs two CLI commands using its bash tool:
+
+**1. Request a challenge**
+
+```bash
+browser-use cloud signup
+```
+
+Returns a `Challenge ID` and `Challenge` — an obfuscated math problem that requires LLM reasoning to solve.
+
+**2. Solve the challenge and verify**
+
+Claude Code solves the math problem, then verifies with the answer (a string with 2 decimal places, e.g. `"13.60"`):
+
+```bash
+browser-use cloud signup --verify <challenge-id> <answer>
+```
+
+The CLI saves the API key to `~/.browser-use/config.json` automatically. No extra configuration needed — Claude Code can start using cloud browser commands immediately.
+
+### Claim the account (optional)
+
+If the human wants to see the account in the dashboard later:
+
+```bash
+browser-use cloud signup --claim
+```
+
+Returns a claim URL valid for 1 hour. The human can follow the link to sign up and claim the agent-created account.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -102,6 +102,7 @@
                     "group": "Integrations",
                     "icon": "plug",
                     "pages": [
+                      "cloud/tutorials/integrations/claude-code",
                       "cloud/tutorials/integrations/openclaw",
                       "cloud/tutorials/integrations/hermes-agent",
                       "cloud/guides/mcp-server",

--- a/docs/open-source/browser-use-cli.mdx
+++ b/docs/open-source/browser-use-cli.mdx
@@ -102,14 +102,14 @@ browser-use open https://example.com
 # Visible browser window
 browser-use --headed open https://example.com
 
-# Use your real Chrome with Default profile (with existing logins/cookies)
-browser-use --profile "Default" open https://gmail.com
+# Connect to user's Chrome (preserves logins/cookies)
+browser-use connect
 
 # Use a specific Chrome profile
-browser-use --profile "Profile 1" open https://gmail.com
+browser-use --profile "Default" open https://gmail.com
 
-# Auto-discover and connect to running Chrome
-browser-use --connect open https://example.com
+# Cloud browser (zero-config, requires API key)
+browser-use cloud connect
 
 # Connect to an existing browser via CDP URL
 browser-use --cdp-url http://localhost:9222 open https://example.com
@@ -117,6 +117,8 @@ browser-use --cdp-url http://localhost:9222 open https://example.com
 # WebSocket CDP URL also works
 browser-use --cdp-url ws://localhost:9222/devtools/browser/... state
 ```
+
+After `connect` or `cloud connect`, all subsequent commands go to that browser — no extra flags needed.
 
 ## All Commands
 
@@ -154,9 +156,10 @@ browser-use --cdp-url ws://localhost:9222/devtools/browser/... state
 ### Tabs
 | Command | Description |
 |---------|-------------|
-| `switch <tab>` | Switch to tab by index |
-| `close-tab` | Close current tab |
-| `close-tab <tab>` | Close specific tab |
+| `tab list` | List all tabs |
+| `tab new [url]` | Open new tab (blank or with URL) |
+| `tab switch <index>` | Switch to tab by index |
+| `tab close [index...]` | Close tab(s) (current if no index) |
 
 ### Cookies
 | Command | Description |
@@ -213,18 +216,18 @@ Generic REST passthrough to the Browser-Use Cloud API, plus cloud browser provis
 
 | Command | Description |
 |---------|-------------|
-| `cloud connect` | Provision cloud browser and connect |
-| `cloud connect --timeout 120` | Cloud browser with custom timeout |
-| `cloud connect --proxy-country US` | Cloud browser with proxy |
-| `cloud connect --profile-id <id>` | Cloud browser with profile |
+| `cloud connect` | Provision cloud browser and connect (zero-config, auto-manages profile) |
 | `cloud login <api-key>` | Save API key |
 | `cloud logout` | Remove API key |
+| `cloud close` | Disconnect and stop cloud browser |
 | `cloud v2 GET <path>` | GET request to API v2 |
 | `cloud v2 POST <path> '<json>'` | POST request to API v2 |
 | `cloud v3 POST <path> '<json>'` | POST request to API v3 |
 | `cloud v2 poll <task-id>` | Poll task until done |
 | `cloud v2 --help` | Show API v2 endpoints (from OpenAPI spec) |
 | `cloud v3 --help` | Show API v3 endpoints |
+
+`cloud connect` provisions a cloud browser with a persistent profile (auto-created on first use), connects via CDP, and prints a live URL. For custom browser settings (proxy, timeout, specific profile), use `cloud v2 POST /browsers` directly.
 
 ```bash
 # Save API key (or set BROWSER_USE_API_KEY env var)
@@ -323,11 +326,24 @@ BROWSER_USE_SESSION=work browser-use state
 |--------|-------------|
 | `--headed` | Show browser window |
 | `--profile [NAME]` | Use real Chrome (bare `--profile` uses "Default") |
-| `--connect` | Auto-discover and connect to running Chrome via CDP |
+| `--connect` | Auto-discover and connect to running Chrome via CDP (prefer `connect` command instead) |
 | `--cdp-url <url>` | Connect to existing browser via CDP URL (`http://` or `ws://`) |
 | `--session NAME` | Target a named session (default: "default", env: `BROWSER_USE_SESSION`) |
 | `--json` | Output as JSON |
 | `--mcp` | Run as MCP server via stdin/stdout |
+
+## Configuration
+
+```bash
+browser-use config list                            # Show all config values
+browser-use config set cloud_connect_proxy jp      # Set a value
+browser-use config get cloud_connect_proxy         # Get a value
+browser-use config unset cloud_connect_timeout     # Remove a value
+browser-use doctor                                 # Shows config + diagnostics
+browser-use setup                                  # Interactive post-install setup
+```
+
+Config stored in `~/.browser-use/config.json`.
 
 ## Examples
 
@@ -392,6 +408,7 @@ All CLI-managed files live under `~/.browser-use/` (override with `BROWSER_USE_H
 ├── tunnels/
 │   ├── {port}.json      # Tunnel metadata
 │   └── {port}.log       # Tunnel logs
+├── default.state.json   # Daemon lifecycle state (phase, PID, config)
 ├── default.sock         # Daemon socket (ephemeral)
 ├── default.pid          # Daemon PID (ephemeral)
 └── cli.log              # Daemon log


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Claude Code integration guide with cloud-only setup for `browser-use`, including a CLI-based signup and verification flow. Also syncs the `browser-use` CLI docs with upstream and adds the page to Integrations.

- New page: `cloud/tutorials/integrations/claude-code.mdx` — cloud-only setup covers CLI install, adding the `browser-use` skill via `npx skills`, and connecting with `cloud login` + `cloud connect`; added to `docs.json` under Integrations.
- Agent self-registration: `browser-use cloud signup` + `--verify` saves the API key; optional `--claim` link for humans.
- CLI docs synced in `open-source/browser-use-cli.mdx`: new `connect` and `cloud connect` flow (subsequent commands target that browser), tab subcommands (`tab list/new/switch/close`), `cloud close`, new `config` commands and storage path, and updated examples/flags.

<sup>Written for commit 36613fabb1a44eaf36efcc42e5a63905089d7814. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

