### PR TITLE
feat: systemPromptExtension limit 10,000 + version 3.7.0

### DIFF
--- a/browser-use-python/pyproject.toml
+++ b/browser-use-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "browser-use-sdk"
-version = "3.6.0"
+version = "3.7.0"
 description = "Python SDK for the Browser Use cloud API"
 readme = "README.md"
 license = "MIT"

--- a/browser-use-python/src/browser_use_sdk/generated/v2/models.py
+++ b/browser-use-python/src/browser_use_sdk/generated/v2/models.py
@@ -1651,7 +1651,7 @@ class CreateTaskRequest(BaseModel):
         '',
         alias='systemPromptExtension',
         description='Optional extension to the agent system prompt.',
-        max_length=2000,
+        max_length=10000,
         title='System Prompt Extension',
     )
     judge: bool | None = Field(


### PR DESCRIPTION
## Summary
- Raise `systemPromptExtension` max_length from 2,000 to 10,000 chars (matches backend cloud#4449)
- Bump version to 3.7.0 for release

## Test plan
- [ ] `system_prompt_extension` with 5,000 chars passes validation
- [ ] Publish to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase `systemPromptExtension` max length from 2,000 to 10,000 to match the backend and allow longer prompts. Bump `browser-use-sdk` to `3.7.0`.

<sup>Written for commit 1d1b40d6b16b29c85bb89d255941f62c3ca75dd7. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/sdk/pull/154?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

