### PR TITLE
[codex] Move agent signup docs to tutorials

### DIFF
--- a/docs/cloud/agent-signup.mdx
+++ b/docs/cloud/agent-signup.mdx
@@ -1,5 +1,5 @@
 ---
-title: Browser Use agent sign up
+title: Agent Sign Up for Browser Use
 description: "How the Browser Use agent challenge lets an AI agent create a free account and API key."
 icon: key
 ---

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -76,7 +76,7 @@ https://docs.browser-use.com/cloud/llms.txt
 ```
 
 
-# Browser Use agent sign up
+# Agent Sign Up for Browser Use
 Source: https://docs.browser-use.com/cloud/agent-signup
 
 

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -23,7 +23,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.
-- [Browser Use agent sign up](https://docs.browser-use.com/cloud/agent-signup): How an AI agent can complete the Browser Use agent challenge to get a free account and API key.
+- [Agent Sign Up for Browser Use](https://docs.browser-use.com/cloud/agent-signup): How an AI agent can complete the Browser Use agent challenge to get a free account and API key.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
 
 ## Agent

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -62,7 +62,6 @@
                 "group": "Get Started",
                 "pages": [
                   "cloud/quickstart",
-                  "cloud/agent-signup",
                   "cloud/vibecoding"
                 ]
               },
@@ -125,6 +124,7 @@
                     "icon": "graduation-cap",
                     "pages": [
                       "cloud/tutorials/chat-ui",
+                      "cloud/agent-signup",
                       "cloud/tutorials/grow-therapy-compare"
                     ]
                   },

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -76,7 +76,7 @@ https://docs.browser-use.com/cloud/llms.txt
 ```
 
 
-# Browser Use agent sign up
+# Agent Sign Up for Browser Use
 Source: https://docs.browser-use.com/cloud/agent-signup
 
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -23,7 +23,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): State-of-the-art AI browser automation with stealth browsers, CAPTCHA solving, residential proxies, and managed infrastructure.
-- [Browser Use agent sign up](https://docs.browser-use.com/cloud/agent-signup): How an AI agent can complete the Browser Use agent challenge to get a free account and API key.
+- [Agent Sign Up for Browser Use](https://docs.browser-use.com/cloud/agent-signup): How an AI agent can complete the Browser Use agent challenge to get a free account and API key.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
 
 ## Agent


### PR DESCRIPTION
## Summary
- move `cloud/agent-signup` from Get Started to the Tutorials group
- rename the page title to `Agent Sign Up for Browser Use`
- update the llms text labels to match the new title

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('docs/docs.json','utf8'))"`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the Agent Signup guide from Get Started to Tutorials and retitled it “Agent Sign Up for Browser Use”. Updated navigation and LLM index files to match.

- **Refactors**
  - Moved `cloud/agent-signup` to the Tutorials group in `docs.json`.
  - Updated frontmatter title in `cloud/agent-signup.mdx`.
  - Synced labels/links in `cloud/llms.txt`, `cloud/llms-full.txt`, `llms.txt`, and `llms-full.txt`.

<sup>Written for commit fb1d6549ba9e0f2b5a84286d569d948386dfc3be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

