### PR TITLE
Add Browser Use Box package README links

### DIFF
--- a/browser-use-node/README.md
+++ b/browser-use-node/README.md
@@ -40,6 +40,10 @@ console.log(result.output);
 
 [docs.browser-use.com](https://docs.browser-use.com)
 
+## Example Project
+
+[Browser Use Box](https://github.com/browser-use/bux) is a self-hosted 24/7 agent that uses Browser Use Cloud from a Linux box and Telegram. [Watch the demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
+
 ## License
 
 MIT

--- a/browser-use-python/README.md
+++ b/browser-use-python/README.md
@@ -40,6 +40,10 @@ print(result.output)
 
 [docs.browser-use.com](https://docs.browser-use.com)
 
+## Example Project
+
+[Browser Use Box](https://github.com/browser-use/bux) is a self-hosted 24/7 agent that uses Browser Use Cloud from a Linux box and Telegram. [Watch the demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- add Browser Use Box as an example project in the Python package README
- add Browser Use Box as an example project in the Node package README
- link the public TikTok demo from both package-facing docs

## Test plan
- docs-only README changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Browser Use Box example links to the `browser-use-node` and `browser-use-python` READMEs, including a TikTok demo. This showcases a real-world 24/7 self-hosted agent and helps users get started faster.

<sup>Written for commit 2f11fe7ddf793d146ce9c4d4141402f73a3ed06f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

