### PR TITLE
[hotfix] publish: add environment:release to publish-py and publish-ts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -162,6 +162,7 @@ jobs:
   publish-py:
     name: Publish Python SDK to PyPI
     needs: [preflight, approval]
+    environment: release
     runs-on: ubuntu-latest
     permissions:
       id-token: write   # required for PyPI trusted publishing OIDC
@@ -191,6 +192,7 @@ jobs:
   publish-ts:
     name: Publish TypeScript SDK to npm
     needs: [preflight, approval]
+    environment: release
     runs-on: ubuntu-latest
     permissions:
       id-token: write   # required for npm OIDC trusted publishing


### PR DESCRIPTION
## What broke

Live release attempt for v3.8.2 just failed in both publish jobs:

**PyPI:**
```
error: Failed to obtain token for trusted publishing
Server returned 422: "valid token, but no corresponding publisher"
Token claims: environment: None
```

**npm:**
```
npm error code ENEEDAUTH
need auth: You need to authorize this machine using `npm adduser`
```

## Cause

`publish.yml` puts `environment: release` only on the `approval` job (where the gate lives). The actual `publish-py` and `publish-ts` jobs have no `environment:` declared. OIDC tokens minted by those jobs carry `environment: None`, which fails the trusted-publisher claims check on both PyPI and npm (both configured with `environment: release`).

## The fix

Add `environment: release` to both `publish-py` and `publish-ts`. GitHub deduplicates approval clicks within a run — since the `approval` job already had this run's `release` env approved, the publish jobs reuse the approval. No second click. Matches Astral's pattern.

## Verification plan

Once merged: bump 3.8.2 → 3.8.3 via `task release -- patch`. Full chain: auto-release → workflow_call → preflight → approval (one click) → publish-py + publish-ts in parallel via OIDC.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release pipeline by adding environment: release to `publish-py` and `publish-ts` so OIDC tokens match trusted-publisher claims and PyPI/npm publishing works (Linear ENG-4762). Reuses the existing release approval; no extra clicks.

<sup>Written for commit 9b7f5c4b2e4fc31751ac1ad8b1ab93430c37a49e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

