### PR TITLE
docs: add Skills section under Open Source > Examples

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -292,6 +292,19 @@
                   "open-source/examples/apps/news-use",
                   "open-source/examples/apps/msg-use"
                 ]
+              },
+              {
+                "group": "Skills",
+                "icon": "wand-magic-sparkles",
+                "pages": [
+                  "open-source/examples/skills/overview",
+                  "open-source/examples/skills/browser-use",
+                  "open-source/examples/skills/cloud",
+                  "open-source/examples/skills/open-source",
+                  "open-source/examples/skills/qa",
+                  "open-source/examples/skills/remote-browser",
+                  "open-source/examples/skills/x402"
+                ]
               }
             ]
           },

--- a/docs/open-source/examples/skills/browser-use.mdx
+++ b/docs/open-source/examples/skills/browser-use.mdx
@@ -1,0 +1,20 @@
+---
+title: "browser-use"
+description: "Automates browser interactions for web testing, form filling, screenshots, and data extraction. Use when the agent needs to navigate websites, interact with web pages, fill forms, take screenshots, or extract information."
+icon: "terminal"
+---
+
+The `browser-use` skill teaches your agent the full [Browser Use CLI](/open-source/browser-use-cli) command set — a fast, persistent browser it drives directly: `open`, `state`, `click`, `input`, `screenshot`, and more. A background daemon keeps the browser open across commands (~50ms per call), and the agent can connect to your real Chrome (preserving logins) or to a cloud browser.
+
+## Install
+
+```bash
+npx skills add https://github.com/browser-use/browser-use --skill browser-use
+```
+
+## Links
+
+<CardGroup cols={2}>
+  <Card title="skills.sh" icon="up-right-from-square" href="https://www.skills.sh/browser-use/browser-use/browser-use" />
+  <Card title="Source" icon="github" href="https://github.com/browser-use/browser-use/tree/main/skills/browser-use" />
+</CardGroup>

--- a/docs/open-source/examples/skills/cloud.mdx
+++ b/docs/open-source/examples/skills/cloud.mdx
@@ -1,0 +1,24 @@
+---
+title: "cloud"
+description: "Documentation reference for using Browser Use Cloud — the hosted API and SDK for browser automation."
+icon: "cloud"
+---
+
+The `cloud` skill gives your agent a reference for [Browser Use Cloud](/cloud/quickstart): the REST API (v2 and v3), the `browser-use-sdk` (Python and TypeScript), `X-Browser-Use-API-Key` authentication, cloud sessions, browser profiles and profile sync, CDP WebSocket access, stealth browsers, residential proxies, CAPTCHA handling, webhooks, workspaces, the skills marketplace, `liveUrl` streaming, pricing, and integration patterns (chat UI, subagents, n8n/Make/Zapier, Playwright/Puppeteer/Selenium).
+
+<Note>
+For the open-source Python library (`Agent`, `Browser`, `Tools`), use the [`open-source`](/open-source/examples/skills/open-source) skill instead.
+</Note>
+
+## Install
+
+```bash
+npx skills add https://github.com/browser-use/browser-use --skill cloud
+```
+
+## Links
+
+<CardGroup cols={2}>
+  <Card title="skills.sh" icon="up-right-from-square" href="https://www.skills.sh/browser-use/browser-use/cloud" />
+  <Card title="Source" icon="github" href="https://github.com/browser-use/browser-use/tree/main/skills/cloud" />
+</CardGroup>

--- a/docs/open-source/examples/skills/open-source.mdx
+++ b/docs/open-source/examples/skills/open-source.mdx
@@ -1,0 +1,24 @@
+---
+title: "open-source"
+description: "Documentation reference for writing Python code using the browser-use open-source library."
+icon: "code"
+---
+
+The `open-source` skill gives your agent a reference for writing Python against the [`browser-use` library](/open-source/quickstart): `Agent`, `Browser`, and `Tools` configuration, supported LLM models (15+ providers), the Actor API, custom tools, lifecycle hooks, MCP server setup, sensitive-data handling, prompting strategies, and monitoring/observability with Laminar or OpenLIT.
+
+<Note>
+For the Cloud API/SDK, use the [`cloud`](/open-source/examples/skills/cloud) skill. To drive a browser directly via CLI, use the [`browser-use`](/open-source/examples/skills/browser-use) skill.
+</Note>
+
+## Install
+
+```bash
+npx skills add https://github.com/browser-use/browser-use --skill open-source
+```
+
+## Links
+
+<CardGroup cols={2}>
+  <Card title="skills.sh" icon="up-right-from-square" href="https://www.skills.sh/browser-use/browser-use/open-source" />
+  <Card title="Source" icon="github" href="https://github.com/browser-use/browser-use/tree/main/skills/open-source" />
+</CardGroup>

--- a/docs/open-source/examples/skills/overview.mdx
+++ b/docs/open-source/examples/skills/overview.mdx
@@ -1,0 +1,52 @@
+---
+title: "Overview"
+description: "Install Browser Use as an agent skill. Drop browser automation, cloud, QA, and payments into Claude Code, Cursor, and any agent that supports SKILL.md."
+icon: "wand-magic-sparkles"
+---
+
+Browser Use ships a set of [agent skills](https://www.skills.sh/browser-use/browser-use) — self-contained `SKILL.md` bundles that teach a coding agent (Claude Code, Cursor, OpenClaw, Hermes, and others) how to use Browser Use. Each skill is installable from [skills.sh](https://www.skills.sh/browser-use/browser-use) with one command.
+
+## Install
+
+Every skill installs through the [skills CLI](https://www.skills.sh) with the same pattern — swap in the skill name with `--skill`:
+
+```bash
+npx skills add https://github.com/browser-use/browser-use --skill <name>
+```
+
+For example, to install the QA skill:
+
+```bash
+npx skills add https://github.com/browser-use/browser-use --skill qa
+```
+
+<Tip>
+The skills CLI drops the skill into your agent's skills directory (e.g. `.claude/skills/` for Claude Code). Your agent picks it up automatically — no extra wiring.
+</Tip>
+
+## Available skills
+
+<CardGroup cols={2}>
+  <Card title="browser-use" icon="terminal" href="/open-source/examples/skills/browser-use">
+    Drive a browser directly from the CLI — navigate, click, fill forms, screenshot, and extract data.
+  </Card>
+  <Card title="cloud" icon="cloud" href="/open-source/examples/skills/cloud">
+    Reference for Browser Use Cloud — the hosted REST API (v2 & v3) and the Python/TypeScript SDKs.
+  </Card>
+  <Card title="open-source" icon="code" href="/open-source/examples/skills/open-source">
+    Reference for writing Python against the `browser-use` library — Agent, Browser, Tools, and more.
+  </Card>
+  <Card title="qa" icon="vial" href="/open-source/examples/skills/qa">
+    QA-test any site or local dev server and return a 1–5 quality score with evidence.
+  </Card>
+  <Card title="remote-browser" icon="server" href="/open-source/examples/skills/remote-browser">
+    Control a headless browser from a sandboxed remote machine (cloud VMs, CI, coding agents).
+  </Card>
+  <Card title="x402" icon="wallet" href="/open-source/examples/skills/x402">
+    Pay for Browser Use Cloud per request from a crypto wallet — no signup or API key.
+  </Card>
+</CardGroup>
+
+## Source
+
+All skills live in the [`skills/` directory](https://github.com/browser-use/browser-use/tree/main/skills) of the `browser-use` repo.

--- a/docs/open-source/examples/skills/qa.mdx
+++ b/docs/open-source/examples/skills/qa.mdx
@@ -1,0 +1,20 @@
+---
+title: "qa"
+description: "QA-test a website or web app and return a 1–5 quality score (5 = flawless, 1 = broken) with evidence."
+icon: "vial"
+---
+
+The `qa` skill drives a website with a real browser, judges how well it does the thing you asked about, and returns a **score from 1 (broken) to 5 (excellent)** with evidence — the deliverable is a verdict, not a screenshot dump. Use it to test, QA, evaluate, or score a site, page, flow, or app, including a local dev server (e.g. `localhost:5173`) which it tunnels out automatically. It runs on a real Browser Use cloud browser.
+
+## Install
+
+```bash
+npx skills add https://github.com/browser-use/browser-use --skill qa
+```
+
+## Links
+
+<CardGroup cols={2}>
+  <Card title="skills.sh" icon="up-right-from-square" href="https://www.skills.sh/browser-use/browser-use/qa" />
+  <Card title="Source" icon="github" href="https://github.com/browser-use/browser-use/tree/main/skills/qa" />
+</CardGroup>

--- a/docs/open-source/examples/skills/remote-browser.mdx
+++ b/docs/open-source/examples/skills/remote-browser.mdx
@@ -1,0 +1,20 @@
+---
+title: "remote-browser"
+description: "Controls a local browser from a sandboxed remote machine. Use when the agent runs in a sandbox (no GUI) and needs to navigate, interact, screenshot, or expose local dev servers via tunnels."
+icon: "server"
+---
+
+The `remote-browser` skill is for agents running on **sandboxed remote machines** (cloud VMs, CI, coding agents) that need to control a headless browser. It uses the same [Browser Use CLI](/open-source/browser-use-cli) workflow as the [`browser-use`](/open-source/examples/skills/browser-use) skill — `open`, `state`, `click`, `input`, `screenshot`, `close` — plus headless Chromium, cloud browsers, CDP connection, and tunnels to expose local dev servers.
+
+## Install
+
+```bash
+npx skills add https://github.com/browser-use/browser-use --skill remote-browser
+```
+
+## Links
+
+<CardGroup cols={2}>
+  <Card title="skills.sh" icon="up-right-from-square" href="https://www.skills.sh/browser-use/browser-use/remote-browser" />
+  <Card title="Source" icon="github" href="https://github.com/browser-use/browser-use/tree/main/skills/remote-browser" />
+</CardGroup>

--- a/docs/open-source/examples/skills/x402.mdx
+++ b/docs/open-source/examples/skills/x402.mdx
@@ -1,0 +1,20 @@
+---
+title: "x402"
+description: "Set up Browser Use Cloud payments with x402 — pay per request from a crypto wallet (USDC on Base mainnet), no signup or API key."
+icon: "wallet"
+---
+
+The `x402` skill walks your agent through setting up [Browser Use Cloud payments with x402](/cloud/guides/x402) — pay per request from a crypto wallet (USDC on Base mainnet), with no signup, API key, or credit card. It guides wallet setup, funding, writing the key to `.env`, and a ~$1 test run. x402 works through the SDK only. Use it when you want pay-per-use access without an API key.
+
+## Install
+
+```bash
+npx skills add https://github.com/browser-use/browser-use --skill x402
+```
+
+## Links
+
+<CardGroup cols={2}>
+  <Card title="skills.sh" icon="up-right-from-square" href="https://www.skills.sh/browser-use/browser-use/x402" />
+  <Card title="Source" icon="github" href="https://github.com/browser-use/browser-use/tree/main/skills/x402" />
+</CardGroup>

--- a/docs/open-source/examples/skills/x402.mdx
+++ b/docs/open-source/examples/skills/x402.mdx
@@ -4,7 +4,7 @@ description: "Set up Browser Use Cloud payments with x402 — pay per request fr
 icon: "wallet"
 ---
 
-The `x402` skill walks your agent through setting up [Browser Use Cloud payments with x402](/cloud/guides/x402) — pay per request from a crypto wallet (USDC on Base mainnet), with no signup, API key, or credit card. It guides wallet setup, funding, writing the key to `.env`, and a ~$1 test run. x402 works through the SDK only. Use it when you want pay-per-use access without an API key.
+The `x402` skill walks your agent through setting up [Browser Use Cloud payments with x402](/cloud/guides/x402) — pay per request from a crypto wallet (USDC on Base mainnet), with no signup, API key, or credit card. It guides wallet setup, funding, writing the key to `.env`, and a ~$1 test run. The SDK is the easiest path, and non-SDK flows are available via x402-aware client libraries. Use it when you want pay-per-use access without an API key.
 
 ## Install
 


### PR DESCRIPTION
## What

Adds a **Skills** subgroup to the docs sidebar under **Open Source → Examples**, grouped alongside **Templates** and **Apps**.

It documents the installable agent skills published from the [`browser-use` repo `skills/` directory](https://github.com/browser-use/browser-use/tree/main/skills) on [skills.sh](https://www.skills.sh/browser-use/browser-use):

- **overview** — explains skills.sh + the `npx skills add … --skill <name>` install pattern, with a card grid linking to each skill
- **browser-use** — drive a browser from the CLI
- **cloud** — Browser Use Cloud REST API (v2 & v3) + SDK reference
- **open-source** — `browser-use` Python library reference
- **qa** — QA-test a site/dev server and return a 1–5 score
- **remote-browser** — control a headless browser from a sandboxed machine
- **x402** — pay-per-request via crypto wallet

Each page mirrors the skills.sh layout minus the stats: skill description + install command + links to its skills.sh page and source dir. Descriptions are pulled from each skill's `SKILL.md` frontmatter.

## Notes

- "Skills" is overloaded in the docs: these are coding-agent skills (`SKILL.md`), distinct from the legacy cloud "skills = deterministic API endpoint" concept (`cloud/legacy/skills.mdx`). Happy to cross-link/relabel in a follow-up.
- The integration pages (claude-code, hermes-agent, openclaw, x402, browser-use-cli) still install individual skills inline; we could point them at this new catalog later.

## Changes

- `docs/docs.json` — new `Skills` nav group (only change to this file)
- `docs/open-source/examples/skills/*.mdx` — 7 new pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Skills section under Open Source → Examples that catalogs installable `browser-use` agent skills with one-line install commands. Improves discoverability with an overview and six skill pages.

- **New Features**
  - Added "Skills" sidebar group in `docs.json`.
  - Added 7 pages: overview + `browser-use`, `cloud`, `open-source`, `qa`, `remote-browser`, `x402`.
  - Each page includes a short description, `npx skills add … --skill <name>`, and links to skills.sh and source; `x402` clarifies USDC on Base and the no-API-key pay-per-request flow.

<sup>Written for commit 064a2250bb92e4771118b19bb209846c613cce6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

