### PR TITLE
Revert "Add Browser Use Box example link"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,3 @@ Official SDKs for [Browser Use Cloud](https://browser-use.com).
 ## Docs
 
 [docs.browser-use.com](https://docs.browser-use.com)
-
-## Example Project
-
-[Browser Use Box](https://github.com/browser-use/bux) is a self-hosted 24/7 agent that uses Browser Use Cloud from a Linux box and Telegram. [Watch the demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).


### PR DESCRIPTION
Reverts browser-use/sdk#142

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the "Example Project" section and the `Browser Use Box` link from the README by reverting the previous addition. Keeps the README focused on core docs and avoids external links.

<sup>Written for commit 783e7cf18d24917018a794b1fc509568ec8d1f86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

