### PR TITLE
fix(docs): route PostHog to EU ingestion host

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -384,7 +384,8 @@
   },
   "integrations": {
     "posthog": {
-      "apiKey": "phc_F8JMNjW1i2KbGUTaW1unnDdLSPCoyc52SGRU0JecaUh"
+      "apiKey": "phc_F8JMNjW1i2KbGUTaW1unnDdLSPCoyc52SGRU0JecaUh",
+      "apiHost": "https://eu.i.posthog.com"
     }
   },
   "redirects": [


### PR DESCRIPTION
## Problem
`docs.json` configures `integrations.posthog` with an **EU** project key (`phc_F8J…`) but **no `apiHost`**. PostHog-JS / Mintlify default `apiHost` to the **US** ingestion endpoint (`https://us.i.posthog.com`). An EU key sent to the US instance is rejected, so **docs pageviews never reach the EU project** — PostHog records **0 events** with `$host=docs.browser-use.com` despite analytics being "configured."

This makes `docs.browser-use.com` a complete analytics black box: we can't see which doc pages people read, the docs→cloud funnel, or attribute any docs-landing campaign (e.g. tweet CTAs that point at docs pages with UTMs).

## Fix
Add `"apiHost": "https://eu.i.posthog.com"` to the posthog integration so events route to the correct region.

## Why it's safe
- `apiHost` is an officially supported, optional field in Mintlify's `integrations.posthog` schema (`additionalProperties: false` still passes).
- Docs analytics currently produces **zero** data, so there is no existing behavior to regress — it can only start working.

## Verification after deploy
On `docs.browser-use.com`, `window.posthog.config.api_host` should be `https://eu.i.posthog.com`, and `$pageview` events with `$host=docs.browser-use.com` should begin appearing in project 38971.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route docs analytics to the EU PostHog ingestion host by setting `apiHost: https://eu.i.posthog.com` in `integrations.posthog`. This fixes dropped events for `docs.browser-use.com` so pageviews are recorded in the EU project.

<sup>Written for commit aad62323fae3ec33bfeb9fd89b4c3a49d4c60ac4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

