### PR TITLE
[hotfix] auto-release: add actions:read to publish job permissions

### DIFF
--- a/.github/workflows/auto-release-on-version-bump.yml
+++ b/.github/workflows/auto-release-on-version-bump.yml
@@ -241,3 +241,4 @@ jobs:
     permissions:
       contents: read
       id-token: write   # required for OIDC publishing (cascades to the called workflow)
+      actions: read     # required for the called workflow's approval job to read the approvals API


### PR DESCRIPTION
## What broke

`auto-release-on-version-bump.yml` on main is missing `actions: read` in the `publish:` job's `permissions` block. Result: every release attempt dies at workflow startup with:

```
Error calling workflow '.../publish.yml@...'. The nested job 'approval' is requesting 'actions: read', but is only allowed 'actions: none'.
```

The 3.8.3 release attempt (PR #173 → main → auto-release fired → startup_failure in 1s) is the live example. PR #174 reverts the bump so we can re-try after this fix lands.

## Why this slipped through

PR #172 was the broader workflow_call rewrite. The `actions: read` line was added as a follow-up push during review, but the merge picked up an earlier head SHA and the line didn't make it to main. Verified: `grep "actions: read" auto-release-on-version-bump.yml` on main returns nothing.

## The fix

One line. Add `actions: read` to the `publish:` job's `permissions` block alongside the existing `contents: read` and `id-token: write`.

## After merge

1. PR #174 (revert v3.8.3) can merge first or after — doesn't matter, the manifests on main return to 3.8.2 either way.
2. Once both #174 and this PR are on main, run `task release -- patch` again to bump 3.8.2 → 3.8.3 and exercise the full chain end-to-end.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `actions: read` to the `publish` job permissions in `.github/workflows/auto-release-on-version-bump.yml` so the reusable `publish.yml` approval job can read approvals and the release workflow starts successfully again. This fixes release attempts failing at startup due to missing permission.

<sup>Written for commit 6e0837e24bd1d98e71608a6c0c640785157714b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

