### PR TITLE
Add Browser Use Box to Cloud quickstart

### DIFF
--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -43,6 +43,8 @@ console.log(result.output);
 
 Want a full working app? Check out the [Chat UI example](https://docs.browser-use.com/cloud/tutorials/chat-ui).
 
+Want an always-on Browser Use Cloud agent from your own Linux box? Use [Browser Use Box](https://docs.browser-use.com/cloud/tutorials/integrations/browser-use-box) for Telegram control, persistent browser profiles, and scheduled background work. [Watch the short demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
+
 ## Agent vs Browser
 
 | | **Agent** | **Browser** |

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -46,6 +46,8 @@ console.log(result.output);
 
 Want a full working app? Check out the [Chat UI example](/cloud/tutorials/chat-ui).
 
+Want an always-on Browser Use Cloud agent from your own Linux box? Use [Browser Use Box](/cloud/tutorials/integrations/browser-use-box) for Telegram control, persistent browser profiles, and scheduled background work. [Watch the short demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
+
 ## Agent vs Browser
 
 | | **Agent** | **Browser** |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -43,6 +43,8 @@ console.log(result.output);
 
 Want a full working app? Check out the [Chat UI example](https://docs.browser-use.com/cloud/tutorials/chat-ui).
 
+Want an always-on Browser Use Cloud agent from your own Linux box? Use [Browser Use Box](https://docs.browser-use.com/cloud/tutorials/integrations/browser-use-box) for Telegram control, persistent browser profiles, and scheduled background work. [Watch the short demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
+
 ## Agent vs Browser
 
 | | **Agent** | **Browser** |


### PR DESCRIPTION
## Summary
- link Browser Use Box from the Cloud quickstart as the always-on Linux box path
- add the TikTok demo link to the generated full LLM indexes near the quickstart content

## Test
- git diff --check
- python assertion for quickstart and both full LLM files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a link to Browser Use Box in the Cloud quickstart to offer an always‑on Linux box path for Cloud agents. Also added a TikTok demo link near the full LLM index content in both Cloud and root docs.

<sup>Written for commit 392c6bca8bbcd572d839342cad66026ff8d516df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

