### PR TITLE
Revert "Add Browser Use Box package README links"

### DIFF
--- a/browser-use-node/README.md
+++ b/browser-use-node/README.md
@@ -40,10 +40,6 @@ console.log(result.output);
 
 [docs.browser-use.com](https://docs.browser-use.com)
 
-## Example Project
-
-[Browser Use Box](https://github.com/browser-use/bux) is a self-hosted 24/7 agent that uses Browser Use Cloud from a Linux box and Telegram. [Watch the demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
-
 ## License
 
 MIT

--- a/browser-use-python/README.md
+++ b/browser-use-python/README.md
@@ -40,10 +40,6 @@ print(result.output)
 
 [docs.browser-use.com](https://docs.browser-use.com)
 
-## Example Project
-
-[Browser Use Box](https://github.com/browser-use/bux) is a self-hosted 24/7 agent that uses Browser Use Cloud from a Linux box and Telegram. [Watch the demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
-
 ## License
 
 MIT


### PR DESCRIPTION
Reverts browser-use/sdk#144

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the "Example Project" section linking to Browser Use Box from the `browser-use-node` and `browser-use-python` READMEs, reverting the earlier addition to keep package docs focused.

<sup>Written for commit 0199b5c76884932f014a8f6ddcf4aaca17997a5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

