### PR TITLE
docs: add copy page contextual action

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -19,6 +19,7 @@
   },
   "contextual": {
     "options": [
+      "copy",
       "chatgpt",
       "claude",
       "mcp",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- enable Mintlify's built-in `copy` contextual action in `docs/docs.json`
- place `copy` first so the primary page action copies the current page as Markdown instead of defaulting to ChatGPT

## Testing
- `python3 -m json.tool docs/docs.json >/dev/null`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://browser-use.slack.com/archives/C08SZRT860M/p1780267137006649?thread_ts=1780267137.006649&cid=C08SZRT860M)

<div><a href="https://cursor.com/agents/bc-0a130972-a263-58de-a916-1ac463eac3e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a130972-a263-58de-a916-1ac463eac3e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Mintlify’s `copy` contextual action and set it first, making copy-as-Markdown the default page action for docs. Users can now copy the current page as Markdown with one click.

<sup>Written for commit d0d5557b27a93d249f0e0b1e37a96fa16070601f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

