### PR TITLE
Add Browser Use Box integration docs

### DIFF
--- a/docs/cloud/tutorials/integrations/browser-use-box.mdx
+++ b/docs/cloud/tutorials/integrations/browser-use-box.mdx
@@ -1,0 +1,58 @@
+---
+title: Browser Use Box
+description: Run a self-hosted, always-on Browser Use Cloud agent from Telegram.
+---
+
+[Browser Use Box](https://github.com/browser-use/bux) is a self-hosted Linux box agent for Browser Use Cloud. It keeps a Browser Use profile online, accepts tasks from Telegram, and can keep working in the background while you are away.
+
+Use it when you want a personal agent that can:
+
+- run on your own VPS or spare Linux machine
+- control a real Browser Use Cloud browser with persistent cookies
+- resume work from Telegram forum topics
+- schedule recurring checks with cron, `at`, or `tg-schedule`
+- hand off login walls, 2FA, CAPTCHA, and Cloudflare through the live browser URL
+
+Watch the short setup and usage demo on TikTok: [Browser Use Box demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
+
+## Setup
+
+Clone the repo and follow the install guide:
+
+```bash
+git clone https://github.com/browser-use/bux
+cd bux
+```
+
+See the full install path in the [Browser Use Box README](https://github.com/browser-use/bux) and [install guide](https://github.com/browser-use/bux/blob/main/install.md).
+
+## Browser Use Cloud
+
+Browser Use Box uses a long-lived Browser Use Cloud browser session instead of launching local Chrome. The box stores the active CDP WebSocket, live browser URL, profile ID, and browser ID in its browser environment file so agents can reconnect between tasks.
+
+Typical browser automation from the box looks like this:
+
+```bash
+source ~/.claude/browser.env
+browser-harness-js 'await session.connect({wsUrl: process.env.BU_CDP_WS}); await session.Page.navigate({url: "https://example.com"})'
+```
+
+Cookies persist through the bound Browser Use profile. When a site needs a human step, the agent shares the live browser URL and waits for the user to finish the login or challenge.
+
+## Telegram Control
+
+Browser Use Box turns Telegram topics into parallel agent sessions. Each topic gets its own working context, while the Linux box keeps long-running work, schedules, and browser state available across turns.
+
+Example prompts:
+
+- `monitor my Gmail every 30 minutes and draft replies`
+- `watch this PR and tell me when CI is green`
+- `use the browser to update this dashboard`
+- `schedule a daily startup metrics brief`
+
+## Learn More
+
+- [Browser Use Box repo](https://github.com/browser-use/bux)
+- [Public launch page](https://browser-use.github.io/bux/)
+- [TikTok demo](https://www.tiktok.com/@browser_use/video/7639824093721758989)
+- [Playwright automation notes](https://github.com/browser-use/bux/blob/main/docs/playwright-automation.md)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -110,6 +110,7 @@
                     "icon": "plug",
                     "pages": [
                       "cloud/tutorials/integrations/claude-code",
+                      "cloud/tutorials/integrations/browser-use-box",
                       "cloud/tutorials/integrations/openclaw",
                       "cloud/tutorials/integrations/hermes-agent",
                       "cloud/guides/mcp-server",


### PR DESCRIPTION
## Summary
- add Browser Use Box to the Cloud SDK integrations docs nav
- document how it uses Browser Use Cloud and Telegram from a self-hosted box
- include the public launch links and TikTok demo

## Test plan
- python3 -m json.tool docs/docs.json

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new Browser Use Box integration doc and link it in the Integrations nav. It covers setup, running a self-hosted Telegram-controlled agent that uses long-lived Browser Use Cloud sessions, example prompts, and links to the launch page and TikTok demo.

<sup>Written for commit 872be01abefa6ec6246fed2982f4cfb562f5bb74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

