### PR TITLE
release: v3.8.3

### DIFF
--- a/browser-use-node/package.json
+++ b/browser-use-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-use-sdk",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "Official TypeScript SDK for the Browser Use API",
   "repository": {
     "type": "git",

--- a/browser-use-python/pyproject.toml
+++ b/browser-use-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "browser-use-sdk"
-version = "3.8.2"
+version = "3.8.3"
 description = "Python SDK for the Browser Use cloud API"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bumps both SDK manifests to v3.8.3.

Merging this PR triggers `auto-release-on-version-bump` → `publish.yml` (gated by the `release` env, requires a non-author approver, OIDC publish to npm + PyPI).

Generated by `task release -- patch`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `browser-use-sdk` to v3.8.3 in both Node and Python manifests. Merging triggers the auto-release (`publish.yml`) to publish to npm and PyPI, gated by the `release` env and a non-author approval.

<sup>Written for commit c116294d3f530fd903ffa4d3ed958c3bda040e81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

