### PR TITLE
[ENG-4762] sdk: gated release workflow + deprecate laptop publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -160,6 +160,7 @@ jobs:
     needs: [preflight, approval]
     runs-on: ubuntu-latest
     permissions:
+      id-token: write   # required for npm OIDC trusted publishing
       contents: read
     steps:
       - name: Checkout
@@ -175,8 +176,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: '22'
           cache: pnpm
           cache-dependency-path: browser-use-node/pnpm-lock.yaml
 
@@ -188,8 +188,9 @@ jobs:
         working-directory: browser-use-node
         run: pnpm build
 
-      - name: Publish to npm
+      - name: Upgrade npm to OIDC-capable version
+        run: npm install -g npm@latest
+
+      - name: Publish to npm (OIDC trusted publishing)
         working-directory: browser-use-node
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,17 +86,44 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          # npm: HTTP 200 means it exists.
-          if npm view "browser-use-sdk@$VERSION" version >/dev/null 2>&1; then
-            echo "::error::browser-use-sdk@$VERSION is already published to npm. Bump the version before creating a new release."
-            exit 1
-          fi
-          # PyPI: 200 means it exists.
-          if curl -sf "https://pypi.org/pypi/browser-use-sdk/$VERSION/json" >/dev/null 2>&1; then
-            echo "::error::browser-use-sdk==$VERSION is already published to PyPI. Bump the version before creating a new release."
-            exit 1
-          fi
-          echo "::notice::Version $VERSION is not yet published to either registry. OK."
+
+          # === npm ===
+          # Use HTTP HEAD against the version-specific tarball URL for an unambiguous result.
+          # 200 = exists, 404 = doesn't exist, anything else = lookup failed (fail closed).
+          NPM_URL="https://registry.npmjs.org/browser-use-sdk/${VERSION}"
+          NPM_STATUS="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 --retry 3 --retry-delay 2 "$NPM_URL" || echo "000")"
+          case "$NPM_STATUS" in
+            200)
+              echo "::error::browser-use-sdk@${VERSION} is already published to npm. Bump the version before creating a new release."
+              exit 1
+              ;;
+            404)
+              echo "::notice::npm: ${VERSION} not yet published. OK."
+              ;;
+            *)
+              echo "::error::npm lookup for browser-use-sdk@${VERSION} returned unexpected HTTP ${NPM_STATUS} (expected 200 or 404). Failing closed; retry the release once npm is healthy."
+              exit 1
+              ;;
+          esac
+
+          # === PyPI ===
+          PYPI_URL="https://pypi.org/pypi/browser-use-sdk/${VERSION}/json"
+          PYPI_STATUS="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 --retry 3 --retry-delay 2 "$PYPI_URL" || echo "000")"
+          case "$PYPI_STATUS" in
+            200)
+              echo "::error::browser-use-sdk==${VERSION} is already published to PyPI. Bump the version before creating a new release."
+              exit 1
+              ;;
+            404)
+              echo "::notice::PyPI: ${VERSION} not yet published. OK."
+              ;;
+            *)
+              echo "::error::PyPI lookup for browser-use-sdk==${VERSION} returned unexpected HTTP ${PYPI_STATUS} (expected 200 or 404). Failing closed; retry the release once PyPI is healthy."
+              exit 1
+              ;;
+          esac
+
+          echo "::notice::Both registries confirm ${VERSION} is unpublished. Proceeding."
 
   approval:
     name: Release approval gate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,195 @@
+name: publish
+
+# Cancel in-progress runs when a new commit is pushed to the same branch/PR.
+# Release runs are serialized via the concurrency group below so two simultaneous
+# release publishes can't race on registry uploads.
+concurrency:
+  group: publish-${{ github.event.release.tag_name || github.run_id }}
+  cancel-in-progress: false
+
+on:
+  release:
+    types: [published]
+
+# Default permissions: read-only. Individual jobs override what they need.
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    name: Preflight (verify env protection, version sanity)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Verify release environment is protected (fail-closed)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          ENV_NAME="release"
+          if ! RESP="$(gh api -H 'Accept: application/vnd.github+json' \
+              "/repos/${GITHUB_REPOSITORY}/environments/${ENV_NAME}" 2>/dev/null)"; then
+            echo "::error::Environment '${ENV_NAME}' does not exist (or is inaccessible). Create it at https://github.com/${GITHUB_REPOSITORY}/settings/environments/new with required reviewers and prevent_self_review, then re-run."
+            exit 1
+          fi
+          HAS_REVIEWERS="$(echo "$RESP" | jq -r '[.protection_rules[]? | select(.type == "required_reviewers")] | length')"
+          if [ "${HAS_REVIEWERS:-0}" -lt 1 ]; then
+            echo "::error::Environment '${ENV_NAME}' exists but has no required-reviewers protection rule."
+            exit 1
+          fi
+          SELF_REVIEW_BLOCKED="$(echo "$RESP" | jq -r '[.protection_rules[]? | select(.type=="required_reviewers") | .prevent_self_review] | any')"
+          if [ "$SELF_REVIEW_BLOCKED" != "true" ]; then
+            echo "::error::Environment '${ENV_NAME}' must have prevent_self_review enabled. Without it, the gate collapses to one identity when the dispatcher is also a reviewer."
+            exit 1
+          fi
+          echo "::notice::Environment '${ENV_NAME}' is protected with prevent_self_review. OK."
+
+      - name: Extract release tag and verify version coherence
+        id: version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          # Strip optional leading 'v'.
+          VERSION="${RELEASE_TAG#v}"
+          echo "Release tag: $RELEASE_TAG -> version: $VERSION"
+
+          # Verify TS package.json version matches.
+          TS_VERSION="$(node -p "require('./browser-use-node/package.json').version")"
+          # Verify Python pyproject.toml version matches.
+          PY_VERSION="$(grep -E '^version = ' browser-use-python/pyproject.toml | head -1 | sed -E 's/version = "(.*)"/\1/')"
+
+          echo "  TS package.json:       $TS_VERSION"
+          echo "  Python pyproject.toml: $PY_VERSION"
+
+          if [ "$TS_VERSION" != "$VERSION" ]; then
+            echo "::error::Release tag version ($VERSION) does not match browser-use-node/package.json ($TS_VERSION). Run 'task version:bump' and commit before tagging."
+            exit 1
+          fi
+          if [ "$PY_VERSION" != "$VERSION" ]; then
+            echo "::error::Release tag version ($VERSION) does not match browser-use-python/pyproject.toml ($PY_VERSION). Run 'task version:bump' and commit before tagging."
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Verify version not already published (npm + PyPI)
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          # npm: HTTP 200 means it exists.
+          if npm view "browser-use-sdk@$VERSION" version >/dev/null 2>&1; then
+            echo "::error::browser-use-sdk@$VERSION is already published to npm. Bump the version before creating a new release."
+            exit 1
+          fi
+          # PyPI: 200 means it exists.
+          if curl -sf "https://pypi.org/pypi/browser-use-sdk/$VERSION/json" >/dev/null 2>&1; then
+            echo "::error::browser-use-sdk==$VERSION is already published to PyPI. Bump the version before creating a new release."
+            exit 1
+          fi
+          echo "::notice::Version $VERSION is not yet published to either registry. OK."
+
+  approval:
+    name: Release approval gate
+    needs: preflight
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      actions: read
+    steps:
+      - name: Record approver from deployment review log
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          TARGET_VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          set -euo pipefail
+          APPROVER="$(gh api \
+            "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals" \
+            --jq '[.[] | select(.environments[]?.name=="release") | .user.login] | last' \
+            2>/dev/null || echo "")"
+          if [ -z "$APPROVER" ] || [ "$APPROVER" = "null" ]; then
+            APPROVER="(approver lookup failed; check Actions UI)"
+          fi
+          echo "::notice::Release approved by @${APPROVER} for release ${RELEASE_TAG} (v${TARGET_VERSION}). Triggered by @${GITHUB_ACTOR}. Run ${GITHUB_RUN_ID}."
+          echo "Approver:     @${APPROVER}"
+          echo "Triggered by: @${GITHUB_ACTOR}"
+          echo "Release tag:  ${RELEASE_TAG}"
+          echo "Version:      ${TARGET_VERSION}"
+
+  publish-py:
+    name: Publish Python SDK to PyPI
+    needs: [preflight, approval]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # required for PyPI trusted publishing OIDC
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: false  # no cache on release builds
+
+      - name: Build Python package
+        working-directory: browser-use-python
+        run: |
+          set -euo pipefail
+          rm -rf dist/
+          uv build
+
+      - name: Publish to PyPI (trusted publishing)
+        working-directory: browser-use-python
+        run: uv publish --trusted-publishing always
+
+  publish-ts:
+    name: Publish TypeScript SDK to npm
+    needs: [preflight, approval]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+          cache-dependency-path: browser-use-node/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: browser-use-node
+        run: pnpm install --frozen-lockfile
+
+      - name: Build TypeScript SDK
+        working-directory: browser-use-node
+        run: pnpm build
+
+      - name: Publish to npm
+        working-directory: browser-use-node
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -4,9 +4,13 @@ Decision guide for the `/sdk` pipeline. Read this, then go.
 
 ## Release authentication
 
-- **PyPI**: trusted publishing via OIDC. No secret. Configured once at https://pypi.org/manage/project/browser-use-sdk/settings/publishing/ (workflow: `publish.yml`, environment: `release`, repo: browser-use/sdk).
-- **npm**: automation token in repo secret `NPM_TOKEN`. Rotate quarterly or on suspected compromise.
-- The `release` environment requires approval from a reviewer other than the release author (`prevent_self_review: true`).
+Both registries use OIDC trusted publishing. **No static tokens, no secrets to rotate.**
+
+- **PyPI**: trusted publishing configured at https://pypi.org/manage/project/browser-use-sdk/settings/publishing/ (Owner: browser-use, Repository: sdk, Workflow: publish.yml, Environment: release).
+- **npm**: trusted publishing configured at https://www.npmjs.com/package/browser-use-sdk/access (same four fields, Allowed action: npm publish).
+- The `release` environment requires approval from a reviewer other than the release author (`prevent_self_review: true`). Reviewers: gregpr07, LarsenCundric.
+
+If a trusted publisher binding is ever revoked or misconfigured, publishing will fail at the publish step with a clear OIDC error from the registry. The release tag stays cut (you can re-dispatch after re-binding).
 
 ## Phase 0: Discover
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -2,6 +2,12 @@
 
 Decision guide for the `/sdk` pipeline. Read this, then go.
 
+## Release authentication
+
+- **PyPI**: trusted publishing via OIDC. No secret. Configured once at https://pypi.org/manage/project/browser-use-sdk/settings/publishing/ (workflow: `publish.yml`, environment: `release`, repo: browser-use/sdk).
+- **npm**: automation token in repo secret `NPM_TOKEN`. Rotate quarterly or on suspected compromise.
+- The `release` environment requires approval from a reviewer other than the release author (`prevent_self_review: true`).
+
 ## Phase 0: Discover
 
 Diff the fresh OpenAPI specs (`$CLOUD_REPO_PATH/backend/spec/api/v{2,3}/openapi.json`) against the snapshots (`snapshots/v{2,3}.json`). Classify each change:
@@ -39,7 +45,16 @@ Follow existing patterns in the codebase. Read before writing.
 1. Run `task test`. Fix failures (max 3 attempts, then escalate).
 2. Optionally run `task test:live` if backend is reachable.
 3. Confirm version bump with user → bump both packages → save snapshots → commit.
-4. Do NOT publish. Tell user to run `task publish`.
+4. **Release via GitHub Releases (NOT `task publish` — that bypasses the gate).**
+   - Go to https://github.com/browser-use/sdk/releases/new
+   - Tag = `v$NEW_VERSION` (matches both package.json and pyproject.toml)
+   - Release title = `v$NEW_VERSION`
+   - Auto-generate release notes
+   - Click **Publish release**
+   - The `publish.yml` workflow fires. Preflight verifies the env protection and version match, then pauses at the `release` environment for approval.
+   - Ping a release reviewer (gregpr07 or LarsenCundric, whoever is NOT you) to approve in the Actions tab.
+   - Once approved: npm + PyPI publish in parallel. ~3-5 minutes.
+   - If publish fails: the GitHub Release still exists (rollback handle). Investigate, fix, re-cut a new patch version.
 
 ---
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -210,7 +210,7 @@ tasks:
         echo "Emergency unblock (logged): uncomment the lines below in Taskfile.yml"
         echo "  # rm -rf dist/"
         echo "  # task: build:py"
-        echo "  # uv publish --token {{.PYPI_TOKEN}}"
+        echo "  # uv publish --token <PYPI_TOKEN>"
         exit 1
 
   publish:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -181,26 +181,50 @@ tasks:
       - task: version
 
   # ── Publish ───────────────────────────────────────────────────
+  # Releases now ship through GitHub Releases + gated CI (.github/workflows/publish.yml).
+  # The tasks below are intentionally non-functional. The old commands are kept
+  # commented inline so a maintainer can emergency-unblock by editing this file
+  # (intentional friction: editing Taskfile is the only path).
   publish:ts:
-    desc: Publish TypeScript SDK to npm
+    desc: "[DEPRECATED] Use GitHub Releases. See RUNBOOK.md."
     dir: '{{.TS_SDK}}'
-    deps: [build:ts]
     cmds:
-      - npm publish --access public
+      - |
+        echo "ERROR: 'task publish:ts' is deprecated."
+        echo "Releases now ship through GitHub Releases + gated CI."
+        echo "See RUNBOOK.md > 'Release authentication' for the new flow."
+        echo
+        echo "Emergency unblock (logged): uncomment the line below in Taskfile.yml"
+        echo "  # npm publish --access public"
+        exit 1
 
   publish:py:
-    desc: Publish Python SDK to PyPI
+    desc: "[DEPRECATED] Use GitHub Releases. See RUNBOOK.md."
     dir: '{{.PY_SDK}}'
     cmds:
-      - rm -rf dist/
-      - task: build:py
-      - uv publish --token {{.PYPI_TOKEN}}
+      - |
+        echo "ERROR: 'task publish:py' is deprecated."
+        echo "Releases now ship through GitHub Releases + gated CI."
+        echo "See RUNBOOK.md > 'Release authentication' for the new flow."
+        echo
+        echo "Emergency unblock (logged): uncomment the lines below in Taskfile.yml"
+        echo "  # rm -rf dist/"
+        echo "  # task: build:py"
+        echo "  # uv publish --token {{.PYPI_TOKEN}}"
+        exit 1
 
   publish:
-    desc: Publish both SDKs
+    desc: "[DEPRECATED] Use GitHub Releases. See RUNBOOK.md."
     cmds:
-      - task: publish:ts
-      - task: publish:py
+      - |
+        echo "ERROR: 'task publish' is deprecated."
+        echo "Releases now ship through GitHub Releases + gated CI."
+        echo "See RUNBOOK.md > 'Release authentication' for the new flow."
+        echo
+        echo "Emergency unblock (logged): uncomment the lines below in Taskfile.yml"
+        echo "  # task: publish:ts"
+        echo "  # task: publish:py"
+        exit 1
 
   # ── Snapshots ─────────────────────────────────────────────────
   snapshot:save:


### PR DESCRIPTION
## Summary

Moves `browser-use-sdk` releases (PyPI + npm) off laptop credentials and onto a gated CI workflow that publishes from a single, audited path.

Refs ENG-4762.

## Security model

**Before**

- `task publish` ran on whoever's laptop had `npm` logged in and a PyPI token.
- Tokens lived on disk. Anyone with shell access (or a compromised package in `npm i -g`) could publish.
- No second-pair-of-eyes requirement. A typo or a malicious tag could ship instantly.

**After**

- Trigger is `release: published` on `browser-use/sdk` — only repo admins can cut a release.
- `publish.yml` runs preflight (env protection sanity check, version-coherence check across `browser-use-node/package.json` and `browser-use-python/pyproject.toml`, already-published guard against npm + PyPI).
- It then pauses on the `release` environment, which is protected by required reviewers (`gregpr07`, `LarsenCundric`) with `prevent_self_review: true` so the person who cut the release cannot self-approve.
- PyPI publish uses **trusted publishing via OIDC** — no PyPI token anywhere in this repo. The job mints a short-lived token from PyPI keyed to `repo=browser-use/sdk` + `workflow=publish.yml` + `environment=release`.
- npm publish uses `secrets.NPM_TOKEN` scoped to the `release` environment (so it is only readable from a job that has cleared the approval gate).
- `task publish` is deprecated with a hard exit and an inline emergency-unblock note so it isn't accidentally the default path again.

## Two manual setup steps before this can ship a release

1. **Mint the npm automation token and set `NPM_TOKEN` secret.**
   - https://www.npmjs.com/settings/browser-use/tokens (or whatever org owns `browser-use-sdk`)
   - Type: Automation. Scope: publish on `browser-use-sdk`.
   - Add it at https://github.com/browser-use/sdk/settings/environments/release as an environment secret named `NPM_TOKEN` (NOT a repo-wide secret — environment scope is what makes the gate meaningful).

2. **Configure PyPI trusted publishing.**
   - https://pypi.org/manage/project/browser-use-sdk/settings/publishing/
   - Add pending publisher (or publisher) with:
     - Owner: `browser-use`
     - Repository: `sdk`
     - Workflow filename: `publish.yml`
     - Environment: `release`

Once both are in place, no other config is needed. The first GitHub Release after merge is the live verification.

## Deprecation of `task publish`

`Taskfile.yml` `publish`, `publish:ts`, `publish:py` now exit non-zero with a message pointing at the new flow. The original commands are preserved as comments inline so a maintainer with a real registry emergency can locally uncomment + run them — that edit is intentional friction so it's never the default path again.

## What's NOT in this PR

- The PyPI trusted-publisher form click (only repo owners can do that on pypi.org).
- The npm automation token mint + `NPM_TOKEN` secret (same — needs `npm` org access).
- Any version bump or actual release. The first release after merge proves the pipeline end-to-end.

## Verification of the `release` environment (already done out-of-band)

```
{"name":"release","prevent_self_review":true,"reviewers":["gregpr07","LarsenCundric"]}
```

Draft on purpose — leaving for human review before flipping to ready.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves `browser-use-sdk` publishing from laptops to a gated GitHub Actions workflow with human approval. Both PyPI and npm now use OIDC trusted publishing (no static tokens), creating a single audited release path. Addresses ENG-4762.

- **New Features**
  - Adds `publish.yml` triggered on GitHub Release; preflight checks `release` env protection, version match across `browser-use-node/package.json` and `browser-use-python/pyproject.toml`, and that the version isn’t on npm/PyPI using explicit HTTP status checks that fail closed on errors.
  - Enforces an approval gate on the `release` environment with prevent self review.
  - Publishes Python via PyPI Trusted Publishing and TypeScript to npm via OIDC; no `NPM_TOKEN`/`NODE_AUTH_TOKEN` required. Deprecates `task publish*` with non-functional, safe messages (no secret leakage). `RUNBOOK.md` documents the new flow and both OIDC bindings.

- **Migration**
  - Configure trusted publishing for `browser-use-sdk` on both registries: repo `browser-use/sdk`, workflow `publish.yml`, environment `release` (npm: allow `npm publish`).
  - To release: create a GitHub Release `v<version>`; the workflow runs, waits for reviewer approval, then publishes.

<sup>Written for commit b8f535240882584d9a33358b85f5414d93aa0510. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

