### PR TITLE
[hotfix] Taskfile: fix task release BUMP unbound

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -220,6 +220,8 @@ tasks:
         vars: { CLI_ARGS: '{{.CLI_ARGS | default "patch"}}' }
       - cmd: |
           set -euo pipefail
+          BUMP="{{.CLI_ARGS}}"
+          if [ -z "$BUMP" ]; then BUMP="patch"; fi
           NEW_VERSION="$(node -p "require('./{{.TS_SDK}}/package.json').version")"
           echo
           echo "Releasing v${NEW_VERSION}."


### PR DESCRIPTION
## What broke

`task release -- patch` succeeded through bump → commit → push, then died with:

```
BUMP: unbound variable
task: Failed to run task "release": exit status 1
```

The bumped branch got pushed but no PR was opened.

## Cause

Each `cmd: |` block in Task runs in a SEPARATE shell process. `BUMP` was set at the top of the first cmd block (where the safety checks live) but the third cmd block (the one running `gh pr create`) references it in the PR body string and never re-resolved it. With `set -euo pipefail` enabled, the unbound variable killed the script after push but before `gh pr create` ran.

## Fix

Re-resolve `BUMP` at the top of the third cmd block, same two-line pattern as block 1.

Unblocks the first real `task release` run end-to-end.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failure in `task release` where the PR step crashed with "BUMP: unbound variable"; releases now push and open a PR as expected. Addresses ENG-4762.

- **Bug Fixes**
  - Re-resolve `BUMP` at the start of the PR-create `cmd` block since each Task `cmd` runs in its own shell.

<sup>Written for commit adedbd6555de9c79546a3e3874e08460cdde419c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

