### PR TITLE
Revert "release: v3.8.3"

### DIFF
--- a/browser-use-node/package.json
+++ b/browser-use-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-use-sdk",
-  "version": "3.8.3",
+  "version": "3.8.2",
   "description": "Official TypeScript SDK for the Browser Use API",
   "repository": {
     "type": "git",

--- a/browser-use-python/pyproject.toml
+++ b/browser-use-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "browser-use-sdk"
-version = "3.8.3"
+version = "3.8.2"
 description = "Python SDK for the Browser Use cloud API"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Reverts browser-use/sdk#183

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rolls back the v3.8.3 release, restoring `browser-use-sdk` to version 3.8.2 in both Node and Python packages. This prevents an unintended publish and keeps clients on the last stable version.

<sup>Written for commit 0f3bd27f62a40221625b0cfe0be609bf8e65950c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

