### PR TITLE
docs: fix OpenRouter import example

### DIFF
--- a/docs/open-source/supported-models.mdx
+++ b/docs/open-source/supported-models.mdx
@@ -511,7 +511,8 @@ CEREBRAS_API_KEY=
 [Available models](https://openrouter.ai/models). Access 300+ models from any provider through a single API.
 
 ```python
-from browser_use import Agent, ChatOpenRouter
+from browser_use import Agent
+from browser_use.llm import ChatOpenRouter
 
 llm = ChatOpenRouter(model="anthropic/claude-sonnet-4-6")
 


### PR DESCRIPTION
## Summary
- Update the OpenRouter supported-models example to import ChatOpenRouter from rowser_use.llm
- Keep the top-level rowser_use import for Agent

## Validation
- Documentation-only change
- Confirmed the PR diff only modifies docs/open-source/supported-models.mdx
- Checked that rowser_use.llm exports ChatOpenRouter

Related: browser-use/browser-use#4755

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Correct the OpenRouter example in supported-models docs: import `Agent` from `browser_use` and `ChatOpenRouter` from `browser_use.llm`. Aligns the docs with current exports to avoid import errors.

<sup>Written for commit 241870975862f219780c36ba726c2b31eac48935. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

