### PR TITLE
x402: add get_wallet_balance / getWalletBalance via wallet signature

### DIFF
--- a/browser-use-node/src/core/x402.ts
+++ b/browser-use-node/src/core/x402.ts
@@ -46,7 +46,7 @@ function buildWalletAuthMessage(address: string, issuedAt: string, nonce: string
  */
 export async function getWalletBalance(
   privateKey: `0x${string}` | string,
-  opts: { baseUrl?: string } = {},
+  opts: { baseUrl?: string; extra?: Record<string, unknown> } = {},
 ): Promise<X402WalletBalance> {
   let viem;
   try {
@@ -67,7 +67,7 @@ export async function getWalletBalance(
   const resp = await fetch(`${baseUrl}/x402/balance`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ address: account.address, issued_at: issuedAt, nonce, signature }),
+    body: JSON.stringify({ address: account.address, issued_at: issuedAt, nonce, signature, ...opts.extra }),
   });
   if (!resp.ok) {
     throw new Error(`x402 balance check failed: ${resp.status} ${await resp.text()}`);

--- a/browser-use-node/src/core/x402.ts
+++ b/browser-use-node/src/core/x402.ts
@@ -18,6 +18,62 @@ export type FetchLike = (
 
 export const X402_BASE_URL_DEFAULT = "https://x402.api.browser-use.com/api/v3";
 export const X402_BASE_URL_DEFAULT_V2 = "https://x402.api.browser-use.com/api/v2";
+export const X402_BALANCE_BASE_URL_DEFAULT = "https://api.browser-use.com/api/v3";
+
+export interface X402WalletBalance {
+  wallet: string;
+  project_id: string;
+  total_credits_usd: number;
+  additional_credits_usd: number;
+}
+
+function buildWalletAuthMessage(address: string, issuedAt: string, nonce: string): string {
+  return (
+    "Browser Use x402 wallet authentication\n" +
+    "Action: read credit balance\n" +
+    `Wallet: ${address}\n` +
+    `Issued At: ${issuedAt}\n` +
+    `Nonce: ${nonce}`
+  );
+}
+
+/**
+ * Read a wallet-derived project's credit balance
+ *
+ * Authenticates with an off-chain wallet signature (EIP-191): signs a
+ * message proving control of the address; the server resolves the wallet to its
+ * project and returns the balance
+ */
+export async function getWalletBalance(
+  privateKey: `0x${string}` | string,
+  opts: { baseUrl?: string } = {},
+): Promise<X402WalletBalance> {
+  let viem;
+  try {
+    // @ts-ignore - optional peer dep, may not be installed
+    viem = await import("viem/accounts");
+  } catch {
+    throw new Error(MISSING_X402);
+  }
+  const key = privateKey.startsWith("0x") ? privateKey : `0x${privateKey}`;
+  const account = viem.privateKeyToAccount(key as `0x${string}`);
+
+  const issuedAt = new Date().toISOString();
+  const nonce = crypto.randomUUID().replace(/-/g, "");
+  const message = buildWalletAuthMessage(account.address, issuedAt, nonce);
+  const signature = await account.signMessage({ message });
+
+  const baseUrl = (opts.baseUrl ?? X402_BALANCE_BASE_URL_DEFAULT).replace(/\/$/, "");
+  const resp = await fetch(`${baseUrl}/x402/balance`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ address: account.address, issued_at: issuedAt, nonce, signature }),
+  });
+  if (!resp.ok) {
+    throw new Error(`x402 balance check failed: ${resp.status} ${await resp.text()}`);
+  }
+  return (await resp.json()) as X402WalletBalance;
+}
 
 const MISSING_X402 =
   "x402 mode requires the optional peer deps. Install them with: " +

--- a/browser-use-node/src/v3.ts
+++ b/browser-use-node/src/v3.ts
@@ -3,6 +3,9 @@ export type { BrowserUseOptions, RunSessionOptions } from "./v3/client.js";
 
 export { BrowserUseError } from "./core/errors.js";
 
+export { getWalletBalance } from "./core/x402.js";
+export type { X402WalletBalance } from "./core/x402.js";
+
 export { SessionRun } from "./v3/helpers.js";
 export type { RunOptions, SessionResult } from "./v3/helpers.js";
 

--- a/browser-use-python/src/browser_use_sdk/_core/x402.py
+++ b/browser-use-python/src/browser_use_sdk/_core/x402.py
@@ -44,6 +44,7 @@ async def get_wallet_balance(
     *,
     base_url: str = X402_BALANCE_BASE_URL_DEFAULT,
     timeout: float = 30.0,
+    **extra: Any,
 ) -> dict[str, Any]:
     """Read a wallet-derived project's credit balance
 
@@ -81,6 +82,7 @@ async def get_wallet_balance(
                 "issued_at": issued_at,
                 "nonce": nonce,
                 "signature": signature,
+                **extra,
             },
         )
         resp.raise_for_status()
@@ -112,9 +114,7 @@ def x402_client_from_private_key(private_key: str) -> X402Client:
         eth_account = importlib.import_module("eth_account")
         x402_pkg = importlib.import_module("x402")
         evm_pkg = importlib.import_module("x402.mechanisms.evm")
-        register_pkg = importlib.import_module(
-            "x402.mechanisms.evm.exact.register"
-        )
+        register_pkg = importlib.import_module("x402.mechanisms.evm.exact.register")
     except ImportError as e:
         raise _missing_x402() from e
 

--- a/browser-use-python/src/browser_use_sdk/_core/x402.py
+++ b/browser-use-python/src/browser_use_sdk/_core/x402.py
@@ -24,6 +24,68 @@ X402Client = Any
 X402_BASE_URL_DEFAULT = "https://x402.api.browser-use.com/api/v3"
 X402_BASE_URL_DEFAULT_V2 = "https://x402.api.browser-use.com/api/v2"
 
+# Balance check is served on the regular (non-x402) host
+X402_BALANCE_BASE_URL_DEFAULT = "https://api.browser-use.com/api/v3"
+
+
+def _build_wallet_auth_message(address: str, issued_at: str, nonce: str) -> str:
+    # MUST match the backend's build_wallet_auth_message exactly.
+    return (
+        "Browser Use x402 wallet authentication\n"
+        "Action: read credit balance\n"
+        f"Wallet: {address}\n"
+        f"Issued At: {issued_at}\n"
+        f"Nonce: {nonce}"
+    )
+
+
+async def get_wallet_balance(
+    private_key: str,
+    *,
+    base_url: str = X402_BALANCE_BASE_URL_DEFAULT,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Read a wallet-derived project's credit balance
+
+    Authenticates with an off-chain wallet signature (EIP-191): signs a
+    canonical message proving control of the address; the server resolves the
+    wallet to its project and returns the balance.
+
+    Returns the parsed JSON: ``wallet``, ``project_id``, ``total_credits_usd``,
+    ``additional_credits_usd``.
+    """
+    import secrets
+    from datetime import datetime, timezone
+
+    try:
+        import httpx
+        from eth_account import Account
+        from eth_account.messages import encode_defunct
+    except ImportError as e:
+        raise _missing_x402() from e
+
+    account = Account.from_key(private_key)
+    address = account.address
+    issued_at = datetime.now(timezone.utc).isoformat()
+    nonce = secrets.token_hex(16)
+    message = _build_wallet_auth_message(address, issued_at, nonce)
+    signature = account.sign_message(encode_defunct(text=message)).signature.hex()
+    if not signature.startswith("0x"):
+        signature = "0x" + signature
+
+    async with httpx.AsyncClient(timeout=timeout) as http:
+        resp = await http.post(
+            f"{base_url.rstrip('/')}/x402/balance",
+            json={
+                "address": address,
+                "issued_at": issued_at,
+                "nonce": nonce,
+                "signature": signature,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+
 
 def _missing_x402() -> ImportError:
     return ImportError(

--- a/browser-use-python/src/browser_use_sdk/v3/__init__.py
+++ b/browser-use-python/src/browser_use_sdk/v3/__init__.py
@@ -1,6 +1,7 @@
 from .client import AsyncBrowserUse, BrowserUse
 from .helpers import AsyncSessionRun, SessionResult
 from .._core.errors import BrowserUseError
+from .._core.x402 import get_wallet_balance
 
 from ..generated.v3.models import (
     AccountView,
@@ -43,6 +44,8 @@ __all__ = [
     "AsyncSessionRun",
     "SessionResult",
     "BrowserUseError",
+    # x402
+    "get_wallet_balance",
     # Billing models
     "AccountView",
     "PlanInfo",

--- a/docs/cloud/guides/x402.mdx
+++ b/docs/cloud/guides/x402.mdx
@@ -177,6 +177,44 @@ When the backend sees both a payment and a valid API key, the credit goes to the
 - Adding credits via crypto when you already have a regular Browser Use account
 - Multi-wallet setups funding one shared account
 
+## Checking your credit balance
+
+When you sign up the normal way, Browser Use creates an **account** for you (we call it a "project") that holds your credits and runs your tasks, and you log into it with an API key. When you pay with **only a wallet** (no API key), there's no signup step — so the very first time you pay, Browser Use automatically creates one of these same accounts for you and ties it to your wallet. From then on it behaves exactly like a normal account. The only difference is how you prove it's yours: instead of an API key, you sign with your wallet.
+
+To check your wallet's balance, just use the method below:
+
+<CodeGroup>
+```python Python
+from browser_use_sdk.v3 import get_wallet_balance
+
+balance = await get_wallet_balance("0x...")  # same wallet private key you pay with
+print(balance["total_credits_usd"])
+```
+```typescript TypeScript
+import { getWalletBalance } from "browser-use-sdk/v3";
+
+const balance = await getWalletBalance("0x...");  // same wallet private key you pay with
+console.log(balance.total_credits_usd);
+```
+</CodeGroup>
+
+The response contains:
+
+| Field | Description |
+| --- | --- |
+| `wallet` | The wallet address (lowercased) |
+| `project_id` | The account (project) tied to your wallet that the credits live in |
+| `total_credits_usd` | Total credit balance, in USD |
+| `additional_credits_usd` | Credits added via x402 top-ups (excludes any plan allowance) |
+
+<Note>
+  This is for accounts created from a wallet (the default x402 mode). If you're [topping up an existing account](#topping-up-an-existing-account), check that account's balance the normal way with your API key via `client.billing.account()`. A wallet that has never paid yet has no account, so the call returns `404` until the first payment.
+</Note>
+
+<Accordion title="How the balance check works">
+  The SDK signs a fixed, server-defined message ([EIP-191](https://eips.ethereum.org/EIPS/eip-191), the same "Sign-In with Ethereum" mechanism) with your wallet's private key. The signature proves you control the address without moving any funds. The server recovers the signer, matches it to the wallet's project, and returns the balance.
+</Accordion>
+
 ## How it works
 
 Your code asks for something, we say "$5 please", your wallet pays automatically, we run your request.
@@ -254,12 +292,12 @@ const client = new BrowserUse({ x402 });
     You haven't installed the optional x402 deps. Run `pip install "browser-use-sdk[x402]"` (Python) or `npm install @x402/fetch @x402/evm viem` (TypeScript).
   </Accordion>
 
-  <Accordion title='HTTP 500 with "payment was settled but processing failed"'>
-    The on-chain payment may or may not have settled — contact support with your wallet address. This is very rare.
+  <Accordion title='HTTP 503 with "payment was not settled... you were not charged"'>
+    We verified your payment request but couldn't credit your project, so we deliberately **did not settle on-chain** — no USDC moved. Just retry; it's safe. This is rare.
   </Accordion>
 
   <Accordion title="Insufficient credits despite paying">
-    Wait a few seconds. Settlement and credit grant happen in the same request, but the response may be sent before the credit grant fully commits. If credits still show `$0` after a few minutes, contact support.
+    Wait a few seconds. Settlement and credit grant happen in the same request, but the response may be sent before the credit grant fully commits. If credits still show `$0` after a few minutes, contact support with your wallet address. (Conversely, if a payment settles but the request itself then fails, we automatically reclaim the credits so you aren't charged for nothing.)
   </Accordion>
 
   <Accordion title="Wallet on the wrong network">

--- a/docs/cloud/guides/x402.mdx
+++ b/docs/cloud/guides/x402.mdx
@@ -181,7 +181,9 @@ When the backend sees both a payment and a valid API key, the credit goes to the
 
 When you sign up the normal way, Browser Use creates an **account** for you (we call it a "project") that holds your credits and runs your tasks, and you log into it with an API key. When you pay with **only a wallet** (no API key), there's no signup step — so the very first time you pay, Browser Use automatically creates one of these same accounts for you and ties it to your wallet. From then on it behaves exactly like a normal account. The only difference is how you prove it's yours: instead of an API key, you sign with your wallet.
 
-To check your wallet's balance, just use the method below:
+This balance is your **Browser Use credit balance** — the prepaid USD you've added to that account through x402 payments, minus what your tasks have spent.
+
+To check how much credit that account has left, use the method below:
 
 <CodeGroup>
 ```python Python
@@ -204,8 +206,8 @@ The response contains:
 | --- | --- |
 | `wallet` | The wallet address (lowercased) |
 | `project_id` | The account (project) tied to your wallet that the credits live in |
-| `total_credits_usd` | Total credit balance, in USD |
-| `additional_credits_usd` | Credits added via x402 top-ups (excludes any plan allowance) |
+| `total_credits_usd` | Your remaining Browser Use credit balance, in USD |
+| `additional_credits_usd` | Of that total, the portion added via x402 top-ups (excludes any plan allowance) |
 
 <Note>
   This is for accounts created from a wallet (the default x402 mode). If you're [topping up an existing account](#topping-up-an-existing-account), check that account's balance the normal way with your API key via `client.billing.account()`. A wallet that has never paid yet has no account, so the call returns `404` until the first payment.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds wallet-signed balance lookup for x402 projects in both Node and Python SDKs, exposed in v3. No API key needed; uses an EIP-191 signature to prove wallet control.

- **New Features**
  - Node: `getWalletBalance(privateKey, { baseUrl, extra }?)` posts to `https://api.browser-use.com/api/v3/x402/balance` and returns `{ wallet, project_id, total_credits_usd, additional_credits_usd }`. Exported from `browser-use-sdk/v3`. Uses a fixed auth message and forwards `extra` fields.
  - Python: `async get_wallet_balance(private_key, *, base_url=..., timeout=..., **extra)` with the same response fields. Exported from `browser_use_sdk.v3`.
  - Docs: Added “Checking your credit balance” with TS/Python examples and clarified troubleshooting (e.g., 503 when payment isn’t settled).

- **Dependencies**
  - Node: optional peer `viem/accounts` for signing.
  - Python: `eth_account` for signing and `httpx` for HTTP.

<sup>Written for commit ea0741f3b6c046020c97cab57084245f69e8b1f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/158?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

