### PR TITLE
docs: align bu-1-0 pricing with bu-2-0

### DIFF
--- a/docs/generate-llms-txt.sh
+++ b/docs/generate-llms-txt.sh
@@ -187,7 +187,29 @@ for product_nav in d['navigation']['products']:
     awk 'BEGIN{n=0} /^---$/{n++; if(n==2){found=1; next}} found{print}' "$file" \
       | sed "s|](/cloud/|](${BASE_URL}/cloud/|g" \
       | sed -E '/<\/?(CodeGroup|Note|Tip|Warning|Info|Card|Tabs|Tab|Steps|Step|Accordion|AccordionGroup)[^>]*>/d' \
-      | sed -E 's/^[[:space:]]{4}//' >> "$out"
+      | python3 -c '
+# Dedent component-nested content without corrupting code indentation:
+# fenced code blocks are dedented by their common leading whitespace,
+# prose lines lose at most one 4-space nesting level.
+import sys, textwrap
+
+block = None
+out = []
+for line in sys.stdin.read().split("\n"):
+    if block is None:
+        if line.lstrip().startswith("```"):
+            block = [line]
+        else:
+            out.append(line[4:] if line.startswith("    ") else line)
+    else:
+        block.append(line)
+        if line.lstrip().startswith("```"):
+            out.append(textwrap.dedent("\n".join(block)))
+            block = None
+if block is not None:
+    out.append(textwrap.dedent("\n".join(block)))
+sys.stdout.write("\n".join(out))
+' >> "$out"
     echo "" >> "$out"
   done
 

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -223,11 +223,13 @@ ChatBrowserUse offers competitive pricing per 1 million tokens:
 
 **bu-1-0 / bu-latest (Default)**
 
+Since May 20, 2026, `bu-1-0` is priced the same as `bu-2-0`:
+
 | Token Type | Price per 1M tokens |
 |------------|---------------------|
-| Input tokens | $0.20 |
-| Cached tokens | $0.02 |
-| Output tokens | $2.00 |
+| Input tokens | $0.60 |
+| Cached tokens | $0.06 |
+| Output tokens | $3.50 |
 
 **bu-2-0 (Premium)**
 

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -184,6 +184,10 @@ Source: https://docs.browser-use.com/open-source/vibecoding
 Source: https://docs.browser-use.com/open-source/supported-models
 
 
+Browser Use natively supports 15+ LLM providers. Most providers accept any model string. Check each provider's docs to see which models are available.
+
+> **Which model should I use?** See our [benchmark results and recommendations](https://browser-use.com/posts/what-model-to-use) for detailed comparisons across real-world browser tasks.
+
 ### Browser Use [example](https://github.com/browser-use/browser-use/blob/main/examples/models/browser_use_llm.py)
 
 `ChatBrowserUse()` is our optimized in-house model, matching the accuracy of top models while completing tasks **3-5x** faster. [See our blog post→](https://browser-use.com/posts/speed-matters)
@@ -191,11 +195,8 @@ Source: https://docs.browser-use.com/open-source/supported-models
 ```python
 from browser_use import Agent, ChatBrowserUse
 
-# Initialize the model (defaults to bu-latest)
+# Initialize the model - defaults to bu-latest (bu-2-0)
 llm = ChatBrowserUse()
-
-# Or use the premium model
-llm = ChatBrowserUse(model='bu-2-0')
 
 # Create agent with the model
 agent = Agent(
@@ -212,16 +213,19 @@ BROWSER_USE_API_KEY=
 
 Get your API key from the [Browser Use Cloud](https://cloud.browser-use.com/new-api-key). New users get 5 free tasks.
 
-#### Available Models
-
-- `bu-latest` or `bu-1-0`: Default model
-- `bu-2-0`: Latest premium model with improved capabilities
-
 #### Pricing
 
 ChatBrowserUse offers competitive pricing per 1 million tokens:
 
-**bu-1-0 / bu-latest (Default)**
+**bu-2-0 / bu-latest (Default)**
+
+| Token Type | Price per 1M tokens |
+|------------|---------------------|
+| Input tokens | $0.60 |
+| Cached tokens | $0.06 |
+| Output tokens | $3.50 |
+
+**bu-1-0**
 
 Since May 20, 2026, `bu-1-0` is priced the same as `bu-2-0`:
 
@@ -231,16 +235,10 @@ Since May 20, 2026, `bu-1-0` is priced the same as `bu-2-0`:
 | Cached tokens | $0.06 |
 | Output tokens | $3.50 |
 
-**bu-2-0 (Premium)**
 
-| Token Type | Price per 1M tokens |
-|------------|---------------------|
-| Input tokens | $0.60 |
-| Cached tokens | $0.06 |
-| Output tokens | $3.50 |
+### Google Gemini [example](https://github.com/browser-use/browser-use/blob/main/examples/models/gemini.py) {#google-gemini}
 
-
-### Google Gemini [example](https://github.com/browser-use/browser-use/blob/main/examples/models/gemini.py)
+[Available models](https://ai.google.dev/api/models). Also supports Gemma models and Vertex AI via `ChatGoogle(model="...", vertexai=True)`.
 
 `GEMINI_API_KEY` is deprecated and should be named `GOOGLE_API_KEY` as of 2025-05.
 
@@ -252,7 +250,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Initialize the model
-llm = ChatGoogle(model='gemini-flash-latest')
+llm = ChatGoogle(model='gemini-2.5-flash')
 
 # Create agent with the model
 agent = Agent(
@@ -268,16 +266,16 @@ GOOGLE_API_KEY=
 ```
 
 
-### OpenAI [example](https://github.com/browser-use/browser-use/blob/main/examples/models/gpt-4.1.py)
+### OpenAI [example](https://github.com/browser-use/browser-use/blob/main/examples/models/gpt-5-mini.py)
 
-`O3` model is recommended for best accuracy.
+[Available models](https://platform.openai.com/docs/models)
 
 ```python
 from browser_use import Agent, ChatOpenAI
 
 # Initialize the model
 llm = ChatOpenAI(
-model="o3",
+model="gpt-5",
 )
 
 # Create agent with the model
@@ -299,12 +297,14 @@ OPENAI_API_KEY=
 
 ### Anthropic [example](https://github.com/browser-use/browser-use/blob/main/examples/models/claude-4-sonnet.py)
 
+[Available models](https://docs.anthropic.com/en/docs/about-claude/models). Coordinate clicking is automatically enabled for `claude-sonnet-4-*` and `claude-opus-4-*` models.
+
 ```python
 from browser_use import Agent, ChatAnthropic
 
 # Initialize the model
 llm = ChatAnthropic(
-model="claude-sonnet-4-0",
+model="claude-sonnet-4-6",
 )
 
 # Create agent with the model
@@ -320,7 +320,9 @@ And add the variable:
 ANTHROPIC_API_KEY=
 ```
 
-### Azure OpenAI [example](https://github.com/browser-use/browser-use/blob/main/examples/models/azure_openai.py)
+### Azure OpenAI [example](https://github.com/browser-use/browser-use/blob/main/examples/models/azure_openai.py) {#azure-openai}
+
+[Available models](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure)
 
 ```python
 from browser_use import Agent, ChatAzureOpenAI
@@ -383,9 +385,9 @@ The `use_responses_api` parameter accepts:
 - `True`: Force use of the Responses API
 - `False`: Force use of the Chat Completions API
 
-### AWS Bedrock [example](https://github.com/browser-use/browser-use/blob/main/examples/models/aws.py)
+### AWS Bedrock [example](https://github.com/browser-use/browser-use/blob/main/examples/models/aws.py) {#aws-bedrock}
 
-AWS Bedrock provides access to multiple model providers through a single API. We support both a general AWS Bedrock client and provider-specific convenience classes.
+[Available models](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html). AWS Bedrock provides access to multiple model providers through a single API. We support both a general AWS Bedrock client and provider-specific convenience classes. Install with `pip install "browser-use[aws]"`.
 
 #### General AWS Bedrock (supports all providers)
 
@@ -443,7 +445,9 @@ You can also use AWS profiles or IAM roles instead of environment variables. The
 - Session tokens for temporary credentials
 - AWS SSO authentication (`aws_sso_auth=True`)
 
-## Groq [example](https://github.com/browser-use/browser-use/blob/main/examples/models/llama4-groq.py)
+## Groq [example](https://github.com/browser-use/browser-use/blob/main/examples/models/llama4-groq.py) {#groq}
+
+[Available models](https://console.groq.com/docs/models)
 
 ```python
 from browser_use import Agent, ChatGroq
@@ -462,9 +466,9 @@ Required environment variables:
 GROQ_API_KEY=
 ```
 
-## Oracle Cloud Infrastructure (OCI) [example](https://github.com/browser-use/browser-use/blob/main/examples/models/oci_models.py)
+## Oracle Cloud Infrastructure (OCI) [example](https://github.com/browser-use/browser-use/blob/main/examples/models/oci_models.py) {#oci}
 
-OCI provides access to various generative AI models including Meta Llama, Cohere, and other providers through their Generative AI service.
+[Available models](https://docs.oracle.com/en-us/iaas/Content/generative-ai/imported-models.htm). OCI provides access to various generative AI models including Meta Llama, Cohere, and other providers through their Generative AI service. Install with `pip install "browser-use[oci]"`.
 
 ```python
 from browser_use import Agent, ChatOCIRaw
@@ -500,6 +504,8 @@ Authentication methods supported:
 - `RESOURCE_PRINCIPAL`: Uses resource principal authentication
 
 ## Ollama
+
+[Available models](https://ollama.com/library).
 
 1. Install Ollama: https://github.com/ollama/ollama
 2. Run `ollama serve` to start the server
@@ -574,11 +580,9 @@ Required environment variables:
 MODELSCOPE_API_KEY=
 ```
 
-### Vercel AI Gateway [example](https://github.com/browser-use/browser-use/blob/main/examples/models/vercel_ai_gateway.py)
+### Vercel AI Gateway [example](https://github.com/browser-use/browser-use/blob/main/examples/models/vercel_ai_gateway.py) {#vercel}
 
-Vercel AI Gateway provides an OpenAI-compatible API endpoint that acts as a proxy to various AI providers, with features like rate limiting, caching, and monitoring.
-
-To see all available models, visit: https://ai-gateway.vercel.sh/v1/models
+[Available models](https://vercel.com/ai-gateway/models). Vercel AI Gateway provides an OpenAI-compatible API endpoint that acts as a proxy to various AI providers, with features like rate limiting, caching, and monitoring.
 
 ```python
 from browser_use import Agent, ChatVercel
@@ -622,14 +626,112 @@ Required environment variables:
 VERCEL_API_KEY=
 ```
 
-## Other models (DeepSeek, Novita, X...)
+## DeepSeek [example](https://github.com/browser-use/browser-use/blob/main/examples/models/deepseek-chat.py) {#deepseek}
 
-We support all other models that can be called via OpenAI compatible API. We are open to PRs for more providers.
+[Available models](https://api-docs.deepseek.com/quick_start/pricing)
+
+```python
+from browser_use import Agent, ChatDeepSeek
+
+llm = ChatDeepSeek(model="deepseek-chat")
+
+agent = Agent(
+task="Your task here",
+llm=llm
+)
+```
+
+Required environment variables:
+
+```bash .env
+DEEPSEEK_API_KEY=
+```
+
+## Mistral [example](https://github.com/browser-use/browser-use/blob/main/examples/models/mistral.py) {#mistral}
+
+[Available models](https://docs.mistral.ai/getting-started/models/models_overview/)
+
+```python
+from browser_use import Agent, ChatMistral
+
+llm = ChatMistral(model="mistral-large-latest")
+
+agent = Agent(
+task="Your task here",
+llm=llm
+)
+```
+
+Required environment variables:
+
+```bash .env
+MISTRAL_API_KEY=
+```
+
+## Cerebras [example](https://github.com/browser-use/browser-use/blob/main/examples/models/cerebras_example.py) {#cerebras}
+
+[Available models](https://inference-docs.cerebras.ai/models/overview)
+
+```python
+from browser_use import Agent, ChatCerebras
+
+llm = ChatCerebras(model="llama3.3-70b")
+
+agent = Agent(
+task="Your task here",
+llm=llm
+)
+```
+
+Required environment variables:
+
+```bash .env
+CEREBRAS_API_KEY=
+```
+
+## OpenRouter [example](https://github.com/browser-use/browser-use/blob/main/examples/models/openrouter.py) {#openrouter}
+
+[Available models](https://openrouter.ai/models). Access 300+ models from any provider through a single API.
+
+```python
+from browser_use import Agent, ChatOpenRouter
+
+llm = ChatOpenRouter(model="anthropic/claude-sonnet-4-6")
+
+agent = Agent(
+task="Your task here",
+llm=llm
+)
+```
+
+Required environment variables:
+
+```bash .env
+OPENROUTER_API_KEY=
+```
+
+## LiteLLM {#litellm}
+
+Requires separate install (`pip install litellm`). Supports any [LiteLLM model string](https://docs.litellm.ai/docs/providers) — useful when you need a provider not covered by the native integrations above.
+
+```python
+from browser_use import Agent
+from browser_use.llm.litellm import ChatLiteLLM
+
+llm = ChatLiteLLM(model="openai/gpt-5")
+
+agent = Agent(
+task="Your task here",
+llm=llm
+)
+```
+
+## Other OpenAI-Compatible Providers
+
+Any provider with an OpenAI-compatible endpoint works via `ChatOpenAI` with a custom `base_url`:
 
 **Examples available:**
-- [DeepSeek](https://github.com/browser-use/browser-use/blob/main/examples/models/deepseek-chat.py)
 - [Novita](https://github.com/browser-use/browser-use/blob/main/examples/models/novita.py)
-- [OpenRouter](https://github.com/browser-use/browser-use/blob/main/examples/models/openrouter.py)
 
 
 # Browser Use CLI
@@ -734,14 +836,14 @@ browser-use open https://example.com
 # Visible browser window
 browser-use --headed open https://example.com
 
-# Use your real Chrome with Default profile (with existing logins/cookies)
-browser-use --profile "Default" open https://gmail.com
+# Connect to user's Chrome (preserves logins/cookies)
+browser-use connect
 
 # Use a specific Chrome profile
-browser-use --profile "Profile 1" open https://gmail.com
+browser-use --profile "Default" open https://gmail.com
 
-# Auto-discover and connect to running Chrome
-browser-use --connect open https://example.com
+# Cloud browser (zero-config, requires API key)
+browser-use cloud connect
 
 # Connect to an existing browser via CDP URL
 browser-use --cdp-url http://localhost:9222 open https://example.com
@@ -749,6 +851,8 @@ browser-use --cdp-url http://localhost:9222 open https://example.com
 # WebSocket CDP URL also works
 browser-use --cdp-url ws://localhost:9222/devtools/browser/... state
 ```
+
+After `connect` or `cloud connect`, all subsequent commands go to that browser — no extra flags needed.
 
 ## All Commands
 
@@ -786,9 +890,10 @@ browser-use --cdp-url ws://localhost:9222/devtools/browser/... state
 ### Tabs
 | Command | Description |
 |---------|-------------|
-| `switch <tab>` | Switch to tab by index |
-| `close-tab` | Close current tab |
-| `close-tab <tab>` | Close specific tab |
+| `tab list` | List all tabs |
+| `tab new [url]` | Open new tab (blank or with URL) |
+| `tab switch <index>` | Switch to tab by index |
+| `tab close [index...]` | Close tab(s) (current if no index) |
 
 ### Cookies
 | Command | Description |
@@ -845,18 +950,18 @@ Generic REST passthrough to the Browser-Use Cloud API, plus cloud browser provis
 
 | Command | Description |
 |---------|-------------|
-| `cloud connect` | Provision cloud browser and connect |
-| `cloud connect --timeout 120` | Cloud browser with custom timeout |
-| `cloud connect --proxy-country US` | Cloud browser with proxy |
-| `cloud connect --profile-id <id>` | Cloud browser with profile |
+| `cloud connect` | Provision cloud browser and connect (zero-config, auto-manages profile) |
 | `cloud login <api-key>` | Save API key |
 | `cloud logout` | Remove API key |
+| `cloud close` | Disconnect and stop cloud browser |
 | `cloud v2 GET <path>` | GET request to API v2 |
 | `cloud v2 POST <path> '<json>'` | POST request to API v2 |
 | `cloud v3 POST <path> '<json>'` | POST request to API v3 |
 | `cloud v2 poll <task-id>` | Poll task until done |
 | `cloud v2 --help` | Show API v2 endpoints (from OpenAPI spec) |
 | `cloud v3 --help` | Show API v3 endpoints |
+
+`cloud connect` provisions a cloud browser with a persistent profile (auto-created on first use), connects via CDP, and prints a live URL. For custom browser settings (proxy, timeout, specific profile), use `cloud v2 POST /browsers` directly.
 
 ```bash
 # Save API key (or set BROWSER_USE_API_KEY env var)
@@ -955,11 +1060,24 @@ BROWSER_USE_SESSION=work browser-use state
 |--------|-------------|
 | `--headed` | Show browser window |
 | `--profile [NAME]` | Use real Chrome (bare `--profile` uses "Default") |
-| `--connect` | Auto-discover and connect to running Chrome via CDP |
+| `--connect` | Auto-discover and connect to running Chrome via CDP (prefer `connect` command instead) |
 | `--cdp-url <url>` | Connect to existing browser via CDP URL (`http://` or `ws://`) |
 | `--session NAME` | Target a named session (default: "default", env: `BROWSER_USE_SESSION`) |
 | `--json` | Output as JSON |
 | `--mcp` | Run as MCP server via stdin/stdout |
+
+## Configuration
+
+```bash
+browser-use config list                            # Show all config values
+browser-use config set cloud_connect_proxy jp      # Set a value
+browser-use config get cloud_connect_proxy         # Get a value
+browser-use config unset cloud_connect_timeout     # Remove a value
+browser-use doctor                                 # Shows config + diagnostics
+browser-use setup                                  # Interactive post-install setup
+```
+
+Config stored in `~/.browser-use/config.json`.
 
 ## Examples
 
@@ -1024,6 +1142,7 @@ All CLI-managed files live under `~/.browser-use/` (override with `BROWSER_USE_H
 ├── tunnels/
 │   ├── {port}.json      # Tunnel metadata
 │   └── {port}.log       # Tunnel logs
+├── default.state.json   # Daemon lifecycle state (phase, PID, config)
 ├── default.sock         # Daemon socket (ephemeral)
 ├── default.pid          # Daemon PID (ephemeral)
 └── cli.log              # Daemon log
@@ -1098,12 +1217,12 @@ Research the top Hacker News stories and summarize the points.
   controls
   className="w-full aspect-video rounded-xl">
   <source
-    src="https://media.githubusercontent.com/media/browser-use/sdk/rust-terminal-docs/docs/static/terminal_demo.mp4"
-    type="video/mp4"
+src="https://media.githubusercontent.com/media/browser-use/sdk/rust-terminal-docs/docs/static/terminal_demo.mp4"
+type="video/mp4"
   />
   <source
-    src="https://media.githubusercontent.com/media/browser-use/sdk/main/docs/static/terminal_demo.mp4"
-    type="video/mp4"
+src="https://media.githubusercontent.com/media/browser-use/sdk/main/docs/static/terminal_demo.mp4"
+type="video/mp4"
   />
 </video>
 
@@ -1115,9 +1234,7 @@ You can use Browser Use Terminal in three ways:
 | **CLI** | Scriptable commands such as `browser-use-terminal run-openai`. Best for automation and one-off tasks. |
 | **Python** | `browser_use.beta.Agent`, backed by the same Rust runtime. Best when you want browser-use code with terminal runtime behavior. |
 
-<Info>
 Browser Use Terminal is separate from the lower-level `browser-use` CLI. Use `browser` for the Terminal TUI, `browser-use-terminal` for Terminal task commands, and `browser-use` for direct browser-control commands.
-</Info>
 
 ## Terms
 
@@ -1240,18 +1357,18 @@ from browser_use.beta import Agent, BrowserProfile, ChatOpenAI
 
 
 async def main():
-    agent = Agent(
-        task="Go to https://news.ycombinator.com and return the top stories with points.",
-        llm=ChatOpenAI(model="gpt-5.5"),
-        browser_profile=BrowserProfile(
-            headless=True,
-            window_size={"width": 1440, "height": 900},
-            allowed_domains=["news.ycombinator.com"],
-        ),
-    )
+agent = Agent(
+    task="Go to https://news.ycombinator.com and return the top stories with points.",
+    llm=ChatOpenAI(model="gpt-5.5"),
+    browser_profile=BrowserProfile(
+        headless=True,
+        window_size={"width": 1440, "height": 900},
+        allowed_domains=["news.ycombinator.com"],
+    ),
+)
 
-    history = await agent.run(max_steps=12)
-    print(history.final_result())
+history = await agent.run(max_steps=12)
+print(history.final_result())
 
 
 asyncio.run(main())
@@ -1299,8 +1416,8 @@ Pass a supported browser-use model class to `Agent`:
 from browser_use.beta import Agent, ChatAnthropic
 
 agent = Agent(
-    task="Find the latest Browser Use docs update",
-    llm=ChatAnthropic(model="claude-sonnet-4-6"),
+task="Find the latest Browser Use docs update",
+llm=ChatAnthropic(model="claude-sonnet-4-6"),
 )
 ```
 
@@ -1353,13 +1470,13 @@ Managed local browser:
 from browser_use.beta import Agent, BrowserProfile, ChatOpenAI
 
 agent = Agent(
-    task="Open Hacker News",
-    llm=ChatOpenAI(model="gpt-5.5"),
-    browser_profile=BrowserProfile(
-        headless=True,
-        user_data_dir="./browser-profile",
-        window_size={"width": 1280, "height": 900},
-    ),
+task="Open Hacker News",
+llm=ChatOpenAI(model="gpt-5.5"),
+browser_profile=BrowserProfile(
+    headless=True,
+    user_data_dir="./browser-profile",
+    window_size={"width": 1280, "height": 900},
+),
 )
 ```
 
@@ -1367,9 +1484,9 @@ Headed browser:
 
 ```python
 agent = Agent(
-    task="Open Hacker News",
-    llm=ChatOpenAI(model="gpt-5.5"),
-    browser_profile=BrowserProfile(headless=False),
+task="Open Hacker News",
+llm=ChatOpenAI(model="gpt-5.5"),
+browser_profile=BrowserProfile(headless=False),
 )
 ```
 
@@ -1381,14 +1498,14 @@ Browser Use Cloud is the simplest remote browser option for Python too. Set `BRO
 from browser_use.beta import Agent, BrowserSession, ChatOpenAI
 
 agent = Agent(
-    task="Open Hacker News",
-    llm=ChatOpenAI(model="gpt-5.5"),
-    browser_session=BrowserSession(
-        use_cloud=True,
-        cloud_profile_id="profile-id",
-        cloud_proxy_country_code="US",
-        keep_alive=False,
-    ),
+task="Open Hacker News",
+llm=ChatOpenAI(model="gpt-5.5"),
+browser_session=BrowserSession(
+    use_cloud=True,
+    cloud_profile_id="profile-id",
+    cloud_proxy_country_code="US",
+    keep_alive=False,
+),
 )
 ```
 
@@ -1398,12 +1515,12 @@ Existing browser over CDP:
 from browser_use.beta import Agent, BrowserProfile, ChatOpenAI
 
 agent = Agent(
-    task="Open Hacker News",
-    llm=ChatOpenAI(model="gpt-5.5"),
-    browser_profile=BrowserProfile(
-        cdp_url="http://127.0.0.1:9333",
-        user_agent="BrowserUseRemoteCDP/1.0",
-    ),
+task="Open Hacker News",
+llm=ChatOpenAI(model="gpt-5.5"),
+browser_profile=BrowserProfile(
+    cdp_url="http://127.0.0.1:9333",
+    user_agent="BrowserUseRemoteCDP/1.0",
+),
 )
 ```
 
@@ -1471,9 +1588,9 @@ Python runs use the same terminal runtime and terminal state. Configure website 
 from browser_use.beta import Agent, BrowserProfile, ChatOpenAI
 
 agent = Agent(
-    task="Log in to example.com and summarize my dashboard.",
-    llm=ChatOpenAI(model="gpt-5.5"),
-    browser_profile=BrowserProfile(allowed_domains=["example.com"]),
+task="Log in to example.com and summarize my dashboard.",
+llm=ChatOpenAI(model="gpt-5.5"),
+browser_profile=BrowserProfile(allowed_domains=["example.com"]),
 )
 ```
 
@@ -1506,8 +1623,8 @@ Pass domain policy through `BrowserProfile`:
 from browser_use.beta import BrowserProfile
 
 profile = BrowserProfile(
-    allowed_domains=["news.ycombinator.com"],
-    prohibited_domains=["*.tracking.example"],
+allowed_domains=["news.ycombinator.com"],
+prohibited_domains=["*.tracking.example"],
 )
 ```
 

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -84,13 +84,13 @@ import asyncio
 load_dotenv()
 
 async def main():
-llm = ChatBrowserUse()
-task = "Find the number 1 post on Show HN"
-agent = Agent(task=task, llm=llm)
-await agent.run()
+    llm = ChatBrowserUse()
+    task = "Find the number 1 post on Show HN"
+    agent = Agent(task=task, llm=llm)
+    await agent.run()
 
 if __name__ == "__main__":
-asyncio.run(main())
+    asyncio.run(main())
 ```
 ```python Google
 from browser_use import Agent, ChatGoogle
@@ -100,13 +100,13 @@ import asyncio
 load_dotenv()
 
 async def main():
-llm = ChatGoogle(model="gemini-flash-latest")
-task = "Find the number 1 post on Show HN"
-agent = Agent(task=task, llm=llm)
-await agent.run()
+    llm = ChatGoogle(model="gemini-flash-latest")
+    task = "Find the number 1 post on Show HN"
+    agent = Agent(task=task, llm=llm)
+    await agent.run()
 
 if __name__ == "__main__":
-asyncio.run(main())
+    asyncio.run(main())
 ```
 ```python OpenAI
 from browser_use import Agent, ChatOpenAI
@@ -116,13 +116,13 @@ import asyncio
 load_dotenv()
 
 async def main():
-llm = ChatOpenAI(model="gpt-4.1-mini")
-task = "Find the number 1 post on Show HN"
-agent = Agent(task=task, llm=llm)
-await agent.run()
+    llm = ChatOpenAI(model="gpt-4.1-mini")
+    task = "Find the number 1 post on Show HN"
+    agent = Agent(task=task, llm=llm)
+    await agent.run()
 
 if __name__ == "__main__":
-asyncio.run(main())
+    asyncio.run(main())
 ```
 ```python Anthropic
 from browser_use import Agent, ChatAnthropic
@@ -132,13 +132,13 @@ import asyncio
 load_dotenv()
 
 async def main():
-llm = ChatAnthropic(model='claude-sonnet-4-0', temperature=0.0)
-task = "Find the number 1 post on Show HN"
-agent = Agent(task=task, llm=llm)
-await agent.run()
+    llm = ChatAnthropic(model='claude-sonnet-4-0', temperature=0.0)
+    task = "Find the number 1 post on Show HN"
+    agent = Agent(task=task, llm=llm)
+    await agent.run()
 
 if __name__ == "__main__":
-asyncio.run(main())
+    asyncio.run(main())
 ```
 
 
@@ -155,15 +155,15 @@ from browser_use.agent.service import Agent
 
 @sandbox(cloud_profile_id='your-profile-id')
 async def production_task(browser: Browser):
-agent = Agent(
-    task="Your authenticated task",
-    browser=browser,
-    llm=ChatBrowserUse(),
-)
-await agent.run()
+    agent = Agent(
+        task="Your authenticated task",
+        browser=browser,
+        llm=ChatBrowserUse(),
+    )
+    await agent.run()
 
 if __name__ == "__main__":
-asyncio.run(production_task())
+    asyncio.run(production_task())
 ```
 
 See [Browser Use Cloud](https://docs.browser-use.com/cloud/quickstart) for how to sync your cookies to the cloud.
@@ -200,8 +200,8 @@ llm = ChatBrowserUse()
 
 # Create agent with the model
 agent = Agent(
-task="...", # Your task here
-llm=llm
+    task="...", # Your task here
+    llm=llm
 )
 ```
 
@@ -254,8 +254,8 @@ llm = ChatGoogle(model='gemini-2.5-flash')
 
 # Create agent with the model
 agent = Agent(
-task="Your task here",
-llm=llm
+    task="Your task here",
+    llm=llm
 )
 ```
 
@@ -275,13 +275,13 @@ from browser_use import Agent, ChatOpenAI
 
 # Initialize the model
 llm = ChatOpenAI(
-model="gpt-5",
+    model="gpt-5",
 )
 
 # Create agent with the model
 agent = Agent(
-task="...", # Your task here
-llm=llm
+    task="...", # Your task here
+    llm=llm
 )
 ```
 
@@ -304,13 +304,13 @@ from browser_use import Agent, ChatAnthropic
 
 # Initialize the model
 llm = ChatAnthropic(
-model="claude-sonnet-4-6",
+    model="claude-sonnet-4-6",
 )
 
 # Create agent with the model
 agent = Agent(
-task="...", # Your task here
-llm=llm
+    task="...", # Your task here
+    llm=llm
 )
 ```
 
@@ -331,13 +331,13 @@ import os
 
 # Initialize the model
 llm = ChatAzureOpenAI(
-model="o4-mini",
+    model="o4-mini",
 )
 
 # Create agent with the model
 agent = Agent(
-task="...", # Your task here
-llm=llm
+    task="...", # Your task here
+    llm=llm
 )
 ```
 
@@ -363,20 +363,20 @@ from browser_use import Agent, ChatAzureOpenAI
 
 # Auto-detection (recommended) - uses Responses API for gpt-5.1-codex-mini
 llm = ChatAzureOpenAI(
-model="gpt-5.1-codex-mini",
-api_version="2025-03-01-preview",  # Required for Responses API
+    model="gpt-5.1-codex-mini",
+    api_version="2025-03-01-preview",  # Required for Responses API
 )
 
 # Or explicitly enable/disable Responses API for any model
 llm = ChatAzureOpenAI(
-model="gpt-4o",
-api_version="2025-03-01-preview",
-use_responses_api=True,  # Force Responses API (True/False/'auto')
+    model="gpt-4o",
+    api_version="2025-03-01-preview",
+    use_responses_api=True,  # Force Responses API (True/False/'auto')
 )
 
 agent = Agent(
-task="...",
-llm=llm
+    task="...",
+    llm=llm
 )
 ```
 
@@ -397,14 +397,14 @@ from browser_use.llm import ChatAWSBedrock
 
 # Works with any Bedrock model (Anthropic, Meta, AI21, etc.)
 llm = ChatAWSBedrock(
-model="anthropic.claude-3-5-sonnet-20240620-v1:0",  # or any Bedrock model
-aws_region="us-east-1",
+    model="anthropic.claude-3-5-sonnet-20240620-v1:0",  # or any Bedrock model
+    aws_region="us-east-1",
 )
 
 # Create agent with the model
 agent = Agent(
-task="Your task here",
-llm=llm
+    task="Your task here",
+    llm=llm
 )
 ```
 
@@ -416,14 +416,14 @@ from browser_use.llm import ChatAnthropicBedrock
 
 # Anthropic-specific class with Claude defaults
 llm = ChatAnthropicBedrock(
-model="anthropic.claude-3-5-sonnet-20240620-v1:0",
-aws_region="us-east-1",
+    model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+    aws_region="us-east-1",
 )
 
 # Create agent with the model
 agent = Agent(
-task="Your task here",
-llm=llm
+    task="Your task here",
+    llm=llm
 )
 ```
 
@@ -455,8 +455,8 @@ from browser_use import Agent, ChatGroq
 llm = ChatGroq(model="meta-llama/llama-4-maverick-17b-128e-instruct")
 
 agent = Agent(
-task="Your task here",
-llm=llm
+    task="Your task here",
+    llm=llm
 )
 ```
 
@@ -475,21 +475,21 @@ from browser_use import Agent, ChatOCIRaw
 
 # Initialize the OCI model
 llm = ChatOCIRaw(
-model_id="ocid1.generativeaimodel.oc1.us-chicago-1.amaaaaaask7dceya...",
-service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
-compartment_id="ocid1.tenancy.oc1..aaaaaaaayeiis5uk2nuubznrekd...",
-provider="meta",  # or "cohere"
-temperature=0.7,
-max_tokens=800,
-top_p=0.9,
-auth_type="API_KEY",
-auth_profile="DEFAULT"
+    model_id="ocid1.generativeaimodel.oc1.us-chicago-1.amaaaaaask7dceya...",
+    service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+    compartment_id="ocid1.tenancy.oc1..aaaaaaaayeiis5uk2nuubznrekd...",
+    provider="meta",  # or "cohere"
+    temperature=0.7,
+    max_tokens=800,
+    top_p=0.9,
+    auth_type="API_KEY",
+    auth_profile="DEFAULT"
 )
 
 # Create agent with the model
 agent = Agent(
-task="Your task here",
-llm=llm
+    task="Your task here",
+    llm=llm
 )
 ```
 
@@ -540,9 +540,9 @@ base_url = 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1'
 llm = ChatOpenAI(model='qwen-vl-max', api_key=api_key, base_url=base_url)
 
 agent = Agent(
-task="Your task here",
-llm=llm,
-use_vision=True
+    task="Your task here",
+    llm=llm,
+    use_vision=True
 )
 ```
 
@@ -568,9 +568,9 @@ base_url = 'https://api-inference.modelscope.cn/v1/'
 llm = ChatOpenAI(model='Qwen/Qwen2.5-VL-72B-Instruct', api_key=api_key, base_url=base_url)
 
 agent = Agent(
-task="Your task here",
-llm=llm,
-use_vision=True
+    task="Your task here",
+    llm=llm,
+    use_vision=True
 )
 ```
 
@@ -594,29 +594,29 @@ load_dotenv()
 # Get API key (https://vercel.com/ai-gateway)
 api_key = os.getenv('VERCEL_API_KEY')
 if not api_key:
-raise ValueError('VERCEL_API_KEY is not set')
+    raise ValueError('VERCEL_API_KEY is not set')
 
 # Basic usage
 llm = ChatVercel(
-model='openai/gpt-4o',
-api_key=api_key,
+    model='openai/gpt-4o',
+    api_key=api_key,
 )
 
 # With provider options - control which providers are used and in what order
 # This will try Vertex AI first, then fall back to Anthropic if Vertex fails
 llm_with_provider_options = ChatVercel(
-model='anthropic/claude-sonnet-4',
-api_key=api_key,
-provider_options={
-    'gateway': {
-        'order': ['vertex', 'anthropic']  # Try Vertex AI first, then Anthropic
-    }
-},
+    model='anthropic/claude-sonnet-4',
+    api_key=api_key,
+    provider_options={
+        'gateway': {
+            'order': ['vertex', 'anthropic']  # Try Vertex AI first, then Anthropic
+        }
+    },
 )
 
 agent = Agent(
-task="Your task here",
-llm=llm
+    task="Your task here",
+    llm=llm
 )
 ```
 
@@ -636,8 +636,8 @@ from browser_use import Agent, ChatDeepSeek
 llm = ChatDeepSeek(model="deepseek-chat")
 
 agent = Agent(
-task="Your task here",
-llm=llm
+    task="Your task here",
+    llm=llm
 )
 ```
 
@@ -657,8 +657,8 @@ from browser_use import Agent, ChatMistral
 llm = ChatMistral(model="mistral-large-latest")
 
 agent = Agent(
-task="Your task here",
-llm=llm
+    task="Your task here",
+    llm=llm
 )
 ```
 
@@ -678,8 +678,8 @@ from browser_use import Agent, ChatCerebras
 llm = ChatCerebras(model="llama3.3-70b")
 
 agent = Agent(
-task="Your task here",
-llm=llm
+    task="Your task here",
+    llm=llm
 )
 ```
 
@@ -699,8 +699,8 @@ from browser_use import Agent, ChatOpenRouter
 llm = ChatOpenRouter(model="anthropic/claude-sonnet-4-6")
 
 agent = Agent(
-task="Your task here",
-llm=llm
+    task="Your task here",
+    llm=llm
 )
 ```
 
@@ -721,8 +721,8 @@ from browser_use.llm.litellm import ChatLiteLLM
 llm = ChatLiteLLM(model="openai/gpt-5")
 
 agent = Agent(
-task="Your task here",
-llm=llm
+    task="Your task here",
+    llm=llm
 )
 ```
 
@@ -1102,8 +1102,8 @@ browser-use eval "Array.from(document.querySelectorAll('.titleline a')).slice(0,
 browser-use open https://example.com
 browser-use python "
 for i in range(5):
-browser.scroll('down')
-browser.wait(0.5)
+    browser.scroll('down')
+    browser.wait(0.5)
 browser.screenshot('scrolled.png')
 "
 ```
@@ -1357,18 +1357,18 @@ from browser_use.beta import Agent, BrowserProfile, ChatOpenAI
 
 
 async def main():
-agent = Agent(
-    task="Go to https://news.ycombinator.com and return the top stories with points.",
-    llm=ChatOpenAI(model="gpt-5.5"),
-    browser_profile=BrowserProfile(
-        headless=True,
-        window_size={"width": 1440, "height": 900},
-        allowed_domains=["news.ycombinator.com"],
-    ),
-)
+    agent = Agent(
+        task="Go to https://news.ycombinator.com and return the top stories with points.",
+        llm=ChatOpenAI(model="gpt-5.5"),
+        browser_profile=BrowserProfile(
+            headless=True,
+            window_size={"width": 1440, "height": 900},
+            allowed_domains=["news.ycombinator.com"],
+        ),
+    )
 
-history = await agent.run(max_steps=12)
-print(history.final_result())
+    history = await agent.run(max_steps=12)
+    print(history.final_result())
 
 
 asyncio.run(main())
@@ -1416,8 +1416,8 @@ Pass a supported browser-use model class to `Agent`:
 from browser_use.beta import Agent, ChatAnthropic
 
 agent = Agent(
-task="Find the latest Browser Use docs update",
-llm=ChatAnthropic(model="claude-sonnet-4-6"),
+    task="Find the latest Browser Use docs update",
+    llm=ChatAnthropic(model="claude-sonnet-4-6"),
 )
 ```
 
@@ -1470,13 +1470,13 @@ Managed local browser:
 from browser_use.beta import Agent, BrowserProfile, ChatOpenAI
 
 agent = Agent(
-task="Open Hacker News",
-llm=ChatOpenAI(model="gpt-5.5"),
-browser_profile=BrowserProfile(
-    headless=True,
-    user_data_dir="./browser-profile",
-    window_size={"width": 1280, "height": 900},
-),
+    task="Open Hacker News",
+    llm=ChatOpenAI(model="gpt-5.5"),
+    browser_profile=BrowserProfile(
+        headless=True,
+        user_data_dir="./browser-profile",
+        window_size={"width": 1280, "height": 900},
+    ),
 )
 ```
 
@@ -1484,9 +1484,9 @@ Headed browser:
 
 ```python
 agent = Agent(
-task="Open Hacker News",
-llm=ChatOpenAI(model="gpt-5.5"),
-browser_profile=BrowserProfile(headless=False),
+    task="Open Hacker News",
+    llm=ChatOpenAI(model="gpt-5.5"),
+    browser_profile=BrowserProfile(headless=False),
 )
 ```
 
@@ -1498,14 +1498,14 @@ Browser Use Cloud is the simplest remote browser option for Python too. Set `BRO
 from browser_use.beta import Agent, BrowserSession, ChatOpenAI
 
 agent = Agent(
-task="Open Hacker News",
-llm=ChatOpenAI(model="gpt-5.5"),
-browser_session=BrowserSession(
-    use_cloud=True,
-    cloud_profile_id="profile-id",
-    cloud_proxy_country_code="US",
-    keep_alive=False,
-),
+    task="Open Hacker News",
+    llm=ChatOpenAI(model="gpt-5.5"),
+    browser_session=BrowserSession(
+        use_cloud=True,
+        cloud_profile_id="profile-id",
+        cloud_proxy_country_code="US",
+        keep_alive=False,
+    ),
 )
 ```
 
@@ -1515,12 +1515,12 @@ Existing browser over CDP:
 from browser_use.beta import Agent, BrowserProfile, ChatOpenAI
 
 agent = Agent(
-task="Open Hacker News",
-llm=ChatOpenAI(model="gpt-5.5"),
-browser_profile=BrowserProfile(
-    cdp_url="http://127.0.0.1:9333",
-    user_agent="BrowserUseRemoteCDP/1.0",
-),
+    task="Open Hacker News",
+    llm=ChatOpenAI(model="gpt-5.5"),
+    browser_profile=BrowserProfile(
+        cdp_url="http://127.0.0.1:9333",
+        user_agent="BrowserUseRemoteCDP/1.0",
+    ),
 )
 ```
 
@@ -1588,9 +1588,9 @@ Python runs use the same terminal runtime and terminal state. Configure website 
 from browser_use.beta import Agent, BrowserProfile, ChatOpenAI
 
 agent = Agent(
-task="Log in to example.com and summarize my dashboard.",
-llm=ChatOpenAI(model="gpt-5.5"),
-browser_profile=BrowserProfile(allowed_domains=["example.com"]),
+    task="Log in to example.com and summarize my dashboard.",
+    llm=ChatOpenAI(model="gpt-5.5"),
+    browser_profile=BrowserProfile(allowed_domains=["example.com"]),
 )
 ```
 
@@ -1623,8 +1623,8 @@ Pass domain policy through `BrowserProfile`:
 from browser_use.beta import BrowserProfile
 
 profile = BrowserProfile(
-allowed_domains=["news.ycombinator.com"],
-prohibited_domains=["*.tracking.example"],
+    allowed_domains=["news.ycombinator.com"],
+    prohibited_domains=["*.tracking.example"],
 )
 ```
 
@@ -1828,12 +1828,12 @@ Source: https://docs.browser-use.com/open-source/customize/agent/basics
 from browser_use import Agent, ChatBrowserUse
 
 agent = Agent(
-task="Search for latest news about AI",
-llm=ChatBrowserUse(),
+    task="Search for latest news about AI",
+    llm=ChatBrowserUse(),
 )
 
 async def main():
-history = await agent.run(max_steps=100)
+    history = await agent.run(max_steps=100)
 ```
 
 - `task`: The task you want to automate.
@@ -1910,8 +1910,8 @@ If the submit button cannot be clicked:
 # When you have custom actions
 @controller.action("Get 2FA code from authenticator app")
 async def get_2fa_code():
-# Your implementation
-pass
+    # Your implementation
+    pass
 
 task = """
 Login with 2FA:
@@ -2182,9 +2182,9 @@ from browser_use import Agent, Browser, ChatBrowserUse
 browser = Browser.from_system_chrome()
 
 agent = Agent(
-task='Check my Gmail inbox',
-browser=browser,
-llm=ChatBrowserUse(),
+    task='Check my Gmail inbox',
+    browser=browser,
+    llm=ChatBrowserUse(),
 )
 await agent.run()
 ```
@@ -2216,9 +2216,9 @@ from browser_use import Agent, Browser, ChatBrowserUse
 browser = Browser(storage_state='auth.json')
 
 agent = Agent(
-task='Check my notifications',
-browser=browser,
-llm=ChatBrowserUse(),
+    task='Check my notifications',
+    browser=browser,
+    llm=ChatBrowserUse(),
 )
 await agent.run()
 ```
@@ -2242,24 +2242,24 @@ The JSON file follows Playwright's format:
 ```json
 {
   "cookies": [
-{
-  "name": "session_id",
-  "value": "abc123",
-  "domain": ".example.com",
-  "path": "/",
-  "expires": 1704067200,
-  "httpOnly": true,
-  "secure": true,
-  "sameSite": "Lax"
-}
+    {
+      "name": "session_id",
+      "value": "abc123",
+      "domain": ".example.com",
+      "path": "/",
+      "expires": 1704067200,
+      "httpOnly": true,
+      "secure": true,
+      "sameSite": "Lax"
+    }
   ],
   "origins": [
-{
-  "origin": "https://example.com",
-  "localStorage": [
-    {"name": "auth_token", "value": "xyz789"}
-  ]
-}
+    {
+      "origin": "https://example.com",
+      "localStorage": [
+        {"name": "auth_token", "value": "xyz789"}
+      ]
+    }
   ]
 }
 ```
@@ -2286,17 +2286,17 @@ from browser_use import Agent, ChatBrowserUse
 totp_secret = 'JBSWY3DPEHPK3PXP'
 
 agent = Agent(
-task='''
-1. Go to https://example.com/login
-2. Enter username x_user and password x_pass
-3. When prompted for 2FA, enter bu_2fa_code
-''',
-sensitive_data={
-    'x_user': 'myusername',
-    'x_pass': 'mypassword',
-    'bu_2fa_code': totp_secret,  # suffix must be bu_2fa_code
-},
-llm=ChatBrowserUse(),
+    task='''
+    1. Go to https://example.com/login
+    2. Enter username x_user and password x_pass
+    3. When prompted for 2FA, enter bu_2fa_code
+    ''',
+    sensitive_data={
+        'x_user': 'myusername',
+        'x_pass': 'mypassword',
+        'bu_2fa_code': totp_secret,  # suffix must be bu_2fa_code
+    },
+    llm=ChatBrowserUse(),
 )
 await agent.run()
 ```
@@ -2331,19 +2331,19 @@ tools = Tools()
 
 @tools.registry.action('Get email address for signup')
 async def get_email_address():
-return ActionResult(extracted_content=inbox.inbox_id)
+    return ActionResult(extracted_content=inbox.inbox_id)
 
 @tools.registry.action('Get verification code from email')
 async def get_verification_code():
-emails = await email_client.inboxes.messages.list(inbox_id=inbox.inbox_id)
-if emails.messages:
-    return ActionResult(extracted_content=emails.messages[0].text)
-return ActionResult(error='No emails found')
+    emails = await email_client.inboxes.messages.list(inbox_id=inbox.inbox_id)
+    if emails.messages:
+        return ActionResult(extracted_content=emails.messages[0].text)
+    return ActionResult(error='No emails found')
 
 agent = Agent(
-task='Sign up at example.com, get verification code from email',
-tools=tools,
-llm=ChatBrowserUse(),
+    task='Sign up at example.com, get verification code from email',
+    tools=tools,
+    llm=ChatBrowserUse(),
 )
 await agent.run()
 ```
@@ -2363,18 +2363,18 @@ tools = Tools()
 
 @tools.registry.action('Get 2FA code from 1Password', domains=['*.google.com'])
 async def get_1password_2fa():
-client = await Client.authenticate(
-    auth=os.environ['OP_SERVICE_ACCOUNT_TOKEN'],
-    integration_name='Browser-Use',
-    integration_version='v1.0.0',
-)
-code = await client.secrets.resolve('op://Private/Google/One-time passcode')
-return ActionResult(extracted_content=code)
+    client = await Client.authenticate(
+        auth=os.environ['OP_SERVICE_ACCOUNT_TOKEN'],
+        integration_name='Browser-Use',
+        integration_version='v1.0.0',
+    )
+    code = await client.secrets.resolve('op://Private/Google/One-time passcode')
+    return ActionResult(extracted_content=code)
 
 agent = Agent(
-task='Login to Google and check email',
-tools=tools,
-llm=ChatBrowserUse(),
+    task='Login to Google and check email',
+    tools=tools,
+    llm=ChatBrowserUse(),
 )
 await agent.run()
 ```
@@ -2394,9 +2394,9 @@ tools = Tools()
 register_gmail_actions(tools, gmail_service=gmail_service)
 
 agent = Agent(
-task='Login to example.com, then get the verification code from Gmail',
-tools=tools,
-llm=ChatBrowserUse(),
+    task='Login to example.com, then get the verification code from Gmail',
+    tools=tools,
+    llm=ChatBrowserUse(),
 )
 await agent.run()
 ```
@@ -2420,7 +2420,7 @@ Limit where the browser can navigate to prevent credential leaks:
 
 ```python
 browser = Browser(
-allowed_domains=['*.example.com', 'auth.example.com'],
+    allowed_domains=['*.example.com', 'auth.example.com'],
 )
 ```
 
@@ -2430,10 +2430,10 @@ Prevent screenshots from being sent to the LLM:
 
 ```python
 agent = Agent(
-task='Login and check balance',
-use_vision=False,  # No screenshots sent to LLM
-sensitive_data={'password': 'secret123'},
-llm=ChatBrowserUse(),
+    task='Login and check balance',
+    use_vision=False,  # No screenshots sent to LLM
+    sensitive_data={'password': 'secret123'},
+    llm=ChatBrowserUse(),
 )
 ```
 
@@ -2443,14 +2443,14 @@ Route credentials to specific domains only:
 
 ```python
 sensitive_data = {
-'https://*.work.com': {
-    'work_user': 'alice@work.com',
-    'work_pass': 'work_password',
-},
-'https://personal.com': {
-    'personal_user': 'alice@gmail.com',
-    'personal_pass': 'personal_password',
-},
+    'https://*.work.com': {
+        'work_user': 'alice@work.com',
+        'work_pass': 'work_password',
+    },
+    'https://personal.com': {
+        'personal_user': 'alice@gmail.com',
+        'personal_pass': 'personal_password',
+    },
 }
 ```
 
@@ -2471,9 +2471,9 @@ from browser_use import Agent, Browser, ChatBrowserUse
 browser = Browser(cdp_url='wss://cloud.browser-use.com/...')
 
 agent = Agent(
-task='Check my orders',
-browser=browser,
-llm=ChatBrowserUse(),
+    task='Check my orders',
+    browser=browser,
+    llm=ChatBrowserUse(),
 )
 await agent.run()
 ```
@@ -2496,16 +2496,16 @@ from browser_use import Agent, Browser, ChatOpenAI
 browser = Browser.from_system_chrome()
 
 agent = Agent(
-task='Visit https://duckduckgo.com and search for "browser-use founders"',
-browser=browser,
-llm=ChatOpenAI(model='gpt-4.1-mini'),
+    task='Visit https://duckduckgo.com and search for "browser-use founders"',
+    browser=browser,
+    llm=ChatOpenAI(model='gpt-4.1-mini'),
 )
 
 async def main():
-await agent.run()
+    await agent.run()
 
 if __name__ == "__main__":
-asyncio.run(main())
+    asyncio.run(main())
 ```
 
 
@@ -2519,7 +2519,7 @@ from browser_use import Browser
 # List available profiles
 profiles = Browser.list_chrome_profiles()
 for p in profiles:
-print(f"{p['directory']}: {p['name']}")
+    print(f"{p['directory']}: {p['name']}")
 # Output:
 # Profile 1: Work
 # Profile 5: Personal
@@ -2535,9 +2535,9 @@ If auto-detection does not work, specify paths manually:
 
 ```python
 browser = Browser(
-executable_path='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-user_data_dir='~/Library/Application Support/Google/Chrome',
-profile_directory='Default',
+    executable_path='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    user_data_dir='~/Library/Application Support/Google/Chrome',
+    profile_directory='Default',
 )
 ```
 
@@ -2567,26 +2567,26 @@ from browser_use import Agent, Browser, ChatBrowserUse
 
 # Simple: Use Browser-Use cloud browser service
 browser = Browser(
-use_cloud=True,  # Automatically provisions a cloud browser
+    use_cloud=True,  # Automatically provisions a cloud browser
 )
 
 # Advanced: Configure cloud browser parameters
 # Using this settings can bypass any captcha protection on any website
 browser = Browser(
-cloud_profile_id='your-profile-id',  # Optional: specific browser profile
-cloud_proxy_country_code='us',  # Optional: proxy location (us, uk, fr, it, jp, au, de, fi, ca, in)
-cloud_timeout=30,  # Optional: session timeout in minutes (MAX free: 15min, paid: 240min)
+    cloud_profile_id='your-profile-id',  # Optional: specific browser profile
+    cloud_proxy_country_code='us',  # Optional: proxy location (us, uk, fr, it, jp, au, de, fi, ca, in)
+    cloud_timeout=30,  # Optional: session timeout in minutes (MAX free: 15min, paid: 240min)
 )
 
 # Or use a CDP URL from any cloud browser provider
 browser = Browser(
-cdp_url="http://remote-server:9222"  # Get a CDP URL from any provider
+    cdp_url="http://remote-server:9222"  # Get a CDP URL from any provider
 )
 
 agent = Agent(
-task="Your task here",
-llm=ChatBrowserUse(),
-browser=browser,
+    task="Your task here",
+    llm=ChatBrowserUse(),
+    browser=browser,
 )
 ```
 
@@ -2619,20 +2619,20 @@ from browser_use import Agent, Browser, ChatBrowserUse
 from browser_use.browser import ProxySettings
 
 browser = Browser(
-headless=False,
-proxy=ProxySettings(
-    server="http://proxy-server:8080",
-    username="proxy-user",
-    password="proxy-pass"
-),
-cdp_url="http://remote-server:9222"
+    headless=False,
+    proxy=ProxySettings(
+        server="http://proxy-server:8080",
+        username="proxy-user",
+        password="proxy-pass"
+    ),
+    cdp_url="http://remote-server:9222"
 )
 
 
 agent = Agent(
-task="Your task here",
-llm=ChatBrowserUse(),
-browser=browser,
+    task="Your task here",
+    llm=ChatBrowserUse(),
+    browser=browser,
 )
 ```
 
@@ -2805,7 +2805,7 @@ from browser_use import Browser
 
 profiles = Browser.list_chrome_profiles()
 for p in profiles:
-print(f"{p['directory']}: {p['name']}")
+    print(f"{p['directory']}: {p['name']}")
 # Output:
 # Profile 1: Work
 # Profile 5: Personal
@@ -2816,9 +2816,9 @@ print(f"{p['directory']}: {p['name']}")
 **Example return value:**
 ```python
 [
-{'directory': 'Default', 'name': 'Person 1'},
-{'directory': 'Profile 1', 'name': 'Work'},
-{'directory': 'Profile 5', 'name': 'Personal'}
+    {'directory': 'Default', 'name': 'Person 1'},
+    {'directory': 'Profile 1', 'name': 'Work'},
+    {'directory': 'Profile 5', 'name': 'Personal'}
 ]
 ```
 
@@ -2838,13 +2838,13 @@ tools = Tools()
 
 @tools.action('Ask human for help with a question')
 async def ask_human(question: str, browser_session: BrowserSession) -> ActionResult:
-answer = input(f'{question} > ')
-return ActionResult(extracted_content=f'The human responded with: {answer}')
+    answer = input(f'{question} > ')
+    return ActionResult(extracted_content=f'The human responded with: {answer}')
 
 agent = Agent(
-task='Ask human for help',
-llm=llm,
-tools=tools,
+    task='Ask human for help',
+    llm=llm,
+    tools=tools,
 )
 ```
 
@@ -2927,8 +2927,8 @@ tools = Tools()
 
 @tools.action(description='Ask human for help with a question')
 async def ask_human(question: str) -> ActionResult:
-answer = input(f'{question} > ')
-return ActionResult(extracted_content=f'The human responded with: {answer}')
+    answer = input(f'{question} > ')
+    return ActionResult(extracted_content=f'The human responded with: {answer}')
 ```
 
 ```python
@@ -2968,19 +2968,19 @@ tools = Tools()
 
 @tools.action(description='Click the submit button using CSS selector')
 async def click_submit_button(browser_session: BrowserSession):
-# Get the current page
-page = await browser_session.must_get_current_page()
+    # Get the current page
+    page = await browser_session.must_get_current_page()
 
-# Get element(s) by CSS selector
-elements = await page.get_elements_by_css_selector('button[type="submit"]')
+    # Get element(s) by CSS selector
+    elements = await page.get_elements_by_css_selector('button[type="submit"]')
 
-if not elements:
-    return ActionResult(extracted_content='No submit button found')
+    if not elements:
+        return ActionResult(extracted_content='No submit button found')
 
-# Click the first matching element
-await elements[0].click()
+    # Click the first matching element
+    await elements[0].click()
 
-return ActionResult(extracted_content='Submit button clicked!')
+    return ActionResult(extracted_content='Submit button clicked!')
 ```
 
 
@@ -3003,14 +3003,14 @@ You can use Pydantic for the tool parameters:
 from pydantic import BaseModel
 
 class Cars(BaseModel):
-name: str = Field(description='The name of the car, e.g. "Toyota Camry"')
-price: int = Field(description='The price of the car as int in USD, e.g. 25000')
+    name: str = Field(description='The name of the car, e.g. "Toyota Camry"')
+    price: int = Field(description='The price of the car as int in USD, e.g. 25000')
 
 @tools.action(description='Save cars to file')
 def save_cars(cars: list[Cars]) -> str:
-with open('cars.json', 'w') as f:
-    json.dump(cars, f)
-return f'Saved {len(cars)} cars to file'
+    with open('cars.json', 'w') as f:
+        json.dump(cars, f)
+    return f'Saved {len(cars)} cars to file'
 
 task = "find cars and save them to file"
 ```
@@ -3020,12 +3020,12 @@ Limit tools to specific domains:
 
 ```python
 @tools.action(
-description='Fill out banking forms',
-allowed_domains=['https://mybank.com']
+    description='Fill out banking forms',
+    allowed_domains=['https://mybank.com']
 )
 def fill_bank_form(account_number: str) -> str:
-# Only works on mybank.com
-return f'Filled form for account {account_number}'
+    # Only works on mybank.com
+    return f'Filled form for account {account_number}'
 ```
 
 ## Advanced Example
@@ -3046,8 +3046,8 @@ from browser_use import Tools, ActionResult, Browser
 
 @tools.action('My action')
 def my_action(browser: Browser) -> ActionResult:  # WRONG!
-# This will NOT receive the browser session
-pass
+    # This will NOT receive the browser session
+    pass
 ```
 
 ### ✅ Correct: Using `browser_session: BrowserSession`
@@ -3057,9 +3057,9 @@ from browser_use import Tools, ActionResult, BrowserSession
 
 @tools.action('My action')
 async def my_action(browser_session: BrowserSession) -> ActionResult:  # CORRECT!
-page = await browser_session.must_get_current_page()
-# Now you have access to the browser
-return ActionResult(extracted_content='Done')
+    page = await browser_session.must_get_current_page()
+    # Now you have access to the browser
+    return ActionResult(extracted_content='Done')
 ```
 
 ### Key Points
@@ -3094,18 +3094,18 @@ Tools return results using `ActionResult` or simple strings.
 ```python
 @tools.action('My tool')
 def my_tool() -> str:
-return "Task completed successfully"
+    return "Task completed successfully"
 
 @tools.action('Advanced tool')
 def advanced_tool() -> ActionResult:
-return ActionResult(
-    extracted_content="Main result",
-    long_term_memory="Remember this info",
-    error="Something went wrong",
-    is_done=True,
-    success=True,
-    attachments=["file.pdf"],
-)
+    return ActionResult(
+        extracted_content="Main result",
+        long_term_memory="Remember this info",
+        error="Something went wrong",
+        is_done=True,
+        success=True,
+        attachments=["file.pdf"],
+    )
 ```
 
 ## ActionResult Properties
@@ -3125,15 +3125,15 @@ With this you control the context for the LLM.
 ### 1. Include short content always in context
 ```python
 def simple_tool() -> str:
-return "Hello, world!"  # Keep in context for all future steps 
+    return "Hello, world!"  # Keep in context for all future steps 
 ```
 
 ### 2. Show long content once, remember subset in context
 ```python
 return ActionResult(
-extracted_content="[500 lines of product data...]",     # Shows to LLM once
-include_extracted_content_only_once=True,               # Never show full output again
-long_term_memory="Found 50 products"        # Only this in future steps
+    extracted_content="[500 lines of product data...]",     # Shows to LLM once
+    include_extracted_content_only_once=True,               # Never show full output again
+    long_term_memory="Found 50 products"        # Only this in future steps
 )
 ```
 We save the full `extracted_content` to files which the LLM can read in future steps.
@@ -3141,8 +3141,8 @@ We save the full `extracted_content` to files which the LLM can read in future s
 ### 3. Don't show long content, remember subset in context
 ```python
 return ActionResult(
-extracted_content="[500 lines of product data...]",      # The LLM never sees this because `long_term_memory` overrides it and `include_extracted_content_only_once` is not used
-long_term_memory="Saved user's favorite products",      # This is shown to the LLM in future steps
+    extracted_content="[500 lines of product data...]",      # The LLM never sees this because `long_term_memory` overrides it and `include_extracted_content_only_once` is not used
+    long_term_memory="Saved user's favorite products",      # This is shown to the LLM in future steps
 )
 ```
 
@@ -3153,11 +3153,11 @@ Set `is_done=True` to stop the agent completely. Use when your tool finishes the
 ```python
 @tools.action(description='Complete the task')
 def finish_task() -> ActionResult:
-return ActionResult(
-    extracted_content="Task completed!",
-    is_done=True,        # Stops the agent
-    success=True         # Task succeeded 
-)
+    return ActionResult(
+        extracted_content="Task completed!",
+        is_done=True,        # Stops the agent
+        success=True         # Task succeeded 
+    )
 ```
 
 
@@ -3189,13 +3189,13 @@ Add to your Claude Desktop config file:
 ```json
 {
   "mcpServers": {
-"browser-use": {
-  "command": "/Users/your-username/.local/bin/uvx",
-  "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
-  "env": {
-    "OPENAI_API_KEY": "your-openai-api-key-here"
-  }
-}
+    "browser-use": {
+      "command": "/Users/your-username/.local/bin/uvx",
+      "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
+      "env": {
+        "OPENAI_API_KEY": "your-openai-api-key-here"
+      }
+    }
   }
 }
 ```
@@ -3205,13 +3205,13 @@ Add to your Claude Desktop config file:
 ```json
 {
   "mcpServers": {
-"browser-use": {
-  "command": "uvx",
-  "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
-  "env": {
-    "OPENAI_API_KEY": "your-openai-api-key-here"
-  }
-}
+    "browser-use": {
+      "command": "uvx",
+      "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
+      "env": {
+        "OPENAI_API_KEY": "your-openai-api-key-here"
+      }
+    }
   }
 }
 ```
@@ -3229,13 +3229,13 @@ Add to `~/.cursor/mcp.json`:
 ```json
 {
   "mcpServers": {
-"browser-use": {
-  "command": "uvx",
-  "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
-  "env": {
-    "OPENAI_API_KEY": "your-openai-api-key-here"
-  }
-}
+    "browser-use": {
+      "command": "uvx",
+      "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
+      "env": {
+        "OPENAI_API_KEY": "your-openai-api-key-here"
+      }
+    }
   }
 }
 ```
@@ -3244,13 +3244,13 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 ```json
 {
   "mcpServers": {
-"browser-use": {
-  "command": "uvx",
-  "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
-  "env": {
-    "OPENAI_API_KEY": "your-openai-api-key-here"
-  }
-}
+    "browser-use": {
+      "command": "uvx",
+      "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
+      "env": {
+        "OPENAI_API_KEY": "your-openai-api-key-here"
+      }
+    }
   }
 }
 ```
@@ -3312,29 +3312,29 @@ from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
 async def use_browser_mcp():
-# Connect to browser-use MCP server
-server_params = StdioServerParameters(
-    command="uvx",
-    args=["--from", "browser-use[cli]", "browser-use", "--mcp"]
-)
+    # Connect to browser-use MCP server
+    server_params = StdioServerParameters(
+        command="uvx",
+        args=["--from", "browser-use[cli]", "browser-use", "--mcp"]
+    )
 
-async with stdio_client(server_params) as (read, write):
-    async with ClientSession(read, write) as session:
-        await session.initialize()
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
 
-        # Navigate to a website
-        result = await session.call_tool(
-            "browser_navigate",
-            arguments={"url": "https://example.com"}
-        )
-        print(result.content[0].text)
+            # Navigate to a website
+            result = await session.call_tool(
+                "browser_navigate",
+                arguments={"url": "https://example.com"}
+            )
+            print(result.content[0].text)
 
-        # Get page state
-        result = await session.call_tool(
-            "browser_get_state",
-            arguments={"include_screenshot": True}
-        )
-        print("Page state retrieved!")
+            # Get page state
+            result = await session.call_tool(
+                "browser_get_state",
+                arguments={"include_screenshot": True}
+            )
+            print("Page state retrieved!")
 
 asyncio.run(use_browser_mcp())
 ```
@@ -3398,13 +3398,13 @@ Source: https://docs.browser-use.com/open-source/legacy/actor/basics
 
 ```mermaid
 graph TD
-A[Browser] --> B[Page]
-B --> C[Element]
-B --> D[Mouse]
-B --> E[AI Features]
-C --> F[DOM Interactions]
-D --> G[Coordinate Operations]
-E --> H[LLM Integration]
+    A[Browser] --> B[Page]
+    B --> C[Element]
+    B --> D[Mouse]
+    B --> E[AI Features]
+    C --> F[DOM Interactions]
+    D --> G[Coordinate Operations]
+    E --> H[LLM Integration]
 ```
 
 ### Core Classes
@@ -3421,20 +3421,20 @@ from browser_use import Browser, Agent
 from browser_use.llm.openai.chat import ChatOpenAI
 
 async def main():
-llm = ChatOpenAI(api_key="your-api-key")
-browser = Browser()
-await browser.start()
+    llm = ChatOpenAI(api_key="your-api-key")
+    browser = Browser()
+    await browser.start()
 
-# 1. Actor: Precise navigation and element interactions
-page = await browser.new_page("https://github.com/login")
-email_input = await page.must_get_element_by_prompt("username field", llm=llm)
-await email_input.fill("your-username")
+    # 1. Actor: Precise navigation and element interactions
+    page = await browser.new_page("https://github.com/login")
+    email_input = await page.must_get_element_by_prompt("username field", llm=llm)
+    await email_input.fill("your-username")
 
-# 2. Agent: AI-driven complex tasks
-agent = Agent(browser=browser, llm=llm)
-await agent.run("Complete login and navigate to my repositories")
+    # 2. Agent: AI-driven complex tasks
+    agent = Agent(browser=browser, llm=llm)
+    await agent.run("Complete login and navigate to my repositories")
 
-await browser.stop()
+    await browser.stop()
 ```
 
 ## Important Notes
@@ -3503,13 +3503,13 @@ await button.click()
 
 # Extract structured data
 class ProductInfo(BaseModel):
-name: str
-price: float
+    name: str
+    price: float
 
 product = await page.extract_content(
-"Extract product name and price",
-ProductInfo,
-llm=llm
+    "Extract product name and price",
+    ProductInfo,
+    llm=llm
 )
 ```
 
@@ -3524,8 +3524,8 @@ result = await page.evaluate('(x, y) => x + y', 10, 20)
 
 # Complex operations
 stats = await page.evaluate('''() => ({
-url: location.href,
-links: document.querySelectorAll('a').length
+    url: location.href,
+    links: document.querySelectorAll('a').length
 })''')
 ```
 
@@ -3659,8 +3659,8 @@ from browser_use.agent.service import Agent
 
 @sandbox()
 async def my_task(browser: Browser):
-agent = Agent(task="Find the top HN post", browser=browser, llm=ChatBrowserUse())
-await agent.run()
+    agent = Agent(task="Find the top HN post", browser=browser, llm=ChatBrowserUse())
+    await agent.run()
 
 await my_task()
 ```
@@ -3669,13 +3669,13 @@ await my_task()
 
 ```python
 @sandbox(
-cloud_profile_id='your-profile-id',      # Use saved cookies/auth
-cloud_proxy_country_code='us',           # Bypass captchas, cloudflare, geo-restrictions
-cloud_timeout=60,                        # Max session time (minutes)
+    cloud_profile_id='your-profile-id',      # Use saved cookies/auth
+    cloud_proxy_country_code='us',           # Bypass captchas, cloudflare, geo-restrictions
+    cloud_timeout=60,                        # Max session time (minutes)
 )
 async def task(browser: Browser, url: str):
-agent = Agent(task=f"Visit {url}", browser=browser, llm=ChatBrowserUse())
-await agent.run()
+    agent = Agent(task=f"Visit {url}", browser=browser, llm=ChatBrowserUse())
+    await agent.run()
 
 await task(url="https://example.com")
 ```
@@ -3699,8 +3699,8 @@ Source: https://docs.browser-use.com/open-source/legacy/sandbox/events
 ```python
 @sandbox(on_browser_created=lambda data: print(f'👁️  {data.live_url}'))
 async def task(browser: Browser):
-agent = Agent(task="your task", browser=browser, llm=ChatBrowserUse())
-await agent.run()
+    agent = Agent(task="your task", browser=browser, llm=ChatBrowserUse())
+    await agent.run()
 ```
 
 ## All Events
@@ -3709,13 +3709,13 @@ await agent.run()
 from browser_use.sandbox import BrowserCreatedData, LogData, ResultData, ErrorData
 
 @sandbox(
-on_browser_created=lambda data: print(f'Live: {data.live_url}'),
-on_log=lambda log: print(f'{log.level}: {log.message}'),
-on_result=lambda result: print('Done!'),
-on_error=lambda error: print(f'Error: {error.error}'),
+    on_browser_created=lambda data: print(f'Live: {data.live_url}'),
+    on_log=lambda log: print(f'{log.level}: {log.message}'),
+    on_result=lambda result: print('Done!'),
+    on_error=lambda error: print(f'Error: {error.error}'),
 )
 async def task(browser: Browser):
-# Your code
+    # Your code
 ```
 
 All callbacks can be sync or async.
@@ -3742,14 +3742,14 @@ Source: https://docs.browser-use.com/open-source/legacy/sandbox/all-parameters
 
 ```python
 @sandbox(
-cloud_profile_id='550e8400-e29b-41d4-a716-446655440000',
-cloud_proxy_country_code='us',
-cloud_timeout=60,
-on_browser_created=lambda data: print(f'Live: {data.live_url}'),
+    cloud_profile_id='550e8400-e29b-41d4-a716-446655440000',
+    cloud_proxy_country_code='us',
+    cloud_timeout=60,
+    on_browser_created=lambda data: print(f'Live: {data.live_url}'),
 )
 async def task(browser: Browser):
-agent = Agent(task="your task", browser=browser, llm=ChatBrowserUse())
-await agent.run()
+    agent = Agent(task="your task", browser=browser, llm=ChatBrowserUse())
+    await agent.run()
 ```
 
 
@@ -3796,7 +3796,7 @@ async def main():
 	task = """
 	1. Go to reddit https://www.reddit.com/search/?q=browser+agent&type=communities 
 	2. Click directly on the first 5 communities to open each in new tabs
-3. Find out what the latest post is about, and switch directly to the next tab
+    3. Find out what the latest post is about, and switch directly to the next tab
 	4. Return the latest post summary for each page
 	"""
 
@@ -3832,19 +3832,19 @@ llm = ChatGoogle(model='gemini-flash-lite-latest')
 ### 2. Browser Optimizations
 ```python
 browser_profile = BrowserProfile(
-minimum_wait_page_load_time=0.1,    # Reduce wait time
-wait_between_actions=0.1,           # Faster action execution
-headless=True,                      # No GUI overhead
+    minimum_wait_page_load_time=0.1,    # Reduce wait time
+    wait_between_actions=0.1,           # Faster action execution
+    headless=True,                      # No GUI overhead
 )
 ```
 
 ### 3. Agent Optimizations
 ```python
 agent = Agent(
-task=task,
-llm=llm,
-flash_mode=True,                    # Skip LLM thinking process
-extend_system_message=SPEED_PROMPT, # Optimize LLM behavior
+    task=task,
+    llm=llm,
+    flash_mode=True,                    # Skip LLM thinking process
+    extend_system_message=SPEED_PROMPT, # Optimize LLM behavior
 )
 ```
 
@@ -4032,15 +4032,15 @@ async def start_chrome_with_debug_port(port: int = 9222):
 	for path in chrome_paths:
 		if os.path.exists(path) or path in ['chrome', 'chromium']:
 			try:
-# Test if executable works
-test_proc = await asyncio.create_subprocess_exec(
-	path, '--version', stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
-)
-await test_proc.wait()
-chrome_exe = path
-break
+				# Test if executable works
+				test_proc = await asyncio.create_subprocess_exec(
+					path, '--version', stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+				)
+				await test_proc.wait()
+				chrome_exe = path
+				break
 			except Exception:
-continue
+				continue
 
 	if not chrome_exe:
 		raise RuntimeError('❌ Chrome not found. Please install Chrome or Chromium.')
@@ -4064,12 +4064,12 @@ continue
 	for _ in range(20):  # 20 second timeout
 		try:
 			async with aiohttp.ClientSession() as session:
-async with session.get(
-	f'http://localhost:{port}/json/version', timeout=aiohttp.ClientTimeout(total=1)
-) as response:
-	if response.status == 200:
-		cdp_ready = True
-		break
+				async with session.get(
+					f'http://localhost:{port}/json/version', timeout=aiohttp.ClientTimeout(total=1)
+				) as response:
+					if response.status == 200:
+						cdp_ready = True
+						break
 		except Exception:
 			pass
 		await asyncio.sleep(1)
@@ -4152,9 +4152,9 @@ async def playwright_fill_form(params: PlaywrightFillFormAction, browser_session
 			# For radio buttons, find the checked one
 			checked_radio = playwright_page.locator('input[name="size"]:checked')
 			if await checked_radio.count() > 0:
-form_data['size'] = await checked_radio.get_attribute('value')
+				form_data['size'] = await checked_radio.get_attribute('value')
 			else:
-form_data['size'] = 'none selected'
+				form_data['size'] = 'none selected'
 
 		success_msg = f'✅ Form filled successfully with Playwright: {form_data}'
 
@@ -4219,19 +4219,19 @@ async def playwright_get_text(params: PlaywrightGetTextAction, browser_session: 
 			# Use page.title() for title element
 			text_content = await playwright_page.title()
 			result_data = {
-'selector': 'title',
-'text_content': text_content,
-'inner_text': text_content,
-'tag_name': 'TITLE',
-'is_visible': True,
+				'selector': 'title',
+				'text_content': text_content,
+				'inner_text': text_content,
+				'tag_name': 'TITLE',
+				'is_visible': True,
 			}
 		else:
 			# Use Playwright's robust element selection and text extraction
 			element = playwright_page.locator(params.selector).first
 
 			if await element.count() == 0:
-error_msg = f'❌ No element found with selector: {params.selector}'
-return ActionResult(error=error_msg)
+				error_msg = f'❌ No element found with selector: {params.selector}'
+				return ActionResult(error=error_msg)
 
 			text_content = await element.text_content()
 			inner_text = await element.inner_text()
@@ -4241,11 +4241,11 @@ return ActionResult(error=error_msg)
 			is_visible = await element.is_visible()
 
 			result_data = {
-'selector': params.selector,
-'text_content': text_content,
-'inner_text': inner_text,
-'tag_name': tag_name,
-'is_visible': is_visible,
+				'selector': params.selector,
+				'text_content': text_content,
+				'inner_text': inner_text,
+				'tag_name': tag_name,
+				'is_visible': is_visible,
 			}
 
 		success_msg = f'✅ Extracted text using Playwright: {result_data}'
@@ -4283,17 +4283,17 @@ async def main():
 		agent = Agent(
 			task="""
 			Please help me demonstrate the integration between Browser-Use and Playwright:
-			
+
 			1. First, navigate to https://httpbin.org/forms/post
 			2. Use the 'playwright_fill_form' action to fill the form with these details:
-  - Customer name: "Alice Johnson"
-  - Phone: "555-9876"
-  - Email: "alice@demo.com"
-  - Size: "large"
+			   - Customer name: "Alice Johnson"
+			   - Phone: "555-9876"
+			   - Email: "alice@demo.com"
+			   - Size: "large"
 			3. Take a screenshot using the 'playwright_screenshot' action and save it as "form_demo.png"
 			4. Extract the title of the page using 'playwright_get_text' action with selector "title"
 			5. Finally, submit the form and tell me what happened
-			
+
 			This demonstrates how Browser-Use AI can orchestrate tasks while using Playwright's precise capabilities for specific operations.
 			""",
 			llm=ChatOpenAI(model='gpt-4.1-mini'),
@@ -4325,9 +4325,9 @@ async def main():
 		if chrome_process:
 			chrome_process.terminate()
 			try:
-await asyncio.wait_for(chrome_process.wait(), 5)
+				await asyncio.wait_for(chrome_process.wait(), 5)
 			except TimeoutError:
-chrome_process.kill()
+				chrome_process.kill()
 
 		print('✅ Cleanup complete')
 
@@ -4365,13 +4365,13 @@ sensitive_data = company_credentials
 
 
 agent = Agent(
-task='Log into example.com with username x_user and password x_pass',
-sensitive_data=sensitive_data,
-use_vision=False,  #  Disable vision to prevent LLM seeing sensitive data in screenshots
-llm=ChatOpenAI(model='gpt-4.1-mini'),
+    task='Log into example.com with username x_user and password x_pass',
+    sensitive_data=sensitive_data,
+    use_vision=False,  #  Disable vision to prevent LLM seeing sensitive data in screenshots
+    llm=ChatOpenAI(model='gpt-4.1-mini'),
 )
 async def main():
-await agent.run()
+    await agent.run()
 ```
 
 ## How it Works
@@ -4407,8 +4407,8 @@ llm = ChatAzureOpenAI(model='gpt-4.1-mini', api_key=api_key, azure_endpoint=azur
 
 # Secure browser configuration
 browser_profile = BrowserProfile(
-allowed_domains=['*google.com', 'browser-use.com'], 
-enable_default_extensions=False
+    allowed_domains=['*google.com', 'browser-use.com'], 
+    enable_default_extensions=False
 )
 
 # Sensitive data filtering
@@ -4416,14 +4416,14 @@ sensitive_data = {'company_name': 'browser-use'}
 
 # Create secure agent
 agent = Agent(
-task='Find the founders of the sensitive company_name',
-llm=llm,
-browser_profile=browser_profile,
-sensitive_data=sensitive_data
+    task='Find the founders of the sensitive company_name',
+    llm=llm,
+    browser_profile=browser_profile,
+    sensitive_data=sensitive_data
 )
 
 async def main():
-await agent.run(max_steps=10)
+    await agent.run(max_steps=10)
 
 asyncio.run(main())
 ```
@@ -4529,11 +4529,11 @@ import asyncio
 from ad_generator import create_ad_from_landing_page
 
 async def main():
-results = await create_ad_from_landing_page(
-    url="https://your-landing-page.com",
-    debug=False
-)
-print(f"Generated ads: {results}")
+    results = await create_ad_from_landing_page(
+        url="https://your-landing-page.com",
+        debug=False
+    )
+    print(f"Generated ads: {results}")
 
 asyncio.run(main())
 ```
@@ -4610,12 +4610,12 @@ claude mcp add vibetest /full/path/to/vibetest-use/.venv/bin/vibetest-mcp \
 ```json
 {
   "mcpServers": {
-"vibetest": {
-  "command": "/full/path/to/vibetest-use/.venv/bin/vibetest-mcp",
-  "env": {
-    "GOOGLE_API_KEY": "your_api_key"
-  }
-}
+    "vibetest": {
+      "command": "/full/path/to/vibetest-use/.venv/bin/vibetest-mcp",
+      "env": {
+        "GOOGLE_API_KEY": "your_api_key"
+      }
+    }
   }
 }
 ```
@@ -4721,12 +4721,12 @@ All extracted articles are saved to `news_data.json` with complete metadata:
   "hash": "a1b2c3d4...",
   "pulled_at": "2025-09-11T02:49:21Z",
   "data": {
-"title": "Klarna's IPO pops, raising $1.4B",
-"url": "https://techcrunch.com/2025/09/11/klarna-ipo/",
-"posting_time": "12:11 PM PDT · September 10, 2025",
-"short_summary": "Klarna's IPO raises $1.4B, benefiting existing investors like Sequoia.",
-"long_summary": "Fintech Klarna successfully IPO'd on the NYSE...",
-"sentiment": "positive"
+    "title": "Klarna's IPO pops, raising $1.4B",
+    "url": "https://techcrunch.com/2025/09/11/klarna-ipo/",
+    "posting_time": "12:11 PM PDT · September 10, 2025",
+    "short_summary": "Klarna's IPO raises $1.4B, benefiting existing investors like Sequoia.",
+    "long_summary": "Fintech Klarna successfully IPO'd on the NYSE...",
+    "sentiment": "positive"
   }
 }
 ```
@@ -4738,17 +4738,17 @@ import asyncio
 from news_monitor import extract_latest_article
 
 async def main():
-# Extract latest article from any news site
-result = await extract_latest_article(
-    site_url="https://techcrunch.com",
-    debug=False
-)
+    # Extract latest article from any news site
+    result = await extract_latest_article(
+        site_url="https://techcrunch.com",
+        debug=False
+    )
 
-if result["status"] == "success":
-    article = result["data"]
-    print(f"📰 {article['title']}")
-    print(f"😊 Sentiment: {article['sentiment']}")
-    print(f"📝 Summary: {article['short_summary']}")
+    if result["status"] == "success":
+        article = result["data"]
+        print(f"📰 {article['title']}")
+        print(f"😊 Sentiment: {article['sentiment']}")
+        print(f"📝 Summary: {article['short_summary']}")
 
 asyncio.run(main())
 ```
@@ -4758,14 +4758,14 @@ asyncio.run(main())
 ```python
 # Custom monitoring with filters
 async def monitor_with_filters():
-while True:
-    result = await extract_latest_article("https://bloomberg.com")
-    if result["status"] == "success":
-        article = result["data"]
-        # Only alert on negative market news
-        if article["sentiment"] == "negative" and "market" in article["title"].lower():
-            send_alert(article)
-    await asyncio.sleep(300)  # Check every 5 minutes
+    while True:
+        result = await extract_latest_article("https://bloomberg.com")
+        if result["status"] == "success":
+            article = result["data"]
+            # Only alert on negative market news
+            if article["sentiment"] == "negative" and "market" in article["title"].lower():
+                send_alert(article)
+        await asyncio.sleep(300)  # Check every 5 minutes
 ```
 
 ## Source Code
@@ -4853,11 +4853,11 @@ import asyncio
 from scheduler import schedule_messages
 
 async def main():
-messages = [
-    "Send hello to John at 15:30",
-    "Remind Sarah about meeting tomorrow at 9am"
-]
-await schedule_messages(messages, debug=False)
+    messages = [
+        "Send hello to John at 15:30",
+        "Remind Sarah about meeting tomorrow at 9am"
+    ]
+    await schedule_messages(messages, debug=False)
 
 asyncio.run(main())
 ```
@@ -4869,22 +4869,22 @@ The scheduler processes natural language and outputs structured results:
 ```json
 [
   {
-"contact": "Magnus",
-"original_message": "Hi",
-"composed_message": "Hi",
-"scheduled_time": "2025-06-13 18:15"
+    "contact": "Magnus",
+    "original_message": "Hi",
+    "composed_message": "Hi",
+    "scheduled_time": "2025-06-13 18:15"
   },
   {
-"contact": "Camila", 
-"original_message": "I miss her",
-"composed_message": "I miss you ❤️",
-"scheduled_time": "2025-06-14 20:00"
+    "contact": "Camila", 
+    "original_message": "I miss her",
+    "composed_message": "I miss you ❤️",
+    "scheduled_time": "2025-06-14 20:00"
   },
   {
-"contact": "sister",
-"original_message": "happy birthday message", 
-"composed_message": "Happy birthday! 🎉 Wishing you an amazing day, sis! Hope you have the best birthday ever! ❤️🎂🎈",
-"scheduled_time": "2025-06-15 09:00"
+    "contact": "sister",
+    "original_message": "happy birthday message", 
+    "composed_message": "Happy birthday! 🎉 Wishing you an amazing day, sis! Hope you have the best birthday ever! ❤️🎂🎈",
+    "scheduled_time": "2025-06-15 09:00"
   }
 ]
 ```
@@ -5133,11 +5133,11 @@ import os
 Laminar.initialize(project_api_key=os.getenv('LMNR_PROJECT_API_KEY'))
 
 async def main():
-agent = Agent(
-    task="go to ycombinator.com, summarize 3 startups from the latest batch",
-    llm=ChatGoogle(model="gemini-2.5-flash"),
-)
-await agent.run()
+    agent = Agent(
+        task="go to ycombinator.com, summarize 3 startups from the latest batch",
+        llm=ChatGoogle(model="gemini-2.5-flash"),
+    )
+    await agent.run()
 
 asyncio.run(main())
 ```
@@ -5369,9 +5369,9 @@ To track token usage and costs, enable cost calculation:
 from browser_use import Agent, ChatBrowserUse
 
 agent = Agent(
-task="Search for latest news about AI",
-llm=ChatBrowserUse(),
-calculate_cost=True  # Enable cost tracking
+    task="Search for latest news about AI",
+    llm=ChatBrowserUse(),
+    calculate_cost=True  # Enable cost tracking
 )
 
 history = await agent.run()

--- a/docs/open-source/supported-models.mdx
+++ b/docs/open-source/supported-models.mdx
@@ -46,6 +46,16 @@ ChatBrowserUse offers competitive pricing per 1 million tokens:
 | Cached tokens | $0.06 |
 | Output tokens | $3.50 |
 
+**bu-1-0**
+
+Since May 20, 2026, `bu-1-0` is priced the same as `bu-2-0`:
+
+| Token Type | Price per 1M tokens |
+|------------|---------------------|
+| Input tokens | $0.60 |
+| Cached tokens | $0.06 |
+| Output tokens | $3.50 |
+
 
 ### Google Gemini [example](https://github.com/browser-use/browser-use/blob/main/examples/models/gemini.py) {#google-gemini}
 


### PR DESCRIPTION
## Summary

Since May 20, 2026, `bu-1-0` is priced the same as `bu-2-0` ($0.60 input / $0.06 cached / $3.50 output per 1M tokens). This updates the docs to reflect that:

- `docs/open-source/supported-models.mdx` — adds a **bu-1-0** pricing section (the model's old $0.20/$0.02/$2.00 table was removed in an earlier cleanup) with a note about the May 20 change.
- `docs/open-source/llms-full.txt` — replaces the stale bu-1-0 prices with the new ones and adds the same note.

Docs-only — no SDK code changes, no release needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update docs to align `bu-1-0` pricing with `bu-2-0` ($0.60 input / $0.06 cached / $3.50 output per 1M tokens), effective May 20, 2026. Adds a `bu-1-0` pricing block to `docs/open-source/supported-models.mdx`; fixes `docs/generate-llms-txt.sh` to preserve code-block indentation and regenerates `docs/open-source/llms-full.txt` to sync pricing and examples; docs-only, no SDK changes.

<sup>Written for commit 92821162087dbef8c1cfec2ca8a7be11d1f9e042. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

