### PR TITLE
docs: remove custom proxy plan restriction

### DIFF
--- a/docs/cloud/browser/proxies.mdx
+++ b/docs/cloud/browser/proxies.mdx
@@ -52,7 +52,7 @@ const browser = await client.browsers.create({ proxyCountryCode: null });
 
 ## Custom proxy
 
-Bring your own proxy server (HTTP or SOCKS5). Requires custom plan.
+Bring your own proxy server (HTTP or SOCKS5).
 
 <CodeGroup>
 ```python Python

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1086,7 +1086,7 @@ const browser = await client.browsers.create({ proxyCountryCode: null });
 
 ## Custom proxy
 
-Bring your own proxy server (HTTP or SOCKS5). Requires custom plan.
+Bring your own proxy server (HTTP or SOCKS5).
 
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1086,7 +1086,7 @@ const browser = await client.browsers.create({ proxyCountryCode: null });
 
 ## Custom proxy
 
-Bring your own proxy server (HTTP or SOCKS5). Requires custom plan.
+Bring your own proxy server (HTTP or SOCKS5).
 
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the outdated "Requires custom plan" sentence from the Custom proxy docs page
- update the checked-in LLM full-text docs copies to match the corrected wording

## Testing
- searched docs for `Requires custom plan` to confirm the stale wording is gone
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://browser-use.slack.com/archives/C08SZRT860M/p1780853533473489?thread_ts=1780853533.473489&cid=C08SZRT860M)

<div><a href="https://cursor.com/agents/bc-847f3e19-aa33-543a-a74e-8e845a91eda0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-847f3e19-aa33-543a-a74e-8e845a91eda0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the outdated “Requires custom plan” note from the Custom proxy docs to reflect current availability. Synced wording in `docs/cloud/llms-full.txt` and `docs/llms-full.txt` to match the corrected text.

<sup>Written for commit ef0dfc95eba5d175d361b707177c74b5691570c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

