### PR TITLE
[hotfix] publish: diagnose OIDC claims + consolidate approval gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,19 +131,25 @@ jobs:
 
           echo "::notice::Both registries confirm ${VERSION} is unpublished. Proceeding."
 
-  approval:
-    name: Release approval gate
-    needs: preflight
-    runs-on: ubuntu-latest
+  publish-py:
+    name: Publish Python SDK to PyPI
+    needs: [preflight]
     environment: release
+    runs-on: ubuntu-latest
     permissions:
-      actions: read
+      id-token: write   # required for PyPI trusted publishing OIDC
+      contents: read
+      actions: read     # required for /actions/runs/{id}/approvals lookup
     steps:
-      - name: Record approver from deployment review log
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.event.release.tag_name }}
+
+      - name: Record approver
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
-          TARGET_VERSION: ${{ needs.preflight.outputs.version }}
+          TARGET_TAG: ${{ inputs.tag || github.event.release.tag_name }}
         run: |
           set -euo pipefail
           APPROVER="$(gh api \
@@ -153,25 +159,7 @@ jobs:
           if [ -z "$APPROVER" ] || [ "$APPROVER" = "null" ]; then
             APPROVER="(approver lookup failed; check Actions UI)"
           fi
-          echo "::notice::Release approved by @${APPROVER} for release ${RELEASE_TAG} (v${TARGET_VERSION}). Triggered by @${GITHUB_ACTOR}. Run ${GITHUB_RUN_ID}."
-          echo "Approver:     @${APPROVER}"
-          echo "Triggered by: @${GITHUB_ACTOR}"
-          echo "Release tag:  ${RELEASE_TAG}"
-          echo "Version:      ${TARGET_VERSION}"
-
-  publish-py:
-    name: Publish Python SDK to PyPI
-    needs: [preflight, approval]
-    environment: release
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write   # required for PyPI trusted publishing OIDC
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.tag || github.event.release.tag_name }}
+          echo "::notice::Release ${TARGET_TAG} approved by @${APPROVER}, triggered by @${GITHUB_ACTOR}, run ${GITHUB_RUN_ID}."
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
@@ -191,17 +179,33 @@ jobs:
 
   publish-ts:
     name: Publish TypeScript SDK to npm
-    needs: [preflight, approval]
+    needs: [preflight]
     environment: release
     runs-on: ubuntu-latest
     permissions:
       id-token: write   # required for npm OIDC trusted publishing
       contents: read
+      actions: read     # required for /actions/runs/{id}/approvals lookup
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || github.event.release.tag_name }}
+
+      - name: Record approver
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_TAG: ${{ inputs.tag || github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          APPROVER="$(gh api \
+            "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals" \
+            --jq '[.[] | select(.environments[]?.name=="release") | .user.login] | last' \
+            2>/dev/null || echo "")"
+          if [ -z "$APPROVER" ] || [ "$APPROVER" = "null" ]; then
+            APPROVER="(approver lookup failed; check Actions UI)"
+          fi
+          echo "::notice::Release ${TARGET_TAG} approved by @${APPROVER}, triggered by @${GITHUB_ACTOR}, run ${GITHUB_RUN_ID}."
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -222,6 +226,30 @@ jobs:
       - name: Build TypeScript SDK
         working-directory: browser-use-node
         run: pnpm build
+
+      - name: Diagnose OIDC token claims
+        env:
+          ACTIONS_ID_TOKEN_REQUEST_TOKEN: ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}
+          ACTIONS_ID_TOKEN_REQUEST_URL: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}
+        run: |
+          set -euo pipefail
+          # Fetch an OIDC token with audience=npm:registry.npmjs.org (matches what npm uses).
+          TOKEN_JSON="$(curl -fsSL \
+            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=npm:registry.npmjs.org")"
+          TOKEN="$(echo "$TOKEN_JSON" | python3 -c 'import sys,json; print(json.load(sys.stdin)["value"])')"
+          # Decode the payload (middle segment) — strip any URL-safe padding issues.
+          PAYLOAD="$(echo "$TOKEN" | cut -d. -f2 | tr '_-' '/+' | base64 -d 2>/dev/null || echo "$TOKEN" | cut -d. -f2 | python3 -c 'import sys,base64,json; s=sys.stdin.read().strip(); s+="="*(-len(s)%4); print(base64.urlsafe_b64decode(s).decode())')"
+          echo "::group::OIDC token claims (audience=npm:registry.npmjs.org)"
+          echo "$PAYLOAD" | python3 -m json.tool 2>/dev/null || echo "$PAYLOAD"
+          echo "::endgroup::"
+          # Highlight the fields npm checks against the trusted-publisher config.
+          echo "Key fields:"
+          echo "  sub:               $(echo "$PAYLOAD" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("sub"))')"
+          echo "  repository:        $(echo "$PAYLOAD" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("repository"))')"
+          echo "  job_workflow_ref:  $(echo "$PAYLOAD" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("job_workflow_ref"))')"
+          echo "  environment:       $(echo "$PAYLOAD" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("environment"))')"
+          echo "  ref:               $(echo "$PAYLOAD" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("ref"))')"
 
       - name: Publish to npm (OIDC trusted publishing)
         working-directory: browser-use-node


### PR DESCRIPTION
## Two changes

### 1. Diagnose OIDC token claims (publish-ts)

v3.8.2 retry on npm STILL failed with `ENEEDAUTH` even with npm 11.16.0 (well above 11.5.1 OIDC minimum). PyPI side succeeded. Hypothesis: when publish.yml runs via `workflow_call` from auto-release-on-version-bump.yml, the `job_workflow_ref` claim in the OIDC token may point at the calling workflow rather than `publish.yml`. npm's trusted-publisher is exact-match on workflow filename, so a mismatch falls through to legacy auth → ENEEDAUTH.

Adds a diagnostic step right before `npm publish` that fetches the OIDC token (audience=npm:registry.npmjs.org), decodes the JWT payload, and prints the claims npm checks. Next failure surfaces the actual mismatch in one log line.

### 2. Consolidate approval gate

The standalone `approval` job had `environment: release` which forced a separate approval prompt before the publish jobs ran. Then publish-py and publish-ts (also `environment: release`) prompted again — 2 approvals per release. The approval job has been removed; publish jobs gate themselves (one prompt covers both parallel jobs in the same env).

The approver-recording the approval job did is moved to a new first step on publish-py and publish-ts, calling `/actions/runs/{id}/approvals` for the approver login. Both jobs now have `actions: read` permission.

`needs` on publish-py and publish-ts changed from `[preflight, approval]` to `[preflight]`.

## Test plan after merge

Run another release (will need a new patch — 3.8.4 — since 3.8.3 was yanked from PyPI):
1. Single approval prompt (not two).
2. publish-ts step "Diagnose OIDC token claims" prints the claims.
3. If npm still fails, we have the data to fix the trusted-publisher config (or workflow filename mismatch).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an OIDC claims diagnostic to the npm publish job and collapse the release approval flow to a single prompt. This helps debug npm `ENEEDAUTH` and removes duplicate approvals.

- **Refactors**
  - Added an OIDC claims diagnostic before `npm publish` (audience `npm:registry.npmjs.org`) that prints `sub`, `repository`, `job_workflow_ref`, `environment`, and `ref` to verify trusted-publisher matching.

- **Bug Fixes**
  - Consolidated approvals: removed the standalone `approval` job; `publish-py` and `publish-ts` now self-gate on the `release` environment, record the approver via `/actions/runs/{id}/approvals`, and include `actions: read` permission.

<sup>Written for commit e2a0546480c047f589f3bd31e5887d276855959f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

