### PR TITLE
[hotfix] package metadata: add repository field for npm provenance

### DIFF
--- a/browser-use-node/package.json
+++ b/browser-use-node/package.json
@@ -2,6 +2,14 @@
   "name": "browser-use-sdk",
   "version": "3.8.2",
   "description": "Official TypeScript SDK for the Browser Use API",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/browser-use/sdk.git"
+  },
+  "homepage": "https://github.com/browser-use/sdk",
+  "bugs": {
+    "url": "https://github.com/browser-use/sdk/issues"
+  },
   "author": "Browser Use",
   "license": "MIT",
   "type": "module",

--- a/browser-use-python/pyproject.toml
+++ b/browser-use-python/pyproject.toml
@@ -11,6 +11,11 @@ license = "MIT"
 requires-python = ">=3.9"
 dependencies = ["httpx>=0.24", "pydantic>=2.0"]
 
+[project.urls]
+Homepage = "https://github.com/browser-use/sdk"
+Repository = "https://github.com/browser-use/sdk"
+Issues = "https://github.com/browser-use/sdk/issues"
+
 [project.optional-dependencies]
 dev = ["pytest>=7", "pyright>=1.1"]
 examples = ["python-dotenv>=1.0"]


### PR DESCRIPTION
## What broke

v3.8.2 npm publish made it past OIDC auth and provenance generation, then failed at upload:

```
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/browser-use-sdk
- Error verifying sigstore provenance bundle: Failed to validate repository information:
  package.json: "repository.url" is "", expected to match "https://github.com/browser-use/sdk" from provenance
```

npm provenance embeds the GitHub repo URL in the attestation, then cross-checks it against `package.json`'s `repository.url`. Our `package.json` doesn't declare one → mismatch → reject.

## Fix

Adds the standard repository / homepage / bugs fields to `browser-use-node/package.json`. Mirrored on `browser-use-python/pyproject.toml` for symmetry (PyPI doesn't currently enforce this but it's still good metadata).

## Test plan

After merge: bump 3.8.2 → 3.8.3 via `task release -- patch`. Full chain should ship for the first time end-to-end:
- auto-release fires
- publish.yml preflight + approval (single prompt now, after #181)
- PyPI publishes (was working)
- npm publishes (this PR makes provenance verification pass)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes npm publish by adding missing metadata so provenance verification matches the GitHub repo. Mirrors the same URLs in the Python package for consistency.

- **Bug Fixes**
  - Add `repository`, `homepage`, and `bugs` fields to `browser-use-node/package.json` (set `repository.url` to `git+https://github.com/browser-use/sdk.git`).
  - Add `[project.urls]` (`Homepage`, `Repository`, `Issues`) to `browser-use-python/pyproject.toml`.

<sup>Written for commit 36e8eb2b5f9763852c7d2e515c2bf9b2695a76f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

