### PR TITLE
Enable full Mintlify contextual menu providers

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -19,21 +19,12 @@
   },
   "contextual": {
     "options": [
-      "copy",
-      "view",
-      "assistant",
       "chatgpt",
       "claude",
-      "perplexity",
-      "grok",
-      "aistudio",
-      "devin",
-      "windsurf",
       "mcp",
       "add-mcp",
       "cursor",
-      "vscode",
-      "devin-mcp"
+      "vscode"
     ]
   },
   "fonts": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -18,7 +18,23 @@
     "default": "dark"
   },
   "contextual": {
-    "options": ["copy", "view"]
+    "options": [
+      "copy",
+      "view",
+      "assistant",
+      "chatgpt",
+      "claude",
+      "perplexity",
+      "grok",
+      "aistudio",
+      "devin",
+      "windsurf",
+      "mcp",
+      "add-mcp",
+      "cursor",
+      "vscode",
+      "devin-mcp"
+    ]
   },
   "fonts": {
     "family": "Geist"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- narrow `docs/docs.json` `contextual.options` to just the requested Mintlify contextual menu entries
- enable `chatgpt`, `claude`, `mcp`, `add-mcp`, `cursor`, and `vscode`
- remove the additional AI providers and actions from the previous pass

## Validation
- parsed `docs/docs.json` successfully with Node (`node -e "JSON.parse(require('fs').readFileSync('docs/docs.json','utf8'))"`)
- verified the option identifiers against Mintlify's contextual menu docs
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://browser-use.slack.com/archives/C08P3EMVDJ5/p1776375943318599?thread_ts=1776375943.318599&cid=C08P3EMVDJ5)

<div><a href="https://cursor.com/agents/bc-9f1f3a32-0946-5d2e-bc27-2df8bb15ba0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f1f3a32-0946-5d2e-bc27-2df8bb15ba0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits the Mintlify contextual menu in `docs/docs.json` to the approved options for a cleaner experience. Enables quick actions for `chatgpt`, `claude`, `mcp`, `add-mcp`, `cursor`, and `vscode` directly from the docs.

<sup>Written for commit 2836e87172ca2546a3b04e031a27effb0ba21c93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

