### PR TITLE
docs: clean up supported models page

### DIFF
--- a/docs/cloud/legacy/agent.mdx
+++ b/docs/cloud/legacy/agent.mdx
@@ -9,7 +9,6 @@ icon: robot
 | Model | API String | Cost per Step |
 | ----- | ---------- | ------------- |
 | Browser Use 2.0 (default) | `browser-use-2.0` | \$0.006 |
-| Browser Use LLM | `browser-use-llm` | \$0.002 |
 | O3 | `o3` | \$0.03 |
 | Gemini Flash Latest | `gemini-flash-latest` | \$0.0075 |
 | Gemini Flash Lite Latest | `gemini-flash-lite-latest` | \$0.005 |

--- a/docs/open-source/supported-models.mdx
+++ b/docs/open-source/supported-models.mdx
@@ -16,11 +16,8 @@ Browser Use natively supports 15+ LLM providers. Most providers accept any model
 ```python
 from browser_use import Agent, ChatBrowserUse
 
-# Initialize the model (defaults to bu-latest)
+# Initialize the model - defaults to bu-latest (bu-2-0)
 llm = ChatBrowserUse()
-
-# Or use the premium model
-llm = ChatBrowserUse(model='bu-2-0')
 
 # Create agent with the model
 agent = Agent(
@@ -37,24 +34,11 @@ BROWSER_USE_API_KEY=
 
 Get your API key from the [Browser Use Cloud](https://cloud.browser-use.com/new-api-key). New users get 5 free tasks.
 
-#### Available Models
-
-- `bu-latest` or `bu-1-0`: Default model
-- `bu-2-0`: Latest premium model with improved capabilities
-
 #### Pricing
 
 ChatBrowserUse offers competitive pricing per 1 million tokens:
 
-**bu-1-0 / bu-latest (Default)**
-
-| Token Type | Price per 1M tokens |
-|------------|---------------------|
-| Input tokens | $0.20 |
-| Cached tokens | $0.02 |
-| Output tokens | $2.00 |
-
-**bu-2-0 (Premium)**
+**bu-2-0 / bu-latest (Default)**
 
 | Token Type | Price per 1M tokens |
 |------------|---------------------|


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cleaned up the supported models docs by making `bu-latest` (`bu-2-0`) the clear default, removing outdated references, and consolidating pricing into a single `bu-2-0`/`bu-latest` table. Also removed the deprecated `browser-use-llm` row from the legacy Cloud agent pricing.

<sup>Written for commit 27e2929d746f1fc8cce1915a5c65ee817724f584. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/sdk/pull/156?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

