### PR TITLE
fix: populate_by_name on SessionSettings + bump 3.7.1

### DIFF
--- a/browser-use-python/pyproject.toml
+++ b/browser-use-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "browser-use-sdk"
-version = "3.7.0"
+version = "3.7.1"
 description = "Python SDK for the Browser Use cloud API"
 readme = "README.md"
 license = "MIT"

--- a/browser-use-python/src/browser_use_sdk/generated/v2/models.py
+++ b/browser-use-python/src/browser_use_sdk/generated/v2/models.py
@@ -754,6 +754,8 @@ class SessionNotFoundError(BaseModel):
 
 
 class SessionSettings(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     profile_id: UUID | None = Field(
         None,
         alias='profileId',


### PR DESCRIPTION
## Summary
3.7.0 shipped `exclude_unset=True` for SessionSettings serialization, but `model_fields_set` was empty when using Python field names (`proxy_country_code`) because the model lacked `populate_by_name=True`. This meant the proxy fix didn't actually work.

## Verified
```
SessionSettings(proxy_country_code=None)  → {"proxyCountryCode": null}   ✓
SessionSettings(proxy_country_code="de")  → {"proxyCountryCode": "de"}   ✓  
SessionSettings()                         → {}                            ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix SessionSettings serialization with `exclude_unset=True` by enabling `populate_by_name`, so fields set via Python names (e.g., `proxy_country_code`) are correctly tracked and serialized with their aliases. Bumps the SDK to 3.7.1.

- **Bug Fixes**
  - Added `model_config = ConfigDict(populate_by_name=True)` to `SessionSettings` so explicitly set fields using Python names are included in JSON (e.g., `proxy_country_code=None` → `{"proxyCountryCode": null}`, unset → omitted).

<sup>Written for commit c013d8eaa46f7d1affd73ef7fbad9a99a1232279. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/sdk/pull/155?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

