### PR TITLE
Revert "release: v3.8.3"

### DIFF
--- a/browser-use-node/package.json
+++ b/browser-use-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-use-sdk",
-  "version": "3.8.3",
+  "version": "3.8.2",
   "description": "Official TypeScript SDK for the Browser Use API",
   "author": "Browser Use",
   "license": "MIT",

--- a/browser-use-python/pyproject.toml
+++ b/browser-use-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "browser-use-sdk"
-version = "3.8.3"
+version = "3.8.2"
 description = "Python SDK for the Browser Use cloud API"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Reverts browser-use/sdk#178

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the v3.8.3 release, setting `browser-use-sdk` back to 3.8.2 in the Node and Python packages. No API or code changes.

<sup>Written for commit 6526de707451758b8e38779689e4052acd01ad18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

