### PR TITLE
release: v3.8.3

### DIFF
--- a/browser-use-node/package.json
+++ b/browser-use-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-use-sdk",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "Official TypeScript SDK for the Browser Use API",
   "author": "Browser Use",
   "license": "MIT",

--- a/browser-use-python/pyproject.toml
+++ b/browser-use-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "browser-use-sdk"
-version = "3.8.2"
+version = "3.8.3"
 description = "Python SDK for the Browser Use cloud API"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bumps both SDK manifests to v3.8.3.

Merging this PR triggers `auto-release-on-version-bump` → `publish.yml` (gated by the `release` env, requires a non-author approver, OIDC publish to npm + PyPI).

Generated by `task release -- patch`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `browser-use-sdk` to v3.8.3 for both the TypeScript and Python SDKs. Merging will trigger `auto-release-on-version-bump` → `publish.yml` to publish to npm and PyPI (gated by the `release` env and requires a non‑author approval).

<sup>Written for commit 0bf07c08d037f2c4f1d687e216cf165d9ec4d863. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

