### PR TITLE
Add Browser Use Box example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ Official SDKs for [Browser Use Cloud](https://browser-use.com).
 ## Docs
 
 [docs.browser-use.com](https://docs.browser-use.com)
+
+## Example Project
+
+[Browser Use Box](https://github.com/browser-use/bux) is a self-hosted 24/7 agent that uses Browser Use Cloud from a Linux box and Telegram. [Watch the demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).


### PR DESCRIPTION
## Summary
- add Browser Use Box as an example project for the Browser Use Cloud SDK
- link the public Browser Use Box repo and TikTok demo

## Test plan
- docs-only README change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an Example Project section to the README with a link to Browser Use Box and its demo. This gives users a self-hosted agent example that uses Browser Use Cloud from a Linux box with Telegram.

<sup>Written for commit eb0805ba5176ad093408cabdb8936cb8ba383bec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

