### PR TITLE
[codex] Add agent self-registration to main llms files

### DIFF
--- a/docs/cloud/agent-signup.mdx
+++ b/docs/cloud/agent-signup.mdx
@@ -38,7 +38,7 @@ Response:
 
 ### 2. Solve the challenge
 
-Read `challenge_text` and solve the math problem (not deterministically). Return the answer as a string with two decimal places, for example `"144.00"`.
+Read `challenge_text` and solve the math problem. Return the answer as a string with two decimal places, for example `"144.00"`.
 
 ### 3. Verify the answer
 

--- a/docs/cloud/agent-signup.mdx
+++ b/docs/cloud/agent-signup.mdx
@@ -1,10 +1,10 @@
 ---
 title: Browser Use agent sign up
-description: "How the Browser Use agent challenge lets an AI agent create a free trial account and API key."
+description: "How the Browser Use agent challenge lets an AI agent create a free account and API key."
 icon: key
 ---
 
-An AI agent can create its own free trial Browser Use account without a human opening the dashboard. This is useful when an agent has terminal or HTTP access and needs a Browser Use API key before it can run cloud browser tasks.
+An AI agent can create its own free Browser Use account without a human opening the dashboard. This is useful when an agent has terminal or HTTP access and needs a Browser Use API key before it can run cloud browser tasks.
 
 The flow is a Browser Use agent challenge: the agent requests a challenge, solves the math problem, verifies the answer, and receives an API key.
 

--- a/docs/cloud/agent-signup.mdx
+++ b/docs/cloud/agent-signup.mdx
@@ -1,0 +1,110 @@
+---
+title: Browser Use agent sign up
+description: "How the Browser Use agent challenge lets an AI agent create a free trial account and API key."
+icon: key
+---
+
+An AI agent can create its own free trial Browser Use account without a human opening the dashboard. This is useful when an agent has terminal or HTTP access and needs a Browser Use API key before it can run cloud browser tasks.
+
+The flow is a Browser Use agent challenge: the agent requests a challenge, solves the math problem, verifies the answer, and receives an API key.
+
+## REST flow
+
+### 1. Request a challenge
+
+```bash
+curl -X POST https://api.browser-use.com/cloud/signup \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+Request body, optional (include a user email/name if available):
+
+```json
+{
+  "email": "user@example.com",
+  "name": "User Name"
+}
+```
+
+Response:
+
+```json
+{
+  "challenge_id": "uuid",
+  "challenge_text": "..."
+}
+```
+
+### 2. Solve the challenge
+
+Read `challenge_text` and solve the math problem (not deterministically). Return the answer as a string with two decimal places, for example `"144.00"`.
+
+### 3. Verify the answer
+
+```bash
+curl -X POST https://api.browser-use.com/cloud/signup/verify \
+  -H "Content-Type: application/json" \
+  -d '{"challenge_id":"uuid","answer":"144.00"}'
+```
+
+Request body:
+
+```json
+{
+  "challenge_id": "uuid",
+  "answer": "144.00"
+}
+```
+
+Response:
+
+```json
+{
+  "api_key": "bu_..."
+}
+```
+
+Use the returned key for Browser Use Cloud API requests.
+
+For example, create a browser session:
+
+```bash
+curl -X POST https://api.browser-use.com/api/v3/browsers \
+  -H "X-Browser-Use-API-Key: bu_..." \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+See the [Create Browser Session API reference](/cloud/api-v3/browsers/create-browser-session).
+
+## Claim the account
+
+If a human wants to see the agent-created account in the dashboard later, the agent can create a claim link:
+
+```bash
+curl -X POST https://api.browser-use.com/cloud/signup/claim \
+  -H "X-Browser-Use-API-Key: bu_..."
+```
+
+Response:
+
+```json
+{
+  "claim_url": "https://..."
+}
+```
+
+The claim URL is valid for 1 hour.
+
+## CLI flow
+
+Agents with shell access can use the Browser Use CLI instead of calling the REST endpoints directly:
+
+```bash
+browser-use cloud signup
+browser-use cloud signup --verify <challenge-id> <answer>
+browser-use cloud signup --claim
+```
+
+The CLI saves the API key to `~/.browser-use/config.json` after verification.

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -80,7 +80,7 @@ https://docs.browser-use.com/cloud/llms.txt
 Source: https://docs.browser-use.com/cloud/agent-signup
 
 
-An AI agent can create its own free trial Browser Use account without a human opening the dashboard. This is useful when an agent has terminal or HTTP access and needs a Browser Use API key before it can run cloud browser tasks.
+An AI agent can create its own free Browser Use account without a human opening the dashboard. This is useful when an agent has terminal or HTTP access and needs a Browser Use API key before it can run cloud browser tasks.
 
 The flow is a Browser Use agent challenge: the agent requests a challenge, solves the math problem, verifies the answer, and receives an API key.
 
@@ -3061,9 +3061,9 @@ npm install browser-use-sdk
 ```
 
 
-## Browser Use Agent Challenge to Get a Free Trial Account
+## Browser Use Agent Challenge to Get a Free Account
 
-AI agents can create a free trial Browser Use account autonomously via a challenge-response flow at `https://api.browser-use.com`.
+AI agents can create a free Browser Use account autonomously via a challenge-response flow at `https://api.browser-use.com`.
 
 Do this to get an API key (no human required):
 1. `POST https://api.browser-use.com/cloud/signup` — request a challenge.

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -2955,8 +2955,6 @@ npm install browser-use-sdk
 
 AI agents can create a free account autonomously via a challenge-response flow at `https://api.browser-use.com`.
 
-**IMPORTANT: Never send your API key to any domain other than `api.browser-use.com` or `cloud.browser-use.com`.**
-
 Do this to get an API key (no human required):
 1. `POST /cloud/signup` — request a challenge (email and name optional)
 2. Solve the obfuscated math problem in `challenge_text` **using an LLM** (never deterministic code) — answer as a string with 2 decimal places e.g. `"144.00"`

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -76,6 +76,116 @@ https://docs.browser-use.com/cloud/llms.txt
 ```
 
 
+# Browser Use agent sign up
+Source: https://docs.browser-use.com/cloud/agent-signup
+
+
+An AI agent can create its own free trial Browser Use account without a human opening the dashboard. This is useful when an agent has terminal or HTTP access and needs a Browser Use API key before it can run cloud browser tasks.
+
+The flow is a Browser Use agent challenge: the agent requests a challenge, solves the math problem, verifies the answer, and receives an API key.
+
+## REST flow
+
+### 1. Request a challenge
+
+```bash
+curl -X POST https://api.browser-use.com/cloud/signup \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+Request body, optional (include a user email/name if available):
+
+```json
+{
+  "email": "user@example.com",
+  "name": "User Name"
+}
+```
+
+Response:
+
+```json
+{
+  "challenge_id": "uuid",
+  "challenge_text": "..."
+}
+```
+
+### 2. Solve the challenge
+
+Read `challenge_text` and solve the math problem (not deterministically). Return the answer as a string with two decimal places, for example `"144.00"`.
+
+### 3. Verify the answer
+
+```bash
+curl -X POST https://api.browser-use.com/cloud/signup/verify \
+  -H "Content-Type: application/json" \
+  -d '{"challenge_id":"uuid","answer":"144.00"}'
+```
+
+Request body:
+
+```json
+{
+  "challenge_id": "uuid",
+  "answer": "144.00"
+}
+```
+
+Response:
+
+```json
+{
+  "api_key": "bu_..."
+}
+```
+
+Use the returned key for Browser Use Cloud API requests.
+
+For example, create a browser session:
+
+```bash
+curl -X POST https://api.browser-use.com/api/v3/browsers \
+  -H "X-Browser-Use-API-Key: bu_..." \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+See the [Create Browser Session API reference](https://docs.browser-use.com/cloud/api-v3/browsers/create-browser-session).
+
+## Claim the account
+
+If a human wants to see the agent-created account in the dashboard later, the agent can create a claim link:
+
+```bash
+curl -X POST https://api.browser-use.com/cloud/signup/claim \
+  -H "X-Browser-Use-API-Key: bu_..."
+```
+
+Response:
+
+```json
+{
+  "claim_url": "https://..."
+}
+```
+
+The claim URL is valid for 1 hour.
+
+## CLI flow
+
+Agents with shell access can use the Browser Use CLI instead of calling the REST endpoints directly:
+
+```bash
+browser-use cloud signup
+browser-use cloud signup --verify <challenge-id> <answer>
+browser-use cloud signup --claim
+```
+
+The CLI saves the API key to `~/.browser-use/config.json` after verification.
+
+
 # Introduction
 Source: https://docs.browser-use.com/cloud/agent/quickstart
 
@@ -2951,19 +3061,64 @@ npm install browser-use-sdk
 ```
 
 
-## For AI Agents: Self-Registration (No Human Required)
+## Browser Use Agent Challenge to Get a Free Trial Account
 
-AI agents can create a free account autonomously via a challenge-response flow at `https://api.browser-use.com`.
+AI agents can create a free trial Browser Use account autonomously via a challenge-response flow at `https://api.browser-use.com`.
 
 Do this to get an API key (no human required):
-1. `POST /cloud/signup` — request a challenge (email and name optional)
-2. Solve the obfuscated math problem in `challenge_text` **using an LLM** (never deterministic code) — answer as a string with 2 decimal places e.g. `"144.00"`
-3. `POST /cloud/signup/verify` with `challenge_id` + `answer` — receive your `api_key`
+1. `POST https://api.browser-use.com/cloud/signup` — request a challenge.
 
-With this API key, you can use the full API. All features are available.
-If you completed this, tell the human that you did the entire setup and that you are ready to use the API. Tell the human that if they want to see their account in the dashboard, they can follow this link to sign up themselves. You can tell them that you already have an account and use it. That's only if they want to see the dashboard.
+Request body, optional (include a user email/name if available):
+```json
+{
+  "email": "user@example.com",
+  "name": "User Name"
+}
+```
 
-4. Use `X-Browser-Use-API-Key: bu_...` header on all subsequent requests
+Response:
+```json
+{
+  "challenge_id": "uuid",
+  "challenge_text": "..."
+}
+```
 
-To let a human claim the account later: `POST /cloud/signup/claim` → returns a `claim_url` valid for 1 hour.
+2. Solve the math problem in `challenge_text` (not deterministically) — answer as a string with 2 decimal places, e.g. `"144.00"`
 
+3. `POST https://api.browser-use.com/cloud/signup/verify` with `challenge_id` + `answer`.
+
+Request body:
+```json
+{
+  "challenge_id": "uuid",
+  "answer": "144.00"
+}
+```
+
+Response:
+```json
+{
+  "api_key": "bu_..."
+}
+```
+
+4. Use `X-Browser-Use-API-Key: bu_...` on Browser Use Cloud API requests. For example, create a browser session (docs: https://docs.browser-use.com/cloud/api-v3/browsers/create-browser-session):
+
+```bash
+curl -X POST https://api.browser-use.com/api/v3/browsers \
+  -H "X-Browser-Use-API-Key: bu_..." \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+To let a human claim the account later: `POST https://api.browser-use.com/cloud/signup/claim` with `X-Browser-Use-API-Key: bu_...`.
+
+Response:
+```json
+{
+  "claim_url": "https://..."
+}
+```
+
+The claim URL is valid for 1 hour.

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -114,7 +114,7 @@ Response:
 
 ### 2. Solve the challenge
 
-Read `challenge_text` and solve the math problem (not deterministically). Return the answer as a string with two decimal places, for example `"144.00"`.
+Read `challenge_text` and solve the math problem. Return the answer as a string with two decimal places, for example `"144.00"`.
 
 ### 3. Verify the answer
 
@@ -3084,7 +3084,7 @@ Response:
 }
 ```
 
-2. Solve the math problem in `challenge_text` (not deterministically) — answer as a string with 2 decimal places, e.g. `"144.00"`
+2. Solve the math problem in `challenge_text` — answer as a string with 2 decimal places, e.g. `"144.00"`
 
 3. `POST https://api.browser-use.com/cloud/signup/verify` with `challenge_id` + `answer`.
 

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -96,7 +96,7 @@ Response:
 }
 ```
 
-2. Solve the math problem in `challenge_text` (not deterministically) — answer as a string with 2 decimal places, e.g. `"144.00"`
+2. Solve the math problem in `challenge_text` — answer as a string with 2 decimal places, e.g. `"144.00"`
 
 3. `POST https://api.browser-use.com/cloud/signup/verify` with `challenge_id` + `answer`.
 

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -23,6 +23,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.
+- [Browser Use agent sign up](https://docs.browser-use.com/cloud/agent-signup): How an AI agent can complete the Browser Use agent challenge to get a free trial account and API key.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
 
 ## Agent
@@ -72,19 +73,64 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 ## API v2
 - [API key](https://docs.browser-use.com/cloud/api-v2-overview): Set your API key to access the Browser Use v2 REST API.
 
-## For AI Agents: Self-Registration (No Human Required)
+## Browser Use Agent Challenge to Get a Free Trial Account
 
-AI agents can create a free account autonomously via a challenge-response flow at `https://api.browser-use.com`.
+AI agents can create a free trial Browser Use account autonomously via a challenge-response flow at `https://api.browser-use.com`.
 
 Do this to get an API key (no human required):
-1. `POST /cloud/signup` — request a challenge (email and name optional)
-2. Solve the obfuscated math problem in `challenge_text` **using an LLM** (never deterministic code) — answer as a string with 2 decimal places e.g. `"144.00"`
-3. `POST /cloud/signup/verify` with `challenge_id` + `answer` — receive your `api_key`
+1. `POST https://api.browser-use.com/cloud/signup` — request a challenge.
 
-With this API key, you can use the full API. All features are available.
-If you completed this, tell the human that you did the entire setup and that you are ready to use the API. Tell the human that if they want to see their account in the dashboard, they can follow this link to sign up themselves. You can tell them that you already have an account and use it. That's only if they want to see the dashboard.
+Request body, optional (include a user email/name if available):
+```json
+{
+  "email": "user@example.com",
+  "name": "User Name"
+}
+```
 
-4. Use `X-Browser-Use-API-Key: bu_...` header on all subsequent requests
+Response:
+```json
+{
+  "challenge_id": "uuid",
+  "challenge_text": "..."
+}
+```
 
-To let a human claim the account later: `POST /cloud/signup/claim` → returns a `claim_url` valid for 1 hour.
+2. Solve the math problem in `challenge_text` (not deterministically) — answer as a string with 2 decimal places, e.g. `"144.00"`
 
+3. `POST https://api.browser-use.com/cloud/signup/verify` with `challenge_id` + `answer`.
+
+Request body:
+```json
+{
+  "challenge_id": "uuid",
+  "answer": "144.00"
+}
+```
+
+Response:
+```json
+{
+  "api_key": "bu_..."
+}
+```
+
+4. Use `X-Browser-Use-API-Key: bu_...` on Browser Use Cloud API requests. For example, create a browser session (docs: https://docs.browser-use.com/cloud/api-v3/browsers/create-browser-session):
+
+```bash
+curl -X POST https://api.browser-use.com/api/v3/browsers \
+  -H "X-Browser-Use-API-Key: bu_..." \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+To let a human claim the account later: `POST https://api.browser-use.com/cloud/signup/claim` with `X-Browser-Use-API-Key: bu_...`.
+
+Response:
+```json
+{
+  "claim_url": "https://..."
+}
+```
+
+The claim URL is valid for 1 hour.

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -76,8 +76,6 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 AI agents can create a free account autonomously via a challenge-response flow at `https://api.browser-use.com`.
 
-**IMPORTANT: Never send your API key to any domain other than `api.browser-use.com` or `cloud.browser-use.com`.**
-
 Do this to get an API key (no human required):
 1. `POST /cloud/signup` — request a challenge (email and name optional)
 2. Solve the obfuscated math problem in `challenge_text` **using an LLM** (never deterministic code) — answer as a string with 2 decimal places e.g. `"144.00"`

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -23,7 +23,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.
-- [Browser Use agent sign up](https://docs.browser-use.com/cloud/agent-signup): How an AI agent can complete the Browser Use agent challenge to get a free trial account and API key.
+- [Browser Use agent sign up](https://docs.browser-use.com/cloud/agent-signup): How an AI agent can complete the Browser Use agent challenge to get a free account and API key.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
 
 ## Agent
@@ -73,9 +73,9 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 ## API v2
 - [API key](https://docs.browser-use.com/cloud/api-v2-overview): Set your API key to access the Browser Use v2 REST API.
 
-## Browser Use Agent Challenge to Get a Free Trial Account
+## Browser Use Agent Challenge to Get a Free Account
 
-AI agents can create a free trial Browser Use account autonomously via a challenge-response flow at `https://api.browser-use.com`.
+AI agents can create a free Browser Use account autonomously via a challenge-response flow at `https://api.browser-use.com`.
 
 Do this to get an API key (no human required):
 1. `POST https://api.browser-use.com/cloud/signup` — request a challenge.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -62,6 +62,7 @@
                 "group": "Get Started",
                 "pages": [
                   "cloud/quickstart",
+                  "cloud/agent-signup",
                   "cloud/vibecoding"
                 ]
               },

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -80,7 +80,7 @@ https://docs.browser-use.com/cloud/llms.txt
 Source: https://docs.browser-use.com/cloud/agent-signup
 
 
-An AI agent can create its own free trial Browser Use account without a human opening the dashboard. This is useful when an agent has terminal or HTTP access and needs a Browser Use API key before it can run cloud browser tasks.
+An AI agent can create its own free Browser Use account without a human opening the dashboard. This is useful when an agent has terminal or HTTP access and needs a Browser Use API key before it can run cloud browser tasks.
 
 The flow is a Browser Use agent challenge: the agent requests a challenge, solves the math problem, verifies the answer, and receives an API key.
 
@@ -3061,9 +3061,9 @@ npm install browser-use-sdk
 ```
 
 
-## Browser Use Agent Challenge to Get a Free Trial Account
+## Browser Use Agent Challenge to Get a Free Account
 
-AI agents can create a free trial Browser Use account autonomously via a challenge-response flow at `https://api.browser-use.com`.
+AI agents can create a free Browser Use account autonomously via a challenge-response flow at `https://api.browser-use.com`.
 
 Do this to get an API key (no human required):
 1. `POST https://api.browser-use.com/cloud/signup` — request a challenge.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2955,8 +2955,6 @@ npm install browser-use-sdk
 
 AI agents can create a free account autonomously via a challenge-response flow at `https://api.browser-use.com`.
 
-**IMPORTANT: Never send your API key to any domain other than `api.browser-use.com` or `cloud.browser-use.com`.**
-
 Do this to get an API key (no human required):
 1. `POST /cloud/signup` — request a challenge (email and name optional)
 2. Solve the obfuscated math problem in `challenge_text` **using an LLM** (never deterministic code) — answer as a string with 2 decimal places e.g. `"144.00"`

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -76,6 +76,116 @@ https://docs.browser-use.com/cloud/llms.txt
 ```
 
 
+# Browser Use agent sign up
+Source: https://docs.browser-use.com/cloud/agent-signup
+
+
+An AI agent can create its own free trial Browser Use account without a human opening the dashboard. This is useful when an agent has terminal or HTTP access and needs a Browser Use API key before it can run cloud browser tasks.
+
+The flow is a Browser Use agent challenge: the agent requests a challenge, solves the math problem, verifies the answer, and receives an API key.
+
+## REST flow
+
+### 1. Request a challenge
+
+```bash
+curl -X POST https://api.browser-use.com/cloud/signup \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+Request body, optional (include a user email/name if available):
+
+```json
+{
+  "email": "user@example.com",
+  "name": "User Name"
+}
+```
+
+Response:
+
+```json
+{
+  "challenge_id": "uuid",
+  "challenge_text": "..."
+}
+```
+
+### 2. Solve the challenge
+
+Read `challenge_text` and solve the math problem (not deterministically). Return the answer as a string with two decimal places, for example `"144.00"`.
+
+### 3. Verify the answer
+
+```bash
+curl -X POST https://api.browser-use.com/cloud/signup/verify \
+  -H "Content-Type: application/json" \
+  -d '{"challenge_id":"uuid","answer":"144.00"}'
+```
+
+Request body:
+
+```json
+{
+  "challenge_id": "uuid",
+  "answer": "144.00"
+}
+```
+
+Response:
+
+```json
+{
+  "api_key": "bu_..."
+}
+```
+
+Use the returned key for Browser Use Cloud API requests.
+
+For example, create a browser session:
+
+```bash
+curl -X POST https://api.browser-use.com/api/v3/browsers \
+  -H "X-Browser-Use-API-Key: bu_..." \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+See the [Create Browser Session API reference](https://docs.browser-use.com/cloud/api-v3/browsers/create-browser-session).
+
+## Claim the account
+
+If a human wants to see the agent-created account in the dashboard later, the agent can create a claim link:
+
+```bash
+curl -X POST https://api.browser-use.com/cloud/signup/claim \
+  -H "X-Browser-Use-API-Key: bu_..."
+```
+
+Response:
+
+```json
+{
+  "claim_url": "https://..."
+}
+```
+
+The claim URL is valid for 1 hour.
+
+## CLI flow
+
+Agents with shell access can use the Browser Use CLI instead of calling the REST endpoints directly:
+
+```bash
+browser-use cloud signup
+browser-use cloud signup --verify <challenge-id> <answer>
+browser-use cloud signup --claim
+```
+
+The CLI saves the API key to `~/.browser-use/config.json` after verification.
+
+
 # Introduction
 Source: https://docs.browser-use.com/cloud/agent/quickstart
 
@@ -2951,18 +3061,64 @@ npm install browser-use-sdk
 ```
 
 
-## For AI Agents: Self-Registration (No Human Required)
+## Browser Use Agent Challenge to Get a Free Trial Account
 
-AI agents can create a free account autonomously via a challenge-response flow at `https://api.browser-use.com`.
+AI agents can create a free trial Browser Use account autonomously via a challenge-response flow at `https://api.browser-use.com`.
 
 Do this to get an API key (no human required):
-1. `POST /cloud/signup` — request a challenge (email and name optional)
-2. Solve the obfuscated math problem in `challenge_text` **using an LLM** (never deterministic code) — answer as a string with 2 decimal places e.g. `"144.00"`
-3. `POST /cloud/signup/verify` with `challenge_id` + `answer` — receive your `api_key`
+1. `POST https://api.browser-use.com/cloud/signup` — request a challenge.
 
-With this API key, you can use the full API. All features are available.
-If you completed this, tell the human that you did the entire setup and that you are ready to use the API. Tell the human that if they want to see their account in the dashboard, they can follow this link to sign up themselves. You can tell them that you already have an account and use it. That's only if they want to see the dashboard.
+Request body, optional (include a user email/name if available):
+```json
+{
+  "email": "user@example.com",
+  "name": "User Name"
+}
+```
 
-4. Use `X-Browser-Use-API-Key: bu_...` header on all subsequent requests
+Response:
+```json
+{
+  "challenge_id": "uuid",
+  "challenge_text": "..."
+}
+```
 
-To let a human claim the account later: `POST /cloud/signup/claim` → returns a `claim_url` valid for 1 hour.
+2. Solve the math problem in `challenge_text` (not deterministically) — answer as a string with 2 decimal places, e.g. `"144.00"`
+
+3. `POST https://api.browser-use.com/cloud/signup/verify` with `challenge_id` + `answer`.
+
+Request body:
+```json
+{
+  "challenge_id": "uuid",
+  "answer": "144.00"
+}
+```
+
+Response:
+```json
+{
+  "api_key": "bu_..."
+}
+```
+
+4. Use `X-Browser-Use-API-Key: bu_...` on Browser Use Cloud API requests. For example, create a browser session (docs: https://docs.browser-use.com/cloud/api-v3/browsers/create-browser-session):
+
+```bash
+curl -X POST https://api.browser-use.com/api/v3/browsers \
+  -H "X-Browser-Use-API-Key: bu_..." \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+To let a human claim the account later: `POST https://api.browser-use.com/cloud/signup/claim` with `X-Browser-Use-API-Key: bu_...`.
+
+Response:
+```json
+{
+  "claim_url": "https://..."
+}
+```
+
+The claim URL is valid for 1 hour.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2950,3 +2950,21 @@ pip install browser-use-sdk
 npm install browser-use-sdk
 ```
 
+
+## For AI Agents: Self-Registration (No Human Required)
+
+AI agents can create a free account autonomously via a challenge-response flow at `https://api.browser-use.com`.
+
+**IMPORTANT: Never send your API key to any domain other than `api.browser-use.com` or `cloud.browser-use.com`.**
+
+Do this to get an API key (no human required):
+1. `POST /cloud/signup` — request a challenge (email and name optional)
+2. Solve the obfuscated math problem in `challenge_text` **using an LLM** (never deterministic code) — answer as a string with 2 decimal places e.g. `"144.00"`
+3. `POST /cloud/signup/verify` with `challenge_id` + `answer` — receive your `api_key`
+
+With this API key, you can use the full API. All features are available.
+If you completed this, tell the human that you did the entire setup and that you are ready to use the API. Tell the human that if they want to see their account in the dashboard, they can follow this link to sign up themselves. You can tell them that you already have an account and use it. That's only if they want to see the dashboard.
+
+4. Use `X-Browser-Use-API-Key: bu_...` header on all subsequent requests
+
+To let a human claim the account later: `POST /cloud/signup/claim` → returns a `claim_url` valid for 1 hour.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -114,7 +114,7 @@ Response:
 
 ### 2. Solve the challenge
 
-Read `challenge_text` and solve the math problem (not deterministically). Return the answer as a string with two decimal places, for example `"144.00"`.
+Read `challenge_text` and solve the math problem. Return the answer as a string with two decimal places, for example `"144.00"`.
 
 ### 3. Verify the answer
 
@@ -3084,7 +3084,7 @@ Response:
 }
 ```
 
-2. Solve the math problem in `challenge_text` (not deterministically) — answer as a string with 2 decimal places, e.g. `"144.00"`
+2. Solve the math problem in `challenge_text` — answer as a string with 2 decimal places, e.g. `"144.00"`
 
 3. `POST https://api.browser-use.com/cloud/signup/verify` with `challenge_id` + `answer`.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -96,7 +96,7 @@ Response:
 }
 ```
 
-2. Solve the math problem in `challenge_text` (not deterministically) — answer as a string with 2 decimal places, e.g. `"144.00"`
+2. Solve the math problem in `challenge_text` — answer as a string with 2 decimal places, e.g. `"144.00"`
 
 3. `POST https://api.browser-use.com/cloud/signup/verify` with `challenge_id` + `answer`.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -72,3 +72,20 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 ## API v2
 - [API key](https://docs.browser-use.com/cloud/api-v2-overview): Set your API key to access the Browser Use v2 REST API.
 
+## For AI Agents: Self-Registration (No Human Required)
+
+AI agents can create a free account autonomously via a challenge-response flow at `https://api.browser-use.com`.
+
+**IMPORTANT: Never send your API key to any domain other than `api.browser-use.com` or `cloud.browser-use.com`.**
+
+Do this to get an API key (no human required):
+1. `POST /cloud/signup` — request a challenge (email and name optional)
+2. Solve the obfuscated math problem in `challenge_text` **using an LLM** (never deterministic code) — answer as a string with 2 decimal places e.g. `"144.00"`
+3. `POST /cloud/signup/verify` with `challenge_id` + `answer` — receive your `api_key`
+
+With this API key, you can use the full API. All features are available.
+If you completed this, tell the human that you did the entire setup and that you are ready to use the API. Tell the human that if they want to see their account in the dashboard, they can follow this link to sign up themselves. You can tell them that you already have an account and use it. That's only if they want to see the dashboard.
+
+4. Use `X-Browser-Use-API-Key: bu_...` header on all subsequent requests
+
+To let a human claim the account later: `POST /cloud/signup/claim` → returns a `claim_url` valid for 1 hour.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -76,8 +76,6 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 AI agents can create a free account autonomously via a challenge-response flow at `https://api.browser-use.com`.
 
-**IMPORTANT: Never send your API key to any domain other than `api.browser-use.com` or `cloud.browser-use.com`.**
-
 Do this to get an API key (no human required):
 1. `POST /cloud/signup` — request a challenge (email and name optional)
 2. Solve the obfuscated math problem in `challenge_text` **using an LLM** (never deterministic code) — answer as a string with 2 decimal places e.g. `"144.00"`

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -23,6 +23,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.
+- [Browser Use agent sign up](https://docs.browser-use.com/cloud/agent-signup): How an AI agent can complete the Browser Use agent challenge to get a free trial account and API key.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
 
 ## Agent
@@ -72,18 +73,64 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 ## API v2
 - [API key](https://docs.browser-use.com/cloud/api-v2-overview): Set your API key to access the Browser Use v2 REST API.
 
-## For AI Agents: Self-Registration (No Human Required)
+## Browser Use Agent Challenge to Get a Free Trial Account
 
-AI agents can create a free account autonomously via a challenge-response flow at `https://api.browser-use.com`.
+AI agents can create a free trial Browser Use account autonomously via a challenge-response flow at `https://api.browser-use.com`.
 
 Do this to get an API key (no human required):
-1. `POST /cloud/signup` — request a challenge (email and name optional)
-2. Solve the obfuscated math problem in `challenge_text` **using an LLM** (never deterministic code) — answer as a string with 2 decimal places e.g. `"144.00"`
-3. `POST /cloud/signup/verify` with `challenge_id` + `answer` — receive your `api_key`
+1. `POST https://api.browser-use.com/cloud/signup` — request a challenge.
 
-With this API key, you can use the full API. All features are available.
-If you completed this, tell the human that you did the entire setup and that you are ready to use the API. Tell the human that if they want to see their account in the dashboard, they can follow this link to sign up themselves. You can tell them that you already have an account and use it. That's only if they want to see the dashboard.
+Request body, optional (include a user email/name if available):
+```json
+{
+  "email": "user@example.com",
+  "name": "User Name"
+}
+```
 
-4. Use `X-Browser-Use-API-Key: bu_...` header on all subsequent requests
+Response:
+```json
+{
+  "challenge_id": "uuid",
+  "challenge_text": "..."
+}
+```
 
-To let a human claim the account later: `POST /cloud/signup/claim` → returns a `claim_url` valid for 1 hour.
+2. Solve the math problem in `challenge_text` (not deterministically) — answer as a string with 2 decimal places, e.g. `"144.00"`
+
+3. `POST https://api.browser-use.com/cloud/signup/verify` with `challenge_id` + `answer`.
+
+Request body:
+```json
+{
+  "challenge_id": "uuid",
+  "answer": "144.00"
+}
+```
+
+Response:
+```json
+{
+  "api_key": "bu_..."
+}
+```
+
+4. Use `X-Browser-Use-API-Key: bu_...` on Browser Use Cloud API requests. For example, create a browser session (docs: https://docs.browser-use.com/cloud/api-v3/browsers/create-browser-session):
+
+```bash
+curl -X POST https://api.browser-use.com/api/v3/browsers \
+  -H "X-Browser-Use-API-Key: bu_..." \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+To let a human claim the account later: `POST https://api.browser-use.com/cloud/signup/claim` with `X-Browser-Use-API-Key: bu_...`.
+
+Response:
+```json
+{
+  "claim_url": "https://..."
+}
+```
+
+The claim URL is valid for 1 hour.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -23,7 +23,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.
-- [Browser Use agent sign up](https://docs.browser-use.com/cloud/agent-signup): How an AI agent can complete the Browser Use agent challenge to get a free trial account and API key.
+- [Browser Use agent sign up](https://docs.browser-use.com/cloud/agent-signup): How an AI agent can complete the Browser Use agent challenge to get a free account and API key.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
 
 ## Agent
@@ -73,9 +73,9 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 ## API v2
 - [API key](https://docs.browser-use.com/cloud/api-v2-overview): Set your API key to access the Browser Use v2 REST API.
 
-## Browser Use Agent Challenge to Get a Free Trial Account
+## Browser Use Agent Challenge to Get a Free Account
 
-AI agents can create a free trial Browser Use account autonomously via a challenge-response flow at `https://api.browser-use.com`.
+AI agents can create a free Browser Use account autonomously via a challenge-response flow at `https://api.browser-use.com`.
 
 Do this to get an API key (no human required):
 1. `POST https://api.browser-use.com/cloud/signup` — request a challenge.


### PR DESCRIPTION
## Summary
- add the agent self-registration/challenge block to `docs/llms.txt`
- add the same block to `docs/llms-full.txt` so the full main docs include it too
- keep the wording aligned with the existing cloud-specific `docs/cloud/llms.txt` block

## Validation
- `git diff --check`
- `rg -n "For AI Agents|cloud/signup|challenge_text|signup/claim" docs/llms.txt docs/llms-full.txt`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an agent self-registration guide and expanded LLM docs so agents can create free accounts and get an API key via the challenge flow without human input. Introduced `docs/cloud/agent-signup.mdx`, linked it in navigation and Get Started, and updated main and cloud LLM guides with simplified wording, explicit request/response schemas for `https://api.browser-use.com/cloud/signup`, `/cloud/signup/verify`, and `/cloud/signup/claim`, plus CLI examples; removed the API key domain warning and all “trial” wording.

<sup>Written for commit 0c797e0af0dcf4645f56f8ba7afc8d9d866d4841. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

