### PR TITLE
[hotfix] Taskfile: fix task release template error

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -185,7 +185,8 @@ tasks:
     cmds:
       - cmd: |
           set -euo pipefail
-          BUMP="{{.CLI_ARGS | default \"patch\"}}"
+          BUMP="{{.CLI_ARGS}}"
+          if [ -z "$BUMP" ]; then BUMP="patch"; fi
           if [ "$BUMP" != "patch" ] && [ "$BUMP" != "minor" ] && [ "$BUMP" != "major" ]; then
             echo "ERROR: invalid bump '$BUMP'. Use patch, minor, or major." >&2
             exit 1
@@ -216,7 +217,7 @@ tasks:
             exit 1
           fi
       - task: "version:bump"
-        vars: { CLI_ARGS: "{{.CLI_ARGS | default \"patch\"}}" }
+        vars: { CLI_ARGS: '{{.CLI_ARGS | default "patch"}}' }
       - cmd: |
           set -euo pipefail
           NEW_VERSION="$(node -p "require('./{{.TS_SDK}}/package.json').version")"


### PR DESCRIPTION
## What broke

`task release -- patch` errored with:

```
template: :2: unexpected "\\" in operand
```

`{{.CLI_ARGS | default \"patch\"}}` has YAML backslash-escaped quotes that Task's Go template engine reads literally.

## Fix

Two surgical edits in the `release:` task:

1. Inside the bash cmd block, dropped the Task-template default and use a bash-level default (`if [ -z "$BUMP" ]; then BUMP="patch"; fi`). Simpler.
2. The inline `vars: { CLI_ARGS: ... }` switched from double-quoted to single-quoted YAML so the inner `"patch"` doesn't need escaping.

## Validation

- YAML parses cleanly.
- No more backslash-escaped quotes in the affected lines.

Unblocks the first end-to-end test of `auto-release-on-version-bump` (PR #168, merged earlier today).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Go template error in the `release` task that caused `task release -- patch` to fail. Default bump is now handled in bash and YAML quoting is corrected, so `patch`, `minor`, and `major` runs work reliably.

<sup>Written for commit 23d7d648afbfd8eb141017128236126074064320. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

