### PR TITLE
Add Qianfan to the supported models page

### DIFF
--- a/docs/open-source/supported-models.mdx
+++ b/docs/open-source/supported-models.mdx
@@ -564,4 +564,5 @@ agent = Agent(
 Any provider with an OpenAI-compatible endpoint works via `ChatOpenAI` with a custom `base_url`:
 
 **Examples available:**
+- [Qianfan (Baidu)](https://github.com/browser-use/browser-use/blob/main/examples/models/qianfan.py)
 - [Novita](https://github.com/browser-use/browser-use/blob/main/examples/models/novita.py)


### PR DESCRIPTION
## Summary

This PR adds Qianfan to the public supported-models page under "Other OpenAI-Compatible Providers".

Changes:
- add a Qianfan example link to `docs/open-source/supported-models.mdx`

## Why

The open-source repo now includes a Qianfan example in browser-use/browser-use#4842, so the public docs should link to it from the supported-models page as well.

This keeps the user-facing docs aligned with the available examples and makes the Qianfan integration easier to discover.

## Scope

This is a docs-only change.
It does not change any SDK or runtime behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Qianfan (Baidu) to the supported models page with a link to the example under Other OpenAI-Compatible Providers. This keeps `docs/open-source/supported-models.mdx` aligned with available examples and makes the Qianfan integration easier to find.

<sup>Written for commit be27c7e5432638fb0b55131ae03c2d65dc5acd97. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/sdk/pull/152?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

