### PR TITLE
[hotfix] publish: bypass npm PATH-shadow with npx npm@11

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -223,9 +223,16 @@ jobs:
         working-directory: browser-use-node
         run: pnpm build
 
-      - name: Upgrade npm to OIDC-capable version
-        run: npm install -g npm@latest
-
       - name: Publish to npm (OIDC trusted publishing)
         working-directory: browser-use-node
-        run: npm publish --access public
+        run: |
+          set -euo pipefail
+          # Node 22 ships with npm 10.x; OIDC trusted publishing requires
+          # npm >= 11.5.1. `npm install -g npm@latest` on the GitHub runner
+          # puts the new binary on a PATH that doesn't shadow the bundled
+          # npm, so `npm publish` still picks up the old 10.x. Bypass by
+          # invoking the version explicitly via npx.
+          NPM_VERSION="11"
+          echo "Node:    $(node --version)"
+          echo "npm:     $(npx -y npm@${NPM_VERSION} --version)"
+          npx -y npm@${NPM_VERSION} publish --access public


### PR DESCRIPTION
## What broke

v3.8.3 release attempt:
- PyPI: shipped (3.8.3 was live; Larsen yanked it manually since the npm side failed).
- npm: failed with `ENEEDAUTH need auth`.

Two-step upgrade was insufficient:

```yaml
- name: Upgrade npm to OIDC-capable version
  run: npm install -g npm@latest

- name: Publish to npm (OIDC trusted publishing)
  run: npm publish --access public
```

`npm install -g npm@latest` writes to `/usr/local/lib/node_modules` but the Node-bundled npm (10.x) wins in PATH order on the runner. So `npm publish` still invoked the old npm, which doesn't know OIDC, so it falls back to looking for legacy auth (none configured), and that's the ENEEDAUTH.

## Fix

Collapse to one step that uses `npx` to invoke the pinned version:

```yaml
- name: Publish to npm (OIDC trusted publishing)
  run: |
    set -euo pipefail
    NPM_VERSION="11"
    echo "Node:    $(node --version)"
    echo "npm:     $(npx -y npm@${NPM_VERSION} --version)"
    npx -y npm@${NPM_VERSION} publish --access public
```

- `npx -y` bypasses PATH entirely (downloads + invokes the exact pinned version).
- Pin to major `npm@11` (not `@latest`) so a future npm 12 doesn't silently break us.
- Echo versions so the next failure is diagnosable from one log line.

## Test plan after merge

Bump 3.8.3 -> 3.8.4 (since 3.8.3 was published to PyPI then yanked; we shouldn't reuse). `task release -- patch` -> auto-release -> publish.yml -> preflight -> approval -> PyPI (still works) + npm (now works).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes npm publishing in CI by invoking `npm@11` via `npx` to bypass the runner’s PATH-shadowed npm 10.x. Restores OIDC trusted publishing and prevents `ENEEDAUTH` failures. Addresses ENG-4762.

- Bug Fixes
  - Replace the global upgrade with `npx -y npm@11 publish --access public` in `.github/workflows/publish.yml` to ensure `npm>=11.5.1` is used.
  - Log Node and `npm` versions for easier debugging.

<sup>Written for commit b3c19e65138eb7b03a70a965c5ba6ea8829c4128. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

