### PR TITLE
[ux] Taskfile: `task release` auto-creates the release branch

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -4,12 +4,13 @@ Decision guide for the `/sdk` pipeline. Read this, then go.
 
 ## Releasing
 
-1. **From a fresh branch off main, run `task release -- patch`** (or `minor` / `major`). This bumps both `browser-use-node/package.json` and `browser-use-python/pyproject.toml` to the next version, commits as `release: v<NEW_VERSION>`, pushes the branch, and opens a PR.
+1. **From `main`, run `task release -- patch`** (or `minor` / `major`). This pulls latest main, creates a fresh `release/<timestamp>` branch off it, bumps both `browser-use-node/package.json` and `browser-use-python/pyproject.toml`, commits as `release: v<NEW_VERSION>`, pushes the branch, and opens a PR.
 
    Manual alternative (if you don't want the helper):
 
    ```bash
-   git checkout -b release/$(date +%Y%m%d) main
+   git checkout main && git pull --ff-only origin main
+   git checkout -b release/$(date +%Y%m%d-%H%M%S)
    task version:bump -- patch
 
    # Read the new version after the bump, then use it in commit + PR.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -199,23 +199,36 @@ tasks:
             exit 1
           fi
 
-          # Refuse to run on main directly — releases must go through a PR for
-          # the auto-detector to fire on merge.
+          # The task auto-creates the release branch from main, so it must be
+          # run FROM main. Refuse otherwise — running from a feature branch
+          # would surprise the user with a branch named off a non-main tip.
           CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-          if [ "$CURRENT_BRANCH" = "main" ]; then
-            echo "ERROR: refusing to run on main. Releases go through a PR; the auto-detector fires on merge." >&2
-            echo "Run from a fresh branch off main, e.g.:" >&2
-            echo "  git checkout -b release/\$(date +%Y%m%d) main && task release -- $BUMP" >&2
+          if [ "$CURRENT_BRANCH" != "main" ]; then
+            echo "ERROR: refusing to run. \`task release\` auto-creates a release branch off main, so it must be started from main." >&2
+            echo "Currently on: $CURRENT_BRANCH" >&2
+            echo "Switch first:" >&2
+            echo "  git checkout main" >&2
             exit 1
           fi
 
-          # Make sure we're up-to-date with main so the bump diff is clean.
+          # Fast-forward main to origin/main so the new branch is based on the
+          # latest published main, not whatever stale state we have locally.
+          # --ff-only fails if local main has unpushed commits, which would be
+          # weird — bail loud so the user reconciles.
           git fetch origin main --quiet
           if ! git merge-base --is-ancestor origin/main HEAD; then
-            echo "ERROR: branch is behind origin/main. Rebase first:" >&2
-            echo "  git rebase origin/main" >&2
+            echo "ERROR: local main has commits not on origin/main. Reconcile before releasing." >&2
+            echo "  git log origin/main..HEAD --oneline" >&2
             exit 1
           fi
+          git pull --ff-only origin main --quiet
+
+          # Create the release branch. Date+time keeps it unique across
+          # multiple releases the same day; the branch auto-deletes on PR merge
+          # (squash + delete-on-merge), so the branch list stays clean.
+          NEW_BRANCH="release/$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$NEW_BRANCH"
+          echo "::notice::Created release branch $NEW_BRANCH from main."
       - task: "version:bump"
         vars: { CLI_ARGS: '{{.CLI_ARGS | default "patch"}}' }
       - cmd: |


### PR DESCRIPTION
## What changes

Before:
```
git checkout -b release/whatever       # required first
task release -- patch                  # refused on main
```

After:
```
git checkout main                      # not even required if you're already there
task release -- patch                  # auto-pulls main, auto-branches, bumps, PRs
```

## Implementation

Inverted the "refuse on main" check to "require main." Auto-pulls main fast-forward. Creates `release/$(date +%Y%m%d-%H%M%S)` automatically. Rest of the flow (bump, commit, push, gh pr create) unchanged.

RUNBOOK's "Releasing" step 1 simplified to match. Manual fallback updated to mirror.

## Why now

Hit this friction during the v3.8.2 release cycle. The required pre-step is muscle memory worth removing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`task release` now auto-creates a `release/<timestamp>` branch from up-to-date `main`, then bumps, commits, pushes, and opens a PR. Run it directly from `main`; the manual `git checkout -b release/...` step is gone, and the RUNBOOK is updated.

- **New Features**
  - Fast-forwards local `main` to `origin/main` with `--ff-only` before branching.
  - Errors if local `main` is ahead of `origin/main` to avoid releasing from a stale or divergent state.
  - Creates a unique `release/<timestamp>` branch and proceeds with the existing bump/PR flow.

<sup>Written for commit c94a11c2860d9a4217ca582cb57f5957aa417cb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

