### PR TITLE
Revert "Add Browser Use Box to Cloud quickstart"

### DIFF
--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -43,8 +43,6 @@ console.log(result.output);
 
 Want a full working app? Check out the [Chat UI example](https://docs.browser-use.com/cloud/tutorials/chat-ui).
 
-Want an always-on Browser Use Cloud agent from your own Linux box? Use [Browser Use Box](https://docs.browser-use.com/cloud/tutorials/integrations/browser-use-box) for Telegram control, persistent browser profiles, and scheduled background work. [Watch the short demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
-
 ## Agent vs Browser
 
 | | **Agent** | **Browser** |

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -46,8 +46,6 @@ console.log(result.output);
 
 Want a full working app? Check out the [Chat UI example](/cloud/tutorials/chat-ui).
 
-Want an always-on Browser Use Cloud agent from your own Linux box? Use [Browser Use Box](/cloud/tutorials/integrations/browser-use-box) for Telegram control, persistent browser profiles, and scheduled background work. [Watch the short demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
-
 ## Agent vs Browser
 
 | | **Agent** | **Browser** |

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -43,8 +43,6 @@ console.log(result.output);
 
 Want a full working app? Check out the [Chat UI example](https://docs.browser-use.com/cloud/tutorials/chat-ui).
 
-Want an always-on Browser Use Cloud agent from your own Linux box? Use [Browser Use Box](https://docs.browser-use.com/cloud/tutorials/integrations/browser-use-box) for Telegram control, persistent browser profiles, and scheduled background work. [Watch the short demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
-
 ## Agent vs Browser
 
 | | **Agent** | **Browser** |


### PR DESCRIPTION
Reverts browser-use/sdk#146

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the “Browser Use Box” callout from the Cloud quickstart and LLM docs to keep the quickstart focused. Removes the line in docs/cloud/quickstart.mdx, docs/cloud/llms-full.txt, and docs/llms-full.txt.

<sup>Written for commit 609742148da4e1a312ece7e64e52e471564732f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

