### PR TITLE
fix: proxy_country_code=None preserved in SessionSettings

### DIFF
--- a/browser-use-python/src/browser_use_sdk/v2/resources/tasks.py
+++ b/browser-use-python/src/browser_use_sdk/v2/resources/tasks.py
@@ -80,7 +80,7 @@ def _build_create_body(
     if op_vault_id is not None:
         body["opVaultId"] = op_vault_id
     if session_settings is not None:
-        body["sessionSettings"] = session_settings.model_dump(by_alias=True, exclude_none=True)
+        body["sessionSettings"] = session_settings.model_dump(by_alias=True, exclude_unset=True)
     body.update(extra)
     return body
 


### PR DESCRIPTION
## Summary
`SessionSettings.model_dump(exclude_none=True)` stripped `proxyCountryCode` when user explicitly set `proxy_country_code=None` to disable the proxy. The backend never saw the null and defaulted to US proxy.

Fix: `exclude_none=True` → `exclude_unset=True`. This drops fields the user never set (backend uses its defaults) but preserves fields explicitly set to `None` (sent as `null` on the wire).

## Example
```python
# Before: proxy still used despite None
bu.tasks.create("...", session_settings=SessionSettings(proxy_country_code=None))
# Body sent: {"sessionSettings": {}}  ← proxyCountryCode stripped!

# After: proxy correctly disabled
# Body sent: {"sessionSettings": {"proxyCountryCode": null}}  ← preserved
```

Fixes ENG-4710.

## Test plan
- [ ] `SessionSettings(proxy_country_code=None)` sends `proxyCountryCode: null`
- [ ] `SessionSettings()` (no proxy arg) omits `proxyCountryCode` (backend defaults to US)
- [ ] `SessionSettings(proxy_country_code="de")` sends `proxyCountryCode: "de"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves explicit `proxy_country_code=None` in `SessionSettings` so the backend receives `proxyCountryCode: null` and disables the proxy. Switches `model_dump(..., exclude_none=True)` to `exclude_unset=True` to drop only unset fields; fixes ENG-4710.

<sup>Written for commit af37e9c5dd7193ac30e6ad2bfeaad89a65fec0ea. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/sdk/pull/153?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

