### PR TITLE
[fix] sdk: auto-release invokes publish via workflow_call

### DIFF
--- a/.github/workflows/auto-release-on-version-bump.yml
+++ b/.github/workflows/auto-release-on-version-bump.yml
@@ -32,6 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write   # required to create the Release/tag
+    outputs:
+      should_release: ${{ steps.detect.outputs.should_release }}
+      version: ${{ steps.detect.outputs.version }}
+      tag: v${{ steps.detect.outputs.version }}
 
     steps:
       - name: Checkout (full history for range-aware diff)
@@ -225,3 +229,15 @@ jobs:
             exit 0
           fi
           echo "Created Release v${VERSION}. publish.yml takes over from here."
+
+  publish:
+    name: Publish (via release env approval gate)
+    needs: detect-and-release
+    if: needs.detect-and-release.outputs.should_release == 'true'
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag: ${{ needs.detect-and-release.outputs.tag }}
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write   # required for OIDC publishing (cascades to the called workflow)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,18 @@ name: publish
 # Release runs are serialized via the concurrency group below so two simultaneous
 # release publishes can't race on registry uploads.
 concurrency:
-  group: publish-${{ github.event.release.tag_name || github.run_id }}
+  group: publish-${{ inputs.tag || github.event.release.tag_name || github.run_id }}
   cancel-in-progress: false
 
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g. v3.8.3)'
+        required: true
+        type: string
 
 # Default permissions: read-only. Individual jobs override what they need.
 permissions:
@@ -27,7 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.tag || github.event.release.tag_name }}
           fetch-depth: 0
 
       - name: Verify release environment is protected (fail-closed)
@@ -56,7 +62,7 @@ jobs:
       - name: Extract release tag and verify version coherence
         id: version
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
         run: |
           set -euo pipefail
           # Strip optional leading 'v'.
@@ -136,7 +142,7 @@ jobs:
       - name: Record approver from deployment review log
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
           TARGET_VERSION: ${{ needs.preflight.outputs.version }}
         run: |
           set -euo pipefail
@@ -164,7 +170,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.tag || github.event.release.tag_name }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
@@ -193,7 +199,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.tag || github.event.release.tag_name }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## What broke

v3.8.2 release flow ran like this:

1. `task release -- patch` opened a PR, we merged it ✅
2. `auto-release-on-version-bump.yml` fired on the merge ✅
3. It created a `v3.8.2` Release via `gh release create` ✅
4. **`publish.yml` (triggered on `release: published`) never ran ❌**

Result: v3.8.2 Release object existed on GitHub but no npm/PyPI publish ever happened.

## Why

GitHub Actions [intentionally does not trigger downstream workflows](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) on events created by a workflow's default `GITHUB_TOKEN`. Loop prevention. So `auto-release` → Release event → `publish` was always going to be silently broken.

The two ways to fix it:

1. **Have the auto-release workflow use a PAT or GitHub App token to create the Release.** ❌ Reintroduces the static-credential surface we just removed.
2. **Have auto-release invoke publish.yml directly via `workflow_call`.** ✅ This PR.

## The fix

- `publish.yml` grows a `workflow_call` trigger alongside `release: published`. Accepts a `tag` input.
- Every `github.event.release.tag_name` reference becomes `${{ inputs.tag || github.event.release.tag_name }}`, so both trigger paths work.
- `auto-release-on-version-bump.yml` adds a second job `publish` that `uses: ./.github/workflows/publish.yml` with the new tag as input, after the Release is created.

## What's unchanged

- The `release` env approval gate (gregpr07/LarsenCundric/sauravpanda, prevent_self_review) still applies. `workflow_call` propagates environment protection rules.
- PyPI + npm OIDC trusted publishing (no static credentials).
- Preflight checks (env protection, version coherence, already-published guard).
- The GitHub Release object is still created (changelog + rollback handle).

Manual `gh release create v3.8.3 --generate-notes --repo browser-use/sdk` from a human (not a workflow) still works — that event WILL fire publish.yml normally, since it's not a `GITHUB_TOKEN`-created event.

## Test plan

After merge: bump 3.8.2 → 3.8.3 via `task release -- patch`. Merge that PR. Full chain should fire end-to-end:
auto-release → Release create → workflow_call → publish.yml preflight → release env approval → OIDC publish to npm + PyPI.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken auto-release publish by calling `publish.yml` via `workflow_call` after creating a Release, so npm and PyPI publishes run reliably. Keeps the release env approval gate and OIDC publishing unchanged.

- **Bug Fixes**
  - Added `workflow_call` to `publish.yml` with a required `tag` input; all tag refs use `inputs.tag || github.event.release.tag_name`.
  - Updated `auto-release-on-version-bump.yml` to call `./.github/workflows/publish.yml` with the new tag after Release creation, inheriting secrets and permissions.
  - Updated concurrency group to use `inputs.tag` to serialize publish runs.

<sup>Written for commit f01ebcef67dc382b73b87b520ca84d994dae3216. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

