### PR TITLE
mention browser use cli 3

### DIFF
--- a/docs/cloud/agent-signup.mdx
+++ b/docs/cloud/agent-signup.mdx
@@ -103,7 +103,8 @@ Agents with shell access can use the Browser Use CLI after the REST flow returns
 
 ```bash
 uv tool install browser-use
-printf '%s\n' 'bu_...' | browser-use auth login --api-key-stdin
+export BROWSER_USE_API_KEY=bu_...
+browser-use auth status
 ```
 
 Replace `bu_...` with the key returned by the REST flow.

--- a/docs/cloud/agent-signup.mdx
+++ b/docs/cloud/agent-signup.mdx
@@ -97,14 +97,13 @@ Response:
 
 The claim URL is valid for 1 hour.
 
-## CLI flow
+## CLI usage
 
-Agents with shell access can use the Browser Use CLI instead of calling the REST endpoints directly:
+Agents with shell access can use the Browser Use CLI after the REST flow returns an API key:
 
 ```bash
-browser-use cloud signup
-browser-use cloud signup --verify <challenge-id> <answer>
-browser-use cloud signup --claim
+uv tool install browser-use
+browser-use auth login
 ```
 
-The CLI saves the API key to `~/.browser-use/config.json` after verification.
+Paste the returned `bu_...` key when prompted.

--- a/docs/cloud/agent-signup.mdx
+++ b/docs/cloud/agent-signup.mdx
@@ -103,7 +103,7 @@ Agents with shell access can use the Browser Use CLI after the REST flow returns
 
 ```bash
 uv tool install browser-use
-browser-use auth login
+printf '%s\n' 'bu_...' | browser-use auth login --api-key-stdin
 ```
 
-Paste the returned `bu_...` key when prompted.
+Replace `bu_...` with the key returned by the REST flow.

--- a/docs/cloud/guides/x402.mdx
+++ b/docs/cloud/guides/x402.mdx
@@ -112,21 +112,26 @@ const client = new BrowserUse(); // auto-detects from env
 Use this if you're in a language we don't ship an SDK for (Go, Rust, Ruby, etc.), or if you want to use other x402 APIs from the same client library. Hit `https://x402.api.browser-use.com` directly with any [x402 client library](https://github.com/coinbase/x402#all-available-reference-sdks):
 
 ```python
+import asyncio
+
 from x402 import x402Client
 from x402.http.clients import x402HttpxClient
 from x402.mechanisms.evm import EthAccountSigner
 from x402.mechanisms.evm.exact.register import register_exact_evm_client
 from eth_account import Account
 
-client = x402Client()
-register_exact_evm_client(client, EthAccountSigner(Account.from_key("0x...")))
+async def main():
+    client = x402Client()
+    register_exact_evm_client(client, EthAccountSigner(Account.from_key("0x...")))
 
-async with x402HttpxClient(client, timeout=120.0) as http:
-    response = await http.post(
-        "https://x402.api.browser-use.com/api/v3/sessions",
-        json={"task": "..."},
-    )
-    print(response.status_code, response.text[:500])
+    async with x402HttpxClient(client, timeout=120.0) as http:
+        response = await http.post(
+            "https://x402.api.browser-use.com/api/v3/sessions",
+            json={"task": "..."},
+        )
+        print(response.status_code, response.text[:500])
+
+asyncio.run(main())
 ```
 
 `https://x402.api.browser-use.com` exposes the same routes as `https://api.browser-use.com`. It supports every `/api/v2/*` and `/api/v3/*` route, gated by an x402 challenge instead of API key auth.
@@ -162,6 +167,8 @@ If you already have a Browser Use API key (for example, one created via the dash
 
 <CodeGroup>
 ```python Python
+import asyncio
+
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse(
@@ -169,7 +176,11 @@ client = AsyncBrowserUse(
     x402_private_key="0x...",             # wallet that pays
     base_url="https://x402.api.browser-use.com/api/v3",
 )
-result = await client.run("...")          # $5 USDC charged, credited to the API key's project
+async def main():
+    result = await client.run("...")      # $5 USDC charged, credited to the API key's project
+    print(result.output)
+
+asyncio.run(main())
 
 ```
 
@@ -201,10 +212,15 @@ To check how much credit that account has left, use the method below:
 
 <CodeGroup>
 ```python Python
+import asyncio
+
 from browser_use_sdk.v3 import get_wallet_balance
 
-balance = await get_wallet_balance("0x...")  # same wallet private key you pay with
-print(balance["total_credits_usd"])
+async def main():
+    balance = await get_wallet_balance("0x...")  # same wallet private key you pay with
+    print(balance["total_credits_usd"])
+
+asyncio.run(main())
 
 ```
 

--- a/docs/cloud/guides/x402.mdx
+++ b/docs/cloud/guides/x402.mdx
@@ -3,18 +3,21 @@ title: x402 (pay-per-request)
 description: "Pay for Browser Use Cloud with crypto (USDC on Base). ~30 seconds from wallet to first request."
 ---
 
+<!-- prettier-ignore-start -->
+
 [x402](https://www.x402.org) is a payment protocol [created by Coinbase](https://www.coinbase.com/developer-platform/discover/launches/x402) that lets APIs, or AI agents, charge for requests directly with crypto.
 
 x402 lets your code, or an autonomous AI agent, pay Browser Use Cloud directly with cryptocurrency. No account signup, no credit card, and no API key is needed. Your wallet is your identity.
 
 <Note>
-  **New to crypto?** Here's the gist: - **USDC** is a stablecoin pegged 1:1 to
-  the US dollar. 1 USDC = $1. - **Base** is a low-fee blockchain network
-  operated by Coinbase. Sending a payment costs fractions of a cent. -
-  **Wallet** = a public address (your "username") and a private key (your
-  "password"). The private key signs payments. - You'll need at least $5 of USDC
-  on Base in a wallet you control. The Claude Code quickstart below walks you
-  through everything from scratch.
+
+**New to crypto?** Here's the gist:
+
+- **USDC** is a stablecoin pegged 1:1 to the US dollar. 1 USDC = $1.
+- **Base** is a low-fee blockchain network operated by Coinbase. Sending a payment costs fractions of a cent.
+- **Wallet** = a public address (your "username") and a private key (your "password"). The private key signs payments.
+- You'll need at least $5 of USDC on Base in a wallet you control. The Claude Code quickstart below walks you through everything from scratch.
+
 </Note>
 
 **Three ways to start, ranked by laziness:**
@@ -59,8 +62,12 @@ Claude generates (or imports) a wallet, walks you through funding it via Coinbas
 The Browser Use SDK has built-in x402 support. Pass a wallet private key, and you're done.
 
 <CodeGroup>
-  ```bash Python pip install "browser-use-sdk[x402]" ``` ```bash TypeScript npm
-  install browser-use-sdk @x402/fetch @x402/evm viem ```
+```bash Python
+pip install "browser-use-sdk[x402]"
+```
+```bash TypeScript
+npm install browser-use-sdk @x402/fetch @x402/evm viem
+```
 </CodeGroup>
 
 <CodeGroup>
@@ -69,29 +76,31 @@ import asyncio
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 async def main():
-client = AsyncBrowserUse(x402_private_key="0x...") # EVM wallet w/ USDC on Base
-result = await client.run("Go to example.com and tell me the heading.")
-print(result.output)
+    client = AsyncBrowserUse(x402_private_key="0x...")  # EVM wallet w/ USDC on Base
+    result = await client.run("Go to example.com and tell me the heading.")
+    print(result.output)
 
 asyncio.run(main())
+```
 
-````
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
 
 const client = new BrowserUse({ x402PrivateKey: "0x..." });  // EVM wallet w/ USDC on Base
 const result = await client.run("Go to example.com and tell me the heading.");
 console.log(result.output);
-````
-
+```
 </CodeGroup>
 
 Or set `BROWSER_USE_X402_PRIVATE_KEY` in your env, and skip the constructor arg entirely:
 
 <CodeGroup>
-  ```python Python client = AsyncBrowserUse() # auto-detects from env ```
-  ```typescript TypeScript const client = new BrowserUse(); // auto-detects from
-  env ```
+```python Python
+client = AsyncBrowserUse()   # auto-detects from env
+```
+```typescript TypeScript
+const client = new BrowserUse(); // auto-detects from env
+```
 </CodeGroup>
 
 <Note>
@@ -156,13 +165,14 @@ If you already have a Browser Use API key (for example, one created via the dash
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse(
-api*key="bu*...", # existing API key getting topped up
-x402_private_key="0x...", # wallet that pays
-base_url="https://x402.api.browser-use.com/api/v3",
+    api_key="bu_...",                     # existing API key getting topped up
+    x402_private_key="0x...",             # wallet that pays
+    base_url="https://x402.api.browser-use.com/api/v3",
 )
-result = await client.run("...") # $5 USDC charged, credited to the API key's project
+result = await client.run("...")          # $5 USDC charged, credited to the API key's project
 
-````
+```
+
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
 
@@ -172,8 +182,7 @@ const client = new BrowserUse({
   baseUrl: "https://x402.api.browser-use.com/api/v3",
 });
 const result = await client.run("...");
-````
-
+```
 </CodeGroup>
 
 When the backend sees both a payment and a valid API key, the credit goes to the key's project rather than auto-creating a new wallet-keyed one. Useful for:
@@ -194,17 +203,17 @@ To check how much credit that account has left, use the method below:
 ```python Python
 from browser_use_sdk.v3 import get_wallet_balance
 
-balance = await get_wallet_balance("0x...") # same wallet private key you pay with
+balance = await get_wallet_balance("0x...")  # same wallet private key you pay with
 print(balance["total_credits_usd"])
 
-````
+```
+
 ```typescript TypeScript
 import { getWalletBalance } from "browser-use-sdk/v3";
 
 const balance = await getWalletBalance("0x...");  // same wallet private key you pay with
 console.log(balance.total_credits_usd);
-````
-
+```
 </CodeGroup>
 
 The response contains:
@@ -290,7 +299,8 @@ x402 = x402Client()
 register_exact_evm_client(x402, EthAccountSigner(Account.from_key("0x...")))
 client = AsyncBrowserUse(x402=x402)
 
-````
+```
+
 ```typescript TypeScript
 import { x402Client } from "@x402/fetch";
 import { ExactEvmScheme } from "@x402/evm";
@@ -300,8 +310,7 @@ import { BrowserUse } from "browser-use-sdk/v3";
 const x402 = new x402Client();
 x402.register("eip155:*", new ExactEvmScheme(privateKeyToAccount("0x...")));
 const client = new BrowserUse({ x402 });
-````
-
+```
 </CodeGroup>
 
 ## Troubleshooting
@@ -345,3 +354,5 @@ const client = new BrowserUse({ x402 });
 - [x402 protocol spec](https://www.x402.org)
 - [Standard API key auth](/cloud/quickstart) — alternative if you don't want pay-per-use
 - [`x402` Claude Code skill source](https://github.com/browser-use/browser-use/tree/main/skills/x402)
+
+<!-- prettier-ignore-end -->

--- a/docs/cloud/guides/x402.mdx
+++ b/docs/cloud/guides/x402.mdx
@@ -8,18 +8,21 @@ description: "Pay for Browser Use Cloud with crypto (USDC on Base). ~30 seconds 
 x402 lets your code, or an autonomous AI agent, pay Browser Use Cloud directly with cryptocurrency. No account signup, no credit card, and no API key is needed. Your wallet is your identity.
 
 <Note>
-  **New to crypto?** Here's the gist:
-  - **USDC** is a stablecoin pegged 1:1 to the US dollar. 1 USDC = $1.
-  - **Base** is a low-fee blockchain network operated by Coinbase. Sending a payment costs fractions of a cent.
-  - **Wallet** = a public address (your "username") and a private key (your "password"). The private key signs payments.
-  - You'll need at least $5 of USDC on Base in a wallet you control. The Claude Code quickstart below walks you through everything from scratch.
+  **New to crypto?** Here's the gist: - **USDC** is a stablecoin pegged 1:1 to
+  the US dollar. 1 USDC = $1. - **Base** is a low-fee blockchain network
+  operated by Coinbase. Sending a payment costs fractions of a cent. -
+  **Wallet** = a public address (your "username") and a private key (your
+  "password"). The private key signs payments. - You'll need at least $5 of USDC
+  on Base in a wallet you control. The Claude Code quickstart below walks you
+  through everything from scratch.
 </Note>
 
 **Three ways to start, ranked by laziness:**
 
 <CardGroup cols={3}>
   <Card title="Claude Code" icon="terminal" href="#claude-code-quickstart">
-    One command. Claude does the wallet setup, funding walkthrough, and verification for you.
+    One command. Claude does the wallet setup, funding walkthrough, and
+    verification for you.
   </Card>
   <Card title="SDK" icon="code" href="#sdk-quickstart">
     One line in your Python or TypeScript app. Bring your own wallet.
@@ -46,7 +49,9 @@ Then in Claude Code:
 Claude generates (or imports) a wallet, walks you through funding it via Coinbase, writes `BROWSER_USE_X402_PRIVATE_KEY` to your `.env`, installs the SDK, and runs a verification task. Total: ~2 minutes if you have a crypto wallet.
 
 <Tip>
-  Already have a Browser Use Cloud account? The skill detects this and switches to **top-up mode**, adding credits to that existing account instead of creating a new, wallet-keyed one.
+  Already have a Browser Use Cloud account? The skill detects this and switches
+  to **top-up mode**, adding credits to that existing account instead of
+  creating a new, wallet-keyed one.
 </Tip>
 
 ## SDK quickstart
@@ -54,12 +59,8 @@ Claude generates (or imports) a wallet, walks you through funding it via Coinbas
 The Browser Use SDK has built-in x402 support. Pass a wallet private key, and you're done.
 
 <CodeGroup>
-```bash Python
-pip install "browser-use-sdk[x402]"
-```
-```bash TypeScript
-npm install browser-use-sdk @x402/fetch @x402/evm viem
-```
+  ```bash Python pip install "browser-use-sdk[x402]" ``` ```bash TypeScript npm
+  install browser-use-sdk @x402/fetch @x402/evm viem ```
 </CodeGroup>
 
 <CodeGroup>
@@ -68,30 +69,29 @@ import asyncio
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 async def main():
-    client = AsyncBrowserUse(x402_private_key="0x...")  # EVM wallet w/ USDC on Base
-    result = await client.run("Go to example.com and tell me the heading.")
-    print(result.output)
+client = AsyncBrowserUse(x402_private_key="0x...") # EVM wallet w/ USDC on Base
+result = await client.run("Go to example.com and tell me the heading.")
+print(result.output)
 
 asyncio.run(main())
-```
+
+````
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
 
 const client = new BrowserUse({ x402PrivateKey: "0x..." });  // EVM wallet w/ USDC on Base
 const result = await client.run("Go to example.com and tell me the heading.");
 console.log(result.output);
-```
+````
+
 </CodeGroup>
 
 Or set `BROWSER_USE_X402_PRIVATE_KEY` in your env, and skip the constructor arg entirely:
 
 <CodeGroup>
-```python Python
-client = AsyncBrowserUse()   # auto-detects from env
-```
-```typescript TypeScript
-const client = new BrowserUse();  // auto-detects from env
-```
+  ```python Python client = AsyncBrowserUse() # auto-detects from env ```
+  ```typescript TypeScript const client = new BrowserUse(); // auto-detects from
+  env ```
 </CodeGroup>
 
 <Note>
@@ -130,35 +130,39 @@ async with x402HttpxClient(client, timeout=120.0) as http:
 
 You do **not** need ETH for gas. We use [EIP-3009](https://eips.ethereum.org/EIPS/eip-3009), so you sign offchain, and the facilitator pays gas.
 
-<Note>
-  No wallet yet? Jump to [Wallet setup](#wallet-setup) below.
-</Note>
+<Note>No wallet yet? Jump to [Wallet setup](#wallet-setup) below.</Note>
 
 ## Pricing and credits
 
 Each x402 payment adds `$5` of credits to your project by default (or `$1` if your wallet falls back to the smaller option). When credits hit zero, the next request returns `402`, and the SDK automatically signs another payment to keep going. **You don't manage top-ups manually; just make sure your wallet has enough USDC for your expected usage.**
 
 <Warning>
-  **Mid-task drain still terminates the task.** Browser Use sessions run on a worker that doesn't see x402, so once a long-running task starts and burns through its credits, it stops with `INSUFFICIENT_CREDITS` — it does not pause and wait for the next x402 payment. The `$5` default exists so most tasks complete without hitting this; for expensive models (e.g. Opus) or long sessions, pre-fund with multiple requests before kicking off the task.
+  **Mid-task drain still terminates the task.** Browser Use sessions run on a
+  worker that doesn't see x402, so once a long-running task starts and burns
+  through its credits, it stops with `INSUFFICIENT_CREDITS` — it does not pause
+  and wait for the next x402 payment. The `$5` default exists so most tasks
+  complete without hitting this; for expensive models (e.g. Opus) or long
+  sessions, pre-fund with multiple requests before kicking off the task.
 </Warning>
 
 See the [pricing page](https://browser-use.com/pricing) for model and browser costs.
 
 ## Topping up an existing account
 
-If you already have a Browser Use API key (for example, one created via `browser-use cloud signup` or the dashboard), you can use x402 to add credits to **that** account instead of creating a new project based on your crypto wallet. Send your existing API key alongside the payment:
+If you already have a Browser Use API key (for example, one created via the dashboard or the agent signup REST flow), you can use x402 to add credits to **that** account instead of creating a new project based on your crypto wallet. Send your existing API key alongside the payment:
 
 <CodeGroup>
 ```python Python
 from browser_use_sdk.v3 import AsyncBrowserUse
 
 client = AsyncBrowserUse(
-    api_key="bu_...",                     # existing API key getting topped up
-    x402_private_key="0x...",             # wallet that pays
-    base_url="https://x402.api.browser-use.com/api/v3",
+api*key="bu*...", # existing API key getting topped up
+x402_private_key="0x...", # wallet that pays
+base_url="https://x402.api.browser-use.com/api/v3",
 )
-result = await client.run("...")          # $5 USDC charged, credited to the API key's project
-```
+result = await client.run("...") # $5 USDC charged, credited to the API key's project
+
+````
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
 
@@ -168,7 +172,8 @@ const client = new BrowserUse({
   baseUrl: "https://x402.api.browser-use.com/api/v3",
 });
 const result = await client.run("...");
-```
+````
+
 </CodeGroup>
 
 When the backend sees both a payment and a valid API key, the credit goes to the key's project rather than auto-creating a new wallet-keyed one. Useful for:
@@ -189,32 +194,42 @@ To check how much credit that account has left, use the method below:
 ```python Python
 from browser_use_sdk.v3 import get_wallet_balance
 
-balance = await get_wallet_balance("0x...")  # same wallet private key you pay with
+balance = await get_wallet_balance("0x...") # same wallet private key you pay with
 print(balance["total_credits_usd"])
-```
+
+````
 ```typescript TypeScript
 import { getWalletBalance } from "browser-use-sdk/v3";
 
 const balance = await getWalletBalance("0x...");  // same wallet private key you pay with
 console.log(balance.total_credits_usd);
-```
+````
+
 </CodeGroup>
 
 The response contains:
 
-| Field | Description |
-| --- | --- |
-| `wallet` | The wallet address (lowercased) |
-| `project_id` | The account (project) tied to your wallet that the credits live in |
-| `total_credits_usd` | Your remaining Browser Use credit balance, in USD |
+| Field                    | Description                                                                     |
+| ------------------------ | ------------------------------------------------------------------------------- |
+| `wallet`                 | The wallet address (lowercased)                                                 |
+| `project_id`             | The account (project) tied to your wallet that the credits live in              |
+| `total_credits_usd`      | Your remaining Browser Use credit balance, in USD                               |
 | `additional_credits_usd` | Of that total, the portion added via x402 top-ups (excludes any plan allowance) |
 
 <Note>
-  This is for accounts created from a wallet (the default x402 mode). If you're [topping up an existing account](#topping-up-an-existing-account), check that account's balance the normal way with your API key via `client.billing.account()`. A wallet that has never paid yet has no account, so the call returns `404` until the first payment.
+  This is for accounts created from a wallet (the default x402 mode). If you're
+  [topping up an existing account](#topping-up-an-existing-account), check that
+  account's balance the normal way with your API key via
+  `client.billing.account()`. A wallet that has never paid yet has no account,
+  so the call returns `404` until the first payment.
 </Note>
 
 <Accordion title="How the balance check works">
-  The SDK signs a fixed, server-defined message ([EIP-191](https://eips.ethereum.org/EIPS/eip-191), the same "Sign-In with Ethereum" mechanism) with your wallet's private key. The signature proves you control the address without moving any funds. The server recovers the signer, matches it to the wallet's project, and returns the balance.
+  The SDK signs a fixed, server-defined message
+  ([EIP-191](https://eips.ethereum.org/EIPS/eip-191), the same "Sign-In with
+  Ethereum" mechanism) with your wallet's private key. The signature proves you
+  control the address without moving any funds. The server recovers the signer,
+  matches it to the wallet's project, and returns the balance.
 </Accordion>
 
 ## How it works
@@ -234,21 +249,29 @@ If you don't have a wallet ready, here's an easy way to set one up using **MetaM
 
 <Steps>
   <Step title="Install MetaMask (or your wallet of choice)">
-    Get the [MetaMask browser extension](https://metamask.io) via the official site only. Create a new wallet, save the seed phrase somewhere offline, set a password.
+    Get the [MetaMask browser extension](https://metamask.io) via the official
+    site only. Create a new wallet, save the seed phrase somewhere offline, set
+    a password.
   </Step>
   <Step title="Add the Base network">
-    By default, most wallets only show Ethereum. You need to add **Base** (the network we accept payments on) so your wallet can hold USDC there.
+    By default, most wallets only show Ethereum. You need to add **Base** (the
+    network we accept payments on) so your wallet can hold USDC there.
   </Step>
   <Step title="Get USDC into your wallet on Base">
-    Click **"Buy"** inside MetaMask. Pick **USDC**, set network to **Base**, and pay with credit card, bank, etc. The USDC lands directly in your wallet.
+    Click **"Buy"** inside MetaMask. Pick **USDC**, set network to **Base**, and
+    pay with credit card, bank, etc. The USDC lands directly in your wallet.
   </Step>
   <Step title="Export the private key">
-    In MetaMask: click the account menu → **Account details** → **Private keys** → enter your password → copy. That string (starts with `0x`) is your `BROWSER_USE_X402_PRIVATE_KEY`. Other wallets have similar export options in their account settings.
+    In MetaMask: click the account menu → **Account details** → **Private keys**
+    → enter your password → copy. That string (starts with `0x`) is your
+    `BROWSER_USE_X402_PRIVATE_KEY`. Other wallets have similar export options in
+    their account settings.
   </Step>
 </Steps>
 
 <Warning>
-  Wallets hold real money, and anyone with the private key can drain it. Be careful with your keys.
+  Wallets hold real money, and anyone with the private key can drain it. Be
+  careful with your keys.
 </Warning>
 
 ## Advanced: bring your own x402 client
@@ -266,7 +289,8 @@ from browser_use_sdk.v3 import AsyncBrowserUse
 x402 = x402Client()
 register_exact_evm_client(x402, EthAccountSigner(Account.from_key("0x...")))
 client = AsyncBrowserUse(x402=x402)
-```
+
+````
 ```typescript TypeScript
 import { x402Client } from "@x402/fetch";
 import { ExactEvmScheme } from "@x402/evm";
@@ -276,7 +300,8 @@ import { BrowserUse } from "browser-use-sdk/v3";
 const x402 = new x402Client();
 x402.register("eip155:*", new ExactEvmScheme(privateKeyToAccount("0x...")));
 const client = new BrowserUse({ x402 });
-```
+````
+
 </CodeGroup>
 
 ## Troubleshooting
@@ -287,19 +312,28 @@ const client = new BrowserUse({ x402 });
 
     - **Wallet has no USDC on Base.** Check your balance. If empty, top it up.
     - **Your HTTP client isn't x402-aware.** Plain `requests` / `fetch` just sees a 402 and stops; it doesn't know how to read the payment instructions and sign a payment. Use the SDK (which handles this automatically), or wrap your HTTP client with one of the [x402 client libraries](https://github.com/coinbase/x402#all-available-reference-sdks).
+
   </Accordion>
 
-  <Accordion title="ImportError / Cannot find module '@x402/fetch'">
-    You haven't installed the optional x402 deps. Run `pip install "browser-use-sdk[x402]"` (Python) or `npm install @x402/fetch @x402/evm viem` (TypeScript).
-  </Accordion>
+<Accordion title="ImportError / Cannot find module '@x402/fetch'">
+  You haven't installed the optional x402 deps. Run `pip install
+  "browser-use-sdk[x402]"` (Python) or `npm install @x402/fetch @x402/evm viem`
+  (TypeScript).
+</Accordion>
 
-  <Accordion title='HTTP 503 with "payment was not settled... you were not charged"'>
-    We verified your payment request but couldn't credit your project, so we deliberately did not settle on-chain. No USDC was moved, so just retry. This is rare.
-  </Accordion>
+<Accordion title='HTTP 503 with "payment was not settled... you were not charged"'>
+  We verified your payment request but couldn't credit your project, so we
+  deliberately did not settle on-chain. No USDC was moved, so just retry. This
+  is rare.
+</Accordion>
 
-  <Accordion title="Insufficient credits despite paying">
-    Wait a few seconds. Settlement and credit grant happen in the same request, but the response may be sent before the credit grant fully commits. If credits still show `$0` after a few minutes, contact support with your wallet address. (Conversely, if a payment settles but the request itself then fails, we automatically reclaim the credits so you aren't charged for nothing.)
-  </Accordion>
+<Accordion title="Insufficient credits despite paying">
+  Wait a few seconds. Settlement and credit grant happen in the same request,
+  but the response may be sent before the credit grant fully commits. If credits
+  still show `$0` after a few minutes, contact support with your wallet address.
+  (Conversely, if a payment settles but the request itself then fails, we
+  automatically reclaim the credits so you aren't charged for nothing.)
+</Accordion>
 
   <Accordion title="Wallet on the wrong network">
     `eip155:8453` is Base mainnet; `eip155:84532` is Base Sepolia testnet. Browser Use Cloud only accepts mainnet. Withdrawing USDC to Sepolia from Coinbase is **not** the same as Base mainnet, even though both use the same wallet address.

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -173,19 +173,6 @@ Response:
 
 The claim URL is valid for 1 hour.
 
-## CLI flow
-
-Agents with shell access can use the Browser Use CLI instead of calling the REST endpoints directly:
-
-```bash
-browser-use cloud signup
-browser-use cloud signup --verify <challenge-id> <answer>
-browser-use cloud signup --claim
-```
-
-The CLI saves the API key to `~/.browser-use/config.json` after verification.
-
-
 # Introduction
 Source: https://docs.browser-use.com/cloud/agent/quickstart
 

--- a/docs/cloud/tutorials/integrations/claude-code.mdx
+++ b/docs/cloud/tutorials/integrations/claude-code.mdx
@@ -24,7 +24,7 @@ browser-use doctor
 Install the Browser Use skill into Claude Code:
 
 ```bash
-browser-use skill install
+npx skills add https://github.com/browser-use/browser-use --skill browser-use
 ```
 
 **4. Authenticate for cloud browsers**
@@ -55,7 +55,7 @@ Install the Browser Use CLI and skill:
 
 ```bash
 uv tool install browser-use
-browser-use skill install
+npx skills add https://github.com/browser-use/browser-use --skill browser-use
 ```
 
 Claude Code can follow the [REST flow](/cloud/agent-signup#rest-flow) to request and verify a challenge, then put the returned key in its shell environment:

--- a/docs/cloud/tutorials/integrations/claude-code.mdx
+++ b/docs/cloud/tutorials/integrations/claude-code.mdx
@@ -58,7 +58,11 @@ uv tool install browser-use
 browser-use skill install
 ```
 
-Claude Code can follow the [REST flow](/cloud/agent-signup#rest-flow) to request and verify a challenge, then use the returned API key with `browser-use auth login`.
+Claude Code can follow the [REST flow](/cloud/agent-signup#rest-flow) to request and verify a challenge, then save the returned API key:
+
+```bash
+printf '%s\n' 'bu_...' | browser-use auth login --api-key-stdin
+```
 
 ### Claim the account (optional)
 

--- a/docs/cloud/tutorials/integrations/claude-code.mdx
+++ b/docs/cloud/tutorials/integrations/claude-code.mdx
@@ -10,7 +10,7 @@ description: Give Claude Code cloud browser automation with Browser Use.
 **1. Install the CLI**
 
 ```bash
-curl -fsSL https://browser-use.com/cli/install.sh | bash
+uv tool install browser-use
 ```
 
 **2. Verify the installation**
@@ -21,19 +21,18 @@ browser-use doctor
 
 **3. Install the skill**
 
-The Browser Use skill teaches Claude Code the full CLI command set. Install it from [skills.sh](https://skills.sh/browser-use/browser-use/browser-use):
+Install the Browser Use skill into Claude Code:
 
 ```bash
-npx skills add https://github.com/browser-use/browser-use --skill browser-use
+browser-use skill install
 ```
 
-**4. Connect to cloud browsers**
+**4. Authenticate for cloud browsers**
 
-Sign up at [cloud.browser-use.com](https://cloud.browser-use.com) and connect:
+Sign up at [cloud.browser-use.com](https://cloud.browser-use.com), then authenticate:
 
 ```bash
-browser-use cloud login <your-api-key>
-browser-use cloud connect
+browser-use auth login
 ```
 
 Or let Claude Code provision a free API key itself — see [Agent Self-Registration](#agent-self-registration) below.
@@ -46,47 +45,24 @@ Claude Code uses its bash tool to run CLI commands directly:
 > Use browser-use to open github.com/trending and summarize the top repos
 ```
 
-For the complete CLI reference and advanced features like sessions, tunnels, and Python execution, see the [Browser Use CLI docs](https://docs.browser-use.com/open-source/browser-use-cli).
+For the complete CLI reference and Python execution examples, see the [Browser Use CLI docs](https://docs.browser-use.com/open-source/browser-use-cli).
 
 ## Agent Self-Registration
 
 Claude Code can provision its own Browser Use API key autonomously — no human interaction needed. The free tier includes unlimited browser hours, free proxies in 195+ countries, persistent browser profiles, CAPTCHA solving, and stealth browsing at zero cost.
 
-Install the Browser Use CLI:
+Install the Browser Use CLI and skill:
 
 ```bash
-curl -fsSL https://browser-use.com/cli/install.sh | bash
+uv tool install browser-use
+browser-use skill install
 ```
 
-Claude Code runs two CLI commands using its bash tool:
-
-**1. Request a challenge**
-
-```bash
-browser-use cloud signup
-```
-
-Returns a `Challenge ID` and `Challenge` — an obfuscated math problem that requires LLM reasoning to solve.
-
-**2. Solve the challenge and verify**
-
-Claude Code solves the math problem, then verifies with the answer (a string with 2 decimal places, e.g. `"13.60"`):
-
-```bash
-browser-use cloud signup --verify <challenge-id> <answer>
-```
-
-The CLI saves the API key to `~/.browser-use/config.json` automatically. No extra configuration needed — Claude Code can start using cloud browser commands immediately.
+Claude Code can follow the [REST flow](/cloud/agent-signup#rest-flow) to request and verify a challenge, then use the returned API key with `browser-use auth login`.
 
 ### Claim the account (optional)
 
-If the human wants to see the account in the dashboard later:
-
-```bash
-browser-use cloud signup --claim
-```
-
-Returns a claim URL valid for 1 hour. The human can follow the link to sign up and claim the agent-created account.
+If the human wants to see the account in the dashboard later, use the [claim endpoint](/cloud/agent-signup#claim-the-account). The returned claim URL is valid for 1 hour.
 
 ## Pay with USDC via x402
 

--- a/docs/cloud/tutorials/integrations/claude-code.mdx
+++ b/docs/cloud/tutorials/integrations/claude-code.mdx
@@ -58,10 +58,11 @@ uv tool install browser-use
 browser-use skill install
 ```
 
-Claude Code can follow the [REST flow](/cloud/agent-signup#rest-flow) to request and verify a challenge, then save the returned API key:
+Claude Code can follow the [REST flow](/cloud/agent-signup#rest-flow) to request and verify a challenge, then put the returned key in its shell environment:
 
 ```bash
-printf '%s\n' 'bu_...' | browser-use auth login --api-key-stdin
+export BROWSER_USE_API_KEY=bu_...
+browser-use auth status
 ```
 
 ### Claim the account (optional)

--- a/docs/cloud/tutorials/integrations/claude-managed-agents.mdx
+++ b/docs/cloud/tutorials/integrations/claude-managed-agents.mdx
@@ -5,7 +5,7 @@ description: Give Anthropic's Claude Managed Agents a stealth cloud browser via 
 
 [Claude Managed Agents](https://platform.claude.com/docs/en/managed-agents) run on Anthropic's hosted platform. Install the `browser-use` CLI in the agent's environment and it can drive a stealth cloud browser — with proxies, CAPTCHA solving, live view, and recording. Your API key stays in a credential vault; the model never sees it.
 
-The sandbox can't run a local browser, so the agent connects to **Browser Use Cloud** with `browser-use cloud connect`.
+The sandbox can't run a local browser, so the agent starts a named Browser Use Cloud browser and drives it with `browser-use <<'PY'` Python snippets.
 
 ## 1. Create an environment
 
@@ -28,11 +28,11 @@ config:
 
 Store your key as an environment variable so the CLI reads it and the model never does. Get one at [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1).
 
-| Field | Value |
-|-------|-------|
-| Type | Environment variable |
-| Name | `BROWSER_USE_API_KEY` |
-| Value | `bu_...` |
+| Field | Value                 |
+| ----- | --------------------- |
+| Type  | Environment variable  |
+| Name  | `BROWSER_USE_API_KEY` |
+| Value | `bu_...`              |
 
 ## 3. Create the agent
 
@@ -45,13 +45,18 @@ model:
 description: Drives a stealth cloud browser with the Browser Use CLI.
 system: |
   You are a browser agent. Use the `browser-use` CLI to complete web tasks.
-  Always run `browser-use cloud connect` first to provision a remote browser —
-  never launch a local browser. Then: `browser-use open <url>`,
-  `browser-use state` (clickable elements), `browser-use click <i>`,
-  `browser-use type "<text>"`, `browser-use eval "<js>"`.
+  Never launch a local browser in this sandbox. Start a named cloud browser:
+  browser-use <<'PY'
+  start_remote_daemon("managed")
+  PY
+  Then run browser work through the same name:
+  BU_NAME=managed browser-use <<'PY'
+  new_tab("https://example.com")
+  print(page_info())
+  PY
   Your BROWSER_USE_API_KEY is in the environment; never print it.
 tools:
-  - type: agent_toolset_20260401   # shell access so the agent can run the CLI
+  - type: agent_toolset_20260401 # shell access so the agent can run the CLI
     default_config:
       enabled: true
       permission_policy:
@@ -74,8 +79,10 @@ curl -sS "https://api.anthropic.com/v1/sessions/$SESSION_ID/events?beta=true" \
 
 ## 5. Watch it run
 
-The agent runs `browser-use cloud connect` → `open` → `state` → `eval`, then returns the result. The session shows up in [cloud.browser-use.com](https://cloud.browser-use.com) → **Remote Browsers** with a **Live View** and an **mp4 recording**.
+The agent starts a named cloud browser, runs Python helper snippets through `browser-use`, then returns the result. The session shows up in [cloud.browser-use.com](https://cloud.browser-use.com) → **Remote Browsers** with a **Live View** and an **mp4 recording**.
 
 <Tip>
-Always use `browser-use cloud connect` — the Managed Agents sandbox has no GUI, so a local browser won't start. Cloud mode also gives you stealth, residential proxies, live view, and recording.
+  Always use a cloud browser — the Managed Agents sandbox has no GUI, so a local
+  browser won't start. Cloud mode also gives you stealth, residential proxies,
+  live view, and recording.
 </Tip>

--- a/docs/cloud/tutorials/integrations/hermes-agent.mdx
+++ b/docs/cloud/tutorials/integrations/hermes-agent.mdx
@@ -119,10 +119,11 @@ For the cloud browser backend (Option 1):
 hermes config set BROWSER_USE_API_KEY <api-key>
 ```
 
-For CLI mode (Option 2), save the key for the CLI:
+For CLI mode (Option 2), put the key in the agent's shell environment:
 
 ```bash
-printf '%s\n' 'bu_...' | browser-use auth login --api-key-stdin
+export BROWSER_USE_API_KEY=bu_...
+browser-use auth status
 ```
 
 ### Claim the account (optional)

--- a/docs/cloud/tutorials/integrations/hermes-agent.mdx
+++ b/docs/cloud/tutorials/integrations/hermes-agent.mdx
@@ -52,14 +52,14 @@ Just chat with Hermes — any browsing tasks automatically route through Browser
 
 ## Option 2: Browser Use CLI
 
-The [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli) is a standalone tool that gives Hermes browser automation through terminal commands. Hermes drives the browser directly via its terminal tool — giving you shared browser sessions across agents, persistent logins and cookies, profile management, and access to Browser Use's full command surface.
+The [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli) is a standalone tool that gives Hermes browser automation through terminal commands. Hermes drives the browser directly via its terminal tool, using Browser Harness and Python helpers through the `browser-use` command.
 
 ### Setup
 
 **1. Install the CLI**
 
 ```bash
-curl -fsSL https://browser-use.com/cli/install.sh | bash
+uv tool install browser-use
 ```
 
 **2. Verify the installation**
@@ -70,20 +70,20 @@ browser-use doctor
 
 **3. Install the skill**
 
-The Browser Use skill teaches Hermes the full CLI command set. Install it from [skills.sh](https://skills.sh/browser-use/browser-use/browser-use):
+Install the Browser Use skill into Hermes:
 
 ```bash
-hermes skills install skills-sh/browser-use/browser-use/browser-use
+browser-use skill install
 ```
 
 Or ask Hermes directly in chat to install it.
 
-**4. Connect to cloud browsers**
+**4. Authenticate for cloud browsers**
 
-Log in with your API key:
+Authenticate with your API key:
 
 ```bash
-browser-use cloud login <your-api-key>
+browser-use auth login
 ```
 
 Or let the agent provision one itself — see [Agent Self-Registration](#agent-self-registration) below.
@@ -96,54 +96,31 @@ Once the skill is loaded, Hermes can drive the browser through CLI commands via 
 > Use browser-use to open github.com/trending and summarize the top repos
 ```
 
-For the complete CLI reference and advanced features like cloud browsers, tunnels, sessions, and Python execution, see the [Browser Use CLI docs](https://docs.browser-use.com/open-source/browser-use-cli).
+For the complete CLI reference and Python execution examples, see the [Browser Use CLI docs](https://docs.browser-use.com/open-source/browser-use-cli).
 
 ## Agent Self-Registration
 
 Hermes can provision its own Browser Use API key autonomously — no human interaction needed. This works with both options above.
 
-Install the Browser Use CLI:
+Install the Browser Use CLI and skill:
 
 ```bash
-curl -fsSL https://browser-use.com/cli/install.sh | bash
+uv tool install browser-use
+browser-use skill install
 ```
 
-The agent runs three CLI commands using its terminal tool:
+The agent can follow the [REST flow](/cloud/agent-signup#rest-flow) to request and verify a challenge, then use the returned API key.
 
-**1. Request a challenge**
-
-```bash
-browser-use cloud signup
-```
-
-Returns a `Challenge ID` and `Challenge` — an obfuscated math problem that requires LLM reasoning to solve.
-
-**2. Solve the challenge and verify**
-
-The agent solves the math problem, then verifies with the answer (a string with 2 decimal places, e.g. `"13.60"`):
-
-```bash
-browser-use cloud signup --verify <challenge-id> <answer>
-```
-
-The CLI saves the API key to `~/.browser-use/config.json` automatically.
-
-**3. Copy the key to Hermes config**
+**Copy the key to Hermes config**
 
 For the cloud browser backend (Option 1):
 
 ```bash
-hermes config set BROWSER_USE_API_KEY $(browser-use config get api_key)
+hermes config set BROWSER_USE_API_KEY <api-key>
 ```
 
-For CLI mode (Option 2), the key is already saved — no extra step needed.
+For CLI mode (Option 2), run `browser-use auth login` and paste the key.
 
 ### Claim the account (optional)
 
-If the human wants to see the account in the dashboard later:
-
-```bash
-browser-use cloud signup --claim
-```
-
-Returns a claim URL valid for 1 hour. The human can follow the link to sign up and claim the agent-created account.
+If the human wants to see the account in the dashboard later, use the [claim endpoint](/cloud/agent-signup#claim-the-account). The returned claim URL is valid for 1 hour.

--- a/docs/cloud/tutorials/integrations/hermes-agent.mdx
+++ b/docs/cloud/tutorials/integrations/hermes-agent.mdx
@@ -119,7 +119,11 @@ For the cloud browser backend (Option 1):
 hermes config set BROWSER_USE_API_KEY <api-key>
 ```
 
-For CLI mode (Option 2), run `browser-use auth login` and paste the key.
+For CLI mode (Option 2), save the key for the CLI:
+
+```bash
+printf '%s\n' 'bu_...' | browser-use auth login --api-key-stdin
+```
 
 ### Claim the account (optional)
 

--- a/docs/cloud/tutorials/integrations/hermes-agent.mdx
+++ b/docs/cloud/tutorials/integrations/hermes-agent.mdx
@@ -73,7 +73,7 @@ browser-use doctor
 Install the Browser Use skill into Hermes:
 
 ```bash
-browser-use skill install
+npx skills add https://github.com/browser-use/browser-use --skill browser-use
 ```
 
 Or ask Hermes directly in chat to install it.
@@ -106,7 +106,7 @@ Install the Browser Use CLI and skill:
 
 ```bash
 uv tool install browser-use
-browser-use skill install
+npx skills add https://github.com/browser-use/browser-use --skill browser-use
 ```
 
 The agent can follow the [REST flow](/cloud/agent-signup#rest-flow) to request and verify a challenge, then use the returned API key.

--- a/docs/cloud/tutorials/integrations/openclaw.mdx
+++ b/docs/cloud/tutorials/integrations/openclaw.mdx
@@ -73,7 +73,7 @@ The Browser Use CLI is a standalone tool that gives any OpenClaw agent browser a
 **1. Install the CLI**
 
 ```bash
-curl -fsSL https://browser-use.com/cli/install.sh | bash
+uv tool install browser-use
 ```
 
 **2. Verify the installation**
@@ -84,12 +84,12 @@ browser-use doctor
 
 **3. Install the skill**
 
-Ask your OpenClaw agent to install it directly from [ClawHub](https://clawhub.ai/ShawnPana/browser-use), or install from [skills.sh](https://skills.sh/browser-use/browser-use/browser-use):
+Install the Browser Use skill into your coding agent:
 
 ```bash
-npx skills add https://github.com/browser-use/browser-use --skill browser-use
+browser-use skill install
 ```
 
-Once the skill is loaded, OpenClaw agents can use the `browser-use` CLI to navigate pages, click elements, fill forms, take screenshots, extract data, and more. The skill file teaches the agent the full command set.
+Once the skill is loaded, OpenClaw agents can use the `browser-use` CLI to drive pages through Browser Harness and Python helpers.
 
-For the complete CLI reference and advanced features like cloud browsers, tunnels, sessions, and Python execution, see the [README](https://github.com/browser-use/browser-use/blob/main/browser_use/skill_cli/README.md) and the [Browser Use docs](https://docs.browser-use.com).
+For the complete CLI reference, see the [Browser Use CLI docs](https://docs.browser-use.com/open-source/browser-use-cli).

--- a/docs/cloud/tutorials/integrations/openclaw.mdx
+++ b/docs/cloud/tutorials/integrations/openclaw.mdx
@@ -87,7 +87,7 @@ browser-use doctor
 Install the Browser Use skill into your coding agent:
 
 ```bash
-browser-use skill install
+npx skills add https://github.com/browser-use/browser-use --skill browser-use
 ```
 
 Once the skill is loaded, OpenClaw agents can use the `browser-use` CLI to drive pages through Browser Harness and Python helpers.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -173,19 +173,6 @@ Response:
 
 The claim URL is valid for 1 hour.
 
-## CLI flow
-
-Agents with shell access can use the Browser Use CLI instead of calling the REST endpoints directly:
-
-```bash
-browser-use cloud signup
-browser-use cloud signup --verify <challenge-id> <answer>
-browser-use cloud signup --claim
-```
-
-The CLI saves the API key to `~/.browser-use/config.json` after verification.
-
-
 # Introduction
 Source: https://docs.browser-use.com/cloud/agent/quickstart
 

--- a/docs/open-source/browser-use-cli.mdx
+++ b/docs/open-source/browser-use-cli.mdx
@@ -1,463 +1,88 @@
 ---
 title: "Browser Use CLI"
-description: "Fast, persistent browser automation from the command line."
+description: "Direct browser control for coding agents."
 icon: "terminal"
 ---
 
-The Browser Use CLI (`browser-use`) is the command-line interface for the Browser Use platform. It does two things:
+The Browser Use CLI (`browser-use`) gives coding agents a direct browser-control surface backed by [Browser Harness](https://github.com/browser-use/browser-harness). Agents run small Python snippets with browser helpers already available, then inspect, click, type, screenshot, and recover using the same coding loop they use everywhere else.
 
-1. **Direct browser control** — navigate pages, click elements, fill forms, upload files, take screenshots, run JavaScript. Supports three browser modes: managed headless Chromium, real Chrome with existing user profiles and logins, and cloud-hosted browsers via the Browser Use Cloud API. A persistent background daemon keeps the browser alive between commands for fast ~50ms latency.
-
-2. **Cloud platform management** — a generic REST passthrough to the Browser Use API (v2 and v3) for managing agent tasks, cloud browser sessions, profiles, workspaces, files, skills, and billing. Anything available in the cloud dashboard is accessible from the terminal.
-
-The core browser workflow is: navigate to a page, run `state` to get numbered element indices, then interact using those indices. The cloud workflow is: `cloud login` to authenticate, then use `cloud v2`/`cloud v3` commands to hit any API endpoint, or `cloud connect` to provision and drive a cloud browser directly.
-
-## Installation
-
-### Prerequisites
-
-| Platform | Requirements |
-|----------|-------------|
-| **macOS** | Python 3.11+ (installer will use Homebrew if needed) |
-| **Linux** | Python 3.11+ (installer will use apt if needed) |
-| **Windows** | [Git for Windows](https://git-scm.com/download/win), Python 3.11+ |
-
-### One-Line Install (Recommended)
-
-**macOS / Linux:**
-```bash
-curl -fsSL https://browser-use.com/cli/install.sh | bash
-```
-
-**Windows** (run in PowerShell):
-```powershell
-& "C:\Program Files\Git\bin\bash.exe" -c 'curl -fsSL https://browser-use.com/cli/install.sh | bash'
-```
-
-### Install the Skill
-
-The CLI is most powerful when paired with its skill, which gives your coding agent full context on every command, flag, and workflow. It is **highly recommended** to install the skill alongside the CLI:
+## Install the CLI
 
 ```bash
-npx skills add https://github.com/browser-use/browser-use --skill browser-use
+uv tool install browser-use
+browser-use --help
 ```
 
-### Post-Install
-```bash
-browser-use doctor   # Validate installation
-browser-use setup    # Run setup wizard (optional)
-```
+For one-off runs without a permanent tool install, use `uvx browser-use`.
 
-### Manual Installation
+## Install the Agent Skill
 
-If you prefer not to use the one-line installer:
+This adds Browser Use instructions to Claude Code, Codex, and other coding agents:
 
 ```bash
-# 1. Install the package
-uv pip install browser-use
-
-# 2. Install Chromium
-browser-use install
-
-# 3. Validate
-browser-use doctor
+browser-use skill install
 ```
 
-### From Source
-```bash
-uv pip install -e .
-```
+The skill is also discoverable from [skills.sh](https://skills.sh/browser-use/browser-use/browser-use).
 
-## Quick Start
+## Use Python Directly
+
+Pass Python to the CLI. Use `uvx browser-use` for one-off runs, or `browser-use` if you installed it:
 
 ```bash
-# Open a webpage (starts browser automatically)
-browser-use open https://example.com
-
-# See clickable elements with their indices
-browser-use state
-
-# Click an element by index
-browser-use click 5
-
-# Type text into focused element
-browser-use type "Hello World"
-
-# Fill a specific input field (click + type)
-browser-use input 3 "john@example.com"
-
-# Take a screenshot
-browser-use screenshot output.png
-
-# Close the browser
-browser-use close
+uvx browser-use <<'PY'
+new_tab("https://example.com")
+print(page_info())
+PY
 ```
 
-## Browser Modes
+## Local Browser Setup
+
+The default local flow attaches to your running Chrome or Chromium through CDP. If the CLI cannot connect, run:
 
 ```bash
-# Default: headless Chromium
-browser-use open https://example.com
-
-# Visible browser window
-browser-use --headed open https://example.com
-
-# Connect to user's Chrome (preserves logins/cookies)
-browser-use connect
-
-# Use a specific Chrome profile
-browser-use --profile "Default" open https://gmail.com
-
-# Cloud browser (zero-config, requires API key)
-browser-use cloud connect
-
-# Connect to an existing browser via CDP URL
-browser-use --cdp-url http://localhost:9222 open https://example.com
-
-# WebSocket CDP URL also works
-browser-use --cdp-url ws://localhost:9222/devtools/browser/... state
+browser-use --doctor
 ```
 
-After `connect` or `cloud connect`, all subsequent commands go to that browser — no extra flags needed.
+If Chrome asks whether to allow remote debugging, approve it and rerun the command.
 
-## All Commands
+## Cloud Browsers
 
-### Navigation
-| Command | Description |
-|---------|-------------|
-| `open <url>` | Navigate to URL |
-| `back` | Go back in history |
-| `scroll down` | Scroll down |
-| `scroll up` | Scroll up |
-| `scroll down --amount 1000` | Scroll by pixels |
-
-### Inspection
-| Command | Description |
-|---------|-------------|
-| `state` | Get URL, title, and clickable elements |
-| `screenshot [path]` | Take screenshot (base64 if no path) |
-| `screenshot --full path.png` | Full page screenshot |
-
-### Interaction
-| Command | Description |
-|---------|-------------|
-| `click <index>` | Click element by index |
-| `click <x> <y>` | Click at pixel coordinates |
-| `type "text"` | Type into focused element |
-| `input <index> "text"` | Click element, then type |
-| `keys "Enter"` | Send keyboard keys |
-| `keys "Control+a"` | Send key combination |
-| `select <index> "value"` | Select dropdown option |
-| `upload <index> <path>` | Upload file to file input element |
-| `hover <index>` | Hover over element |
-| `dblclick <index>` | Double-click element |
-| `rightclick <index>` | Right-click element |
-
-### Tabs
-| Command | Description |
-|---------|-------------|
-| `tab list` | List all tabs |
-| `tab new [url]` | Open new tab (blank or with URL) |
-| `tab switch <index>` | Switch to tab by index |
-| `tab close [index...]` | Close tab(s) (current if no index) |
-
-### Cookies
-| Command | Description |
-|---------|-------------|
-| `cookies get` | Get all cookies |
-| `cookies get --url <url>` | Get cookies for URL |
-| `cookies set <name> <value>` | Set a cookie |
-| `cookies set name val --domain .example.com --secure` | Set with options |
-| `cookies set name val --same-site Strict` | SameSite: Strict, Lax, None |
-| `cookies set name val --expires 1735689600` | Set expiration timestamp |
-| `cookies clear` | Clear all cookies |
-| `cookies clear --url <url>` | Clear cookies for URL |
-| `cookies export <file>` | Export to JSON file |
-| `cookies import <file>` | Import from JSON file |
-
-### Wait
-| Command | Description |
-|---------|-------------|
-| `wait selector "css"` | Wait for element to be visible |
-| `wait selector ".loading" --state hidden` | Wait for element to disappear |
-| `wait text "Success"` | Wait for text to appear |
-| `wait selector "h1" --timeout 5000` | Custom timeout (ms) |
-
-### Get (Information Retrieval)
-| Command | Description |
-|---------|-------------|
-| `get title` | Get page title |
-| `get html` | Get full page HTML |
-| `get html --selector "h1"` | Get HTML of element |
-| `get text <index>` | Get text content of element |
-| `get value <index>` | Get value of input/textarea |
-| `get attributes <index>` | Get all attributes of element |
-| `get bbox <index>` | Get bounding box (x, y, width, height) |
-
-### JavaScript & Data
-| Command | Description |
-|---------|-------------|
-| `eval "js code"` | Execute JavaScript |
-| `extract "query"` | Extract data with LLM (not yet implemented) |
-
-### Python (Persistent Session)
-```bash
-browser-use python "x = 42"           # Set variable
-browser-use python "print(x)"         # Access variable (prints: 42)
-browser-use python "print(browser.url)"  # Access browser
-browser-use python --vars             # Show defined variables
-browser-use python --reset            # Clear namespace
-browser-use python --file script.py   # Run Python file
-```
-
-## Cloud API
-
-Generic REST passthrough to the Browser-Use Cloud API, plus cloud browser provisioning.
-
-| Command | Description |
-|---------|-------------|
-| `cloud connect` | Provision cloud browser and connect (zero-config, auto-manages profile) |
-| `cloud login <api-key>` | Save API key |
-| `cloud logout` | Remove API key |
-| `cloud close` | Disconnect and stop cloud browser |
-| `cloud v2 GET <path>` | GET request to API v2 |
-| `cloud v2 POST <path> '<json>'` | POST request to API v2 |
-| `cloud v3 POST <path> '<json>'` | POST request to API v3 |
-| `cloud v2 poll <task-id>` | Poll task until done |
-| `cloud v2 --help` | Show API v2 endpoints (from OpenAPI spec) |
-| `cloud v3 --help` | Show API v3 endpoints |
-
-`cloud connect` provisions a cloud browser with a persistent profile (auto-created on first use), connects via CDP, and prints a live URL. For custom browser settings (proxy, timeout, specific profile), use `cloud v2 POST /browsers` directly.
+Authenticate once:
 
 ```bash
-# Save API key (or set BROWSER_USE_API_KEY env var)
-browser-use cloud login sk-abc123...
-
-# Provision a cloud browser and connect
-browser-use cloud connect
-browser-use state                    # works normally
-browser-use close                    # disconnects AND stops cloud browser
-
-# List browsers
-browser-use cloud v2 GET /browsers
-
-# Create a task
-browser-use cloud v2 POST /tasks '{"task":"Search for AI news","url":"https://google.com"}'
-
-# Poll until done
-browser-use cloud v2 poll <task-id>
-
-# Remove API key
-browser-use cloud logout
+browser-use auth login
 ```
 
-API key stored in `~/.browser-use/config.json` with `0600` permissions.
-
-## Tunnels
-
-Expose local dev servers to cloud browsers via Cloudflare tunnels.
-
-| Command | Description |
-|---------|-------------|
-| `tunnel <port>` | Start tunnel, get public URL |
-| `tunnel list` | List active tunnels |
-| `tunnel stop <port>` | Stop tunnel for port |
-| `tunnel stop --all` | Stop all tunnels |
+Then start a named cloud browser and use the same name for later commands:
 
 ```bash
-# Example: Test local dev server with cloud browser
-npm run dev &                              # localhost:3000
-browser-use tunnel 3000                    # → https://abc.trycloudflare.com
-browser-use cloud connect                  # Provision cloud browser
-browser-use open https://abc.trycloudflare.com
+browser-use <<'PY'
+start_remote_daemon("work")
+PY
+
+BU_NAME=work browser-use <<'PY'
+new_tab("https://example.com")
+print(page_info())
+PY
 ```
 
-## Profile Management
-
-The `profile` subcommand syncs local browser cookies to Browser-Use cloud.
-
-The binary is managed at `~/.browser-use/bin/profile-use` and auto-downloaded on first use.
-
-| Command | Description |
-|---------|-------------|
-| `profile` | Interactive sync wizard |
-| `profile list` | List detected browsers and profiles |
-| `profile sync --all` | Sync all profiles to cloud |
-| `profile sync --browser "Google Chrome" --profile "Default"` | Sync specific profile |
-| `profile auth --apikey <key>` | Set API key (shared with `cloud login`) |
-| `profile inspect --browser "Google Chrome" --profile "Default"` | Inspect cookies locally |
-| `profile update` | Download/update the profile-use binary |
-
-## Session Management
-
-| Command | Description |
-|---------|-------------|
-| `sessions` | List active browser sessions |
-| `close` | Close current session's browser and daemon |
-| `close --all` | Close all sessions |
-| `--session NAME` | Target a named session (default: "default") |
+Remote browsers bill until they stop or time out. When the task is done, ask whether to close the browser; if yes, run:
 
 ```bash
-# Default behavior unchanged
-browser-use open https://example.com           # uses session 'default'
-browser-use state                              # talks to 'default' daemon
-
-# Named sessions
-browser-use --session work open https://example.com
-browser-use --session work state
-browser-use --session cloud cloud connect
-
-# List active sessions
-browser-use sessions
-
-# Close specific session
-browser-use --session work close
-
-# Close all sessions
-browser-use close --all
-
-# Env var fallback
-BROWSER_USE_SESSION=work browser-use state
+BU_NAME=work browser-use <<'PY'
+stop_remote_daemon("work")
+PY
 ```
 
-## Global Options
-
-| Option | Description |
-|--------|-------------|
-| `--headed` | Show browser window |
-| `--profile [NAME]` | Use real Chrome (bare `--profile` uses "Default") |
-| `--connect` | Auto-discover and connect to running Chrome via CDP (prefer `connect` command instead) |
-| `--cdp-url <url>` | Connect to existing browser via CDP URL (`http://` or `ws://`) |
-| `--session NAME` | Target a named session (default: "default", env: `BROWSER_USE_SESSION`) |
-| `--json` | Output as JSON |
-| `--mcp` | Run as MCP server via stdin/stdout |
-
-## Configuration
+## Useful Commands
 
 ```bash
-browser-use config list                            # Show all config values
-browser-use config set cloud_connect_proxy jp      # Set a value
-browser-use config get cloud_connect_proxy         # Get a value
-browser-use config unset cloud_connect_timeout     # Remove a value
-browser-use doctor                                 # Shows config + diagnostics
-browser-use setup                                  # Interactive post-install setup
+browser-use --help
+browser-use --doctor
+browser-use auth login
+browser-use auth status
+browser-use skill install
+browser-use skill show
+browser-use telemetry status
 ```
-
-Config stored in `~/.browser-use/config.json`.
-
-## Examples
-
-### Fill a Form
-```bash
-browser-use open https://example.com/contact
-browser-use state
-# Shows: [0] input "Name", [1] input "Email", [2] button "Submit"
-browser-use input 0 "John Doe"
-browser-use input 1 "john@example.com"
-browser-use click 2
-```
-
-### Extract Data with JavaScript
-```bash
-browser-use open https://news.ycombinator.com
-browser-use eval "Array.from(document.querySelectorAll('.titleline a')).slice(0,5).map(a => a.textContent)"
-```
-
-### Python Automation
-```bash
-browser-use open https://example.com
-browser-use python "
-for i in range(5):
-    browser.scroll('down')
-    browser.wait(0.5)
-browser.screenshot('scrolled.png')
-"
-```
-
-## Generate Templates
-
-```bash
-browser-use init                          # Interactive template selection
-browser-use init --list                   # List available templates
-browser-use init --template basic         # Generate specific template
-browser-use init --output my_script.py    # Specify output file
-browser-use init --force                  # Overwrite existing files
-```
-
-## How It Works
-
-The CLI uses a multi-session daemon architecture:
-
-1. First command starts a background daemon for that session (browser stays open)
-2. Subsequent commands communicate via Unix socket (or TCP on Windows)
-3. Browser persists across commands for fast interaction
-4. Each `--session` gets its own daemon, socket, and PID file in `~/.browser-use/`
-5. Daemon auto-starts when needed, auto-exits when browser dies, or stops with `browser-use close`
-
-This gives you ~50ms command latency instead of waiting for browser startup each time.
-
-### File Layout
-
-All CLI-managed files live under `~/.browser-use/` (override with `BROWSER_USE_HOME`):
-
-```
-~/.browser-use/
-├── config.json          # API key, settings (shared with profile-use)
-├── bin/
-│   └── profile-use      # Managed Go binary (auto-downloaded)
-├── tunnels/
-│   ├── {port}.json      # Tunnel metadata
-│   └── {port}.log       # Tunnel logs
-├── default.state.json   # Daemon lifecycle state (phase, PID, config)
-├── default.sock         # Daemon socket (ephemeral)
-├── default.pid          # Daemon PID (ephemeral)
-└── cli.log              # Daemon log
-```
-
-## Windows Troubleshooting
-
-<Accordion title="ARM64 Windows (Surface Pro X, Snapdragon laptops)">
-Install x64 Python (runs via emulation):
-```powershell
-winget install Python.Python.3.11 --architecture x64
-```
-</Accordion>
-
-<Accordion title="Multiple Python versions">
-Set the version explicitly:
-```powershell
-$env:PY_PYTHON=3.11
-```
-</Accordion>
-
-<Accordion title="PATH not working after install">
-Restart your terminal. If still not working:
-```powershell
-# Check PATH
-echo $env:PATH
-
-# Or run via Git Bash
-& "C:\Program Files\Git\bin\bash.exe" -c 'browser-use --help'
-```
-</Accordion>
-
-<Accordion title="Failed to start daemon error">
-Kill zombie processes:
-```powershell
-# Find browser-use Python processes
-wmic process where "name='python.exe' and commandline like '%browser%use%'" get processid
-
-# Kill by PID
-taskkill /PID <pid> /F
-```
-</Accordion>
-
-<Accordion title="Stale virtual environment">
-Delete and reinstall:
-```powershell
-# Kill browser-use Python processes
-wmic process where "name='python.exe' and commandline like '%browser%use%'" call terminate
-Remove-Item -Recurse -Force "$env:USERPROFILE\.browser-use-env"
-# Then run installer again
-```
-</Accordion>

--- a/docs/open-source/browser-use-cli.mdx
+++ b/docs/open-source/browser-use-cli.mdx
@@ -20,10 +20,10 @@ For one-off runs without a permanent tool install, use `uvx browser-use`.
 This adds Browser Use instructions to Claude Code, Codex, and other coding agents:
 
 ```bash
-browser-use skill install
+npx skills add https://github.com/browser-use/browser-use --skill browser-use
 ```
 
-The skill is also discoverable from [skills.sh](https://skills.sh/browser-use/browser-use/browser-use).
+The skill is discoverable from [skills.sh](https://skills.sh/browser-use/browser-use/browser-use).
 
 ## Use Python Directly
 
@@ -91,7 +91,7 @@ browser-use --help
 browser-use --doctor
 browser-use auth login
 browser-use auth status
-browser-use skill install
+npx skills add https://github.com/browser-use/browser-use --skill browser-use
 browser-use skill show
 browser-use telemetry status
 ```

--- a/docs/open-source/browser-use-cli.mdx
+++ b/docs/open-source/browser-use-cli.mdx
@@ -4,7 +4,13 @@ description: "Direct browser control for coding agents."
 icon: "terminal"
 ---
 
-The Browser Use CLI (`browser-use`) gives coding agents a direct browser-control surface backed by [Browser Harness](https://github.com/browser-use/browser-harness). Agents run small Python snippets with browser helpers already available, then inspect, click, type, screenshot, and recover using the same coding loop they use everywhere else.
+The Browser Use CLI (`browser-use`) gives coding agents a direct browser-control surface backed by [Browser Harness](https://github.com/browser-use/browser-harness):
+
+- **Direct browser control** — agents run Python to do actions in the browser.
+- **Three browser modes** — you can use with local Chrome or Chromium with your existing tabs, cookies, extensions, and logins; Browser Use cloud browsers; or any browser reachable through a CDP endpoint.
+- **Agent-ready setup** — install the skill into Claude Code, Codex, and other coding agents so they know when and how to call the CLI.
+
+To try the hosted agent directly, use [Browser Use Cloud](https://cloud.browser-use.com?utm_source=docs&utm_medium=browser-use-cli&utm_campaign=v4), or install the skill.
 
 ## Install the CLI
 
@@ -47,7 +53,11 @@ print(page_info())
 
 ## Local Browser Setup
 
-The default local flow attaches to your running Chrome or Chromium through CDP. If the CLI cannot connect, run:
+The default local flow attaches to your running Chrome or Chromium through CDP. This preserves the browser state the user already has locally: open tabs, cookies, extensions, and logged-in sessions. It is the right default for desktop work where the user can approve Chrome's remote-debugging prompt.
+
+You can also point the CLI at any existing CDP browser by setting `BU_CDP_URL` or `BU_CDP_WS` before running `browser-use`. Use that for managed Chrome instances, Playwright-launched browsers, or infrastructure that already exposes a DevTools endpoint.
+
+If the CLI cannot connect, run:
 
 ```bash
 browser-use --doctor
@@ -57,13 +67,13 @@ If Chrome asks whether to allow remote debugging, approve it and rerun the comma
 
 ## Cloud Browsers
 
-Authenticate once:
+Use Browser Use cloud browsers when the agent runs on a headless machine, needs an isolated browser, needs parallel browser sessions, or needs Browser Use Cloud features such as persistent cloud profiles, proxy routing, CAPTCHA handling, and live browser viewing.
+
+The Browser Harness-backed CLI keeps cloud sessions explicit. You authenticate once, start a named cloud browser, then use that name for later commands:
 
 ```bash
 browser-use auth login
 ```
-
-Then start a named cloud browser and use the same name for later commands:
 
 ```bash
 browser-use <<'PY'
@@ -75,6 +85,8 @@ new_tab("https://example.com")
 print(page_info())
 PY
 ```
+
+Use short, task-specific names when you have multiple agents or sub-agents running in parallel. Each name maps to its own remote browser daemon.
 
 Remote browsers bill until they stop or time out. When the task is done, ask whether to close the browser; if yes, run:
 

--- a/docs/open-source/browser-use-cli.mdx
+++ b/docs/open-source/browser-use-cli.mdx
@@ -36,6 +36,15 @@ print(page_info())
 PY
 ```
 
+The `<<'PY'` form is for Unix-compatible shells such as bash, zsh, Git Bash, or WSL. In PowerShell, pipe a here-string instead:
+
+```powershell
+@'
+new_tab("https://example.com")
+print(page_info())
+'@ | uvx browser-use
+```
+
 ## Local Browser Setup
 
 The default local flow attaches to your running Chrome or Chromium through CDP. If the CLI cannot connect, run:

--- a/docs/open-source/browser-use-terminal.mdx
+++ b/docs/open-source/browser-use-terminal.mdx
@@ -26,9 +26,7 @@ Give this employee admin permission in Azure.
 Research the top Hacker News stories and summarize the points.
 ```
 
-<video
-  controls
-  className="w-full aspect-video rounded-xl">
+<video controls className="w-full aspect-video rounded-xl">
   <source
     src="https://media.githubusercontent.com/media/browser-use/sdk/rust-terminal-docs/docs/static/terminal_demo.mp4"
     type="video/mp4"
@@ -41,15 +39,17 @@ Research the top Hacker News stories and summarize the points.
 
 You can use Browser Use Terminal in four ways:
 
-| Surface | What it is for |
-| --- | --- |
-| **TUI** | The interactive terminal app you launch with `browser`. Best for normal, hands-on use. |
-| **CLI** | Scriptable commands such as `browser-use-terminal run-openai`. Best for automation and one-off tasks. |
-| **Python** | `browser_use.beta.Agent`, backed by the same Rust runtime. Best when you want browser-use code with terminal runtime behavior. |
+| Surface               | What it is for                                                                                                                                                                                |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **TUI**               | The interactive terminal app you launch with `browser`. Best for normal, hands-on use.                                                                                                        |
+| **CLI**               | Scriptable commands such as `browser-use-terminal run-openai`. Best for automation and one-off tasks.                                                                                         |
+| **Python**            | `browser_use.beta.Agent`, backed by the same Rust runtime. Best when you want browser-use code with terminal runtime behavior.                                                                |
 | **Coding assistants** | A skill plus the `browser-use-terminal browser` commands let Claude Code, Codex, OpenCode, and other agents drive the browser. See [Use From Coding Assistants](#use-from-coding-assistants). |
 
 <Info>
-Browser Use Terminal is separate from the lower-level `browser-use` CLI. Use `browser` for the Terminal TUI, `browser-use-terminal` for Terminal task commands, and `browser-use` for direct browser-control commands.
+  Browser Use Terminal is separate from the lower-level `browser-use` CLI. Use
+  `browser` for the Terminal TUI, `browser-use-terminal` for Terminal task
+  commands, and `browser-use` for direct browser-control commands.
 </Info>
 
 ## Terms
@@ -97,25 +97,25 @@ uv pip install browser-use
 
 In the TUI, type `/` to open the command palette. These are the main commands:
 
-| Command | What it does |
-| --- | --- |
-| `/task` | Start a new task. |
-| `/model` | Choose the model and provider. |
-| `/auth` | Sign in to a provider. |
-| `/browser` | Change the browser backend. |
-| `/profile` | Choose the default Chrome profile. |
-| `/history` | Browse previous tasks. |
-| `/context` | Inspect context window attribution. |
-| `/secrets` | Save passwords and 2FA setup keys for website logins. |
-| `/import-passwords` | Import saved logins from 1Password. |
-| `/domains` | Allow or block which sites the agent can visit. |
-| `/sync-cookies` | Sync local cookies. |
-| `/email` | Give the agent a disposable inbox for sign-ups, links, and codes. |
-| `/goal` | Set or view the goal for a long-running task. |
-| `/feedback` | Report a bug or share feedback. |
-| `/update` | Install the latest release. |
-| `/reload` | Restart the UI in this terminal. |
-| `/exit` | Quit Browser Use Terminal. |
+| Command             | What it does                                                      |
+| ------------------- | ----------------------------------------------------------------- |
+| `/task`             | Start a new task.                                                 |
+| `/model`            | Choose the model and provider.                                    |
+| `/auth`             | Sign in to a provider.                                            |
+| `/browser`          | Change the browser backend.                                       |
+| `/profile`          | Choose the default Chrome profile.                                |
+| `/history`          | Browse previous tasks.                                            |
+| `/context`          | Inspect context window attribution.                               |
+| `/secrets`          | Save passwords and 2FA setup keys for website logins.             |
+| `/import-passwords` | Import saved logins from 1Password.                               |
+| `/domains`          | Allow or block which sites the agent can visit.                   |
+| `/sync-cookies`     | Sync local cookies.                                               |
+| `/email`            | Give the agent a disposable inbox for sign-ups, links, and codes. |
+| `/goal`             | Set or view the goal for a long-running task.                     |
+| `/feedback`         | Report a bug or share feedback.                                   |
+| `/update`           | Install the latest release.                                       |
+| `/reload`           | Restart the UI in this terminal.                                  |
+| `/exit`             | Quit Browser Use Terminal.                                        |
 
 ## Run Browser Tasks
 
@@ -277,13 +277,13 @@ agent = Agent(
 
 Supported Python model classes:
 
-| Python model class | Example |
-| --- | --- |
-| `ChatOpenAI` | `ChatOpenAI(model="gpt-5.5")` |
-| `ChatAnthropic` | `ChatAnthropic(model="claude-sonnet-4-6")` |
-| `ChatLiteLLM` | `ChatLiteLLM(model="openai/gpt-5.5")` |
-| `ChatDeepSeek` | `ChatDeepSeek(model="deepseek-v4-pro")` |
-| `ChatOpenRouter` | `ChatOpenRouter(model="openai/gpt-5.5")` |
+| Python model class | Example                                    |
+| ------------------ | ------------------------------------------ |
+| `ChatOpenAI`       | `ChatOpenAI(model="gpt-5.5")`              |
+| `ChatAnthropic`    | `ChatAnthropic(model="claude-sonnet-4-6")` |
+| `ChatLiteLLM`      | `ChatLiteLLM(model="openai/gpt-5.5")`      |
+| `ChatDeepSeek`     | `ChatDeepSeek(model="deepseek-v4-pro")`    |
+| `ChatOpenRouter`   | `ChatOpenRouter(model="openai/gpt-5.5")`   |
 
 ## Choose A Browser
 
@@ -595,14 +595,14 @@ curl -fsSL https://browser-use.com/terminal/install.sh | sh
 
 ### Which Command Should I Use?
 
-| Goal | Command |
-| --- | --- |
-| Open the interactive Terminal app | `browser` |
-| Run a one-shot Terminal agent task | `browser-use-terminal run-openai "..."` |
-| Use Terminal runtime from Python | `browser_use.beta.Agent` |
-| Drive the browser from a coding assistant | `browser-use-terminal browser exec` |
-| Register the skill with coding assistants | `browser-use-terminal skill install` |
-| Directly control a browser with low-level commands | `browser-use open https://example.com` |
+| Goal                                      | Command                                 |
+| ----------------------------------------- | --------------------------------------- |
+| Open the interactive Terminal app         | `browser`                               |
+| Run a one-shot Terminal agent task        | `browser-use-terminal run-openai "..."` |
+| Use Terminal runtime from Python          | `browser_use.beta.Agent`                |
+| Drive the browser from a coding assistant | `browser-use-terminal browser exec`     |
+| Register the skill with coding assistants | `browser-use-terminal skill install`    |
+| Directly control a browser with Python    | `browser-use <<'PY' ... PY`             |
 
 ### Python Cannot Find `browser_use.beta`
 
@@ -617,30 +617,30 @@ python -c "from browser_use.beta import Agent; print('ok')"
 
 When you use `browser_use.beta.Agent`, these Python settings are forwarded to the Rust terminal SDK:
 
-| Python setting | Terminal SDK field |
-| --- | --- |
-| `llm.provider`, inferred from the chat model | `llm.provider` |
-| `llm.model` | `llm.model` |
-| `llm_timeout` | `llm.timeout` |
-| `headless` | `browser.headless` |
-| `keep_alive` | `browser.keep_alive` |
-| `cloud_profile_id`, `profile_id` | `browser.profile_id` |
+| Python setting                                   | Terminal SDK field           |
+| ------------------------------------------------ | ---------------------------- |
+| `llm.provider`, inferred from the chat model     | `llm.provider`               |
+| `llm.model`                                      | `llm.model`                  |
+| `llm_timeout`                                    | `llm.timeout`                |
+| `headless`                                       | `browser.headless`           |
+| `keep_alive`                                     | `browser.keep_alive`         |
+| `cloud_profile_id`, `profile_id`                 | `browser.profile_id`         |
 | `cloud_proxy_country_code`, `proxy_country_code` | `browser.proxy_country_code` |
-| `cdp_url` | `browser.cdp_url` |
-| `headers` / CDP headers | `browser.cdp_headers` |
-| `user_agent` | `browser.user_agent` |
-| `viewport` | `browser.viewport` |
-| `window_size` | `browser.window_size` |
-| `storage_state` | `browser.storage_state` |
-| `downloads_path` | `browser.downloads_path` |
-| `allowed_domains` | `browser.allowed_domains` |
-| `prohibited_domains` | `browser.blocked_domains` |
-| `state_dir` | `browser.state_dir` |
-| `no_viewport` | `browser.no_viewport` |
-| `accept_downloads` | `browser.accept_downloads` |
-| `output_model_schema` | `output_schema` |
-| `calculate_cost` | `calculate_cost` |
-| `max_actions_per_step` | `max_actions_per_step` |
+| `cdp_url`                                        | `browser.cdp_url`            |
+| `headers` / CDP headers                          | `browser.cdp_headers`        |
+| `user_agent`                                     | `browser.user_agent`         |
+| `viewport`                                       | `browser.viewport`           |
+| `window_size`                                    | `browser.window_size`        |
+| `storage_state`                                  | `browser.storage_state`      |
+| `downloads_path`                                 | `browser.downloads_path`     |
+| `allowed_domains`                                | `browser.allowed_domains`    |
+| `prohibited_domains`                             | `browser.blocked_domains`    |
+| `state_dir`                                      | `browser.state_dir`          |
+| `no_viewport`                                    | `browser.no_viewport`        |
+| `accept_downloads`                               | `browser.accept_downloads`   |
+| `output_model_schema`                            | `output_schema`              |
+| `calculate_cost`                                 | `calculate_cost`             |
+| `max_actions_per_step`                           | `max_actions_per_step`       |
 
 The same Python `Agent` instance can continue a terminal-backed session across follow-up runs.
 

--- a/docs/open-source/examples/skills/browser-use.mdx
+++ b/docs/open-source/examples/skills/browser-use.mdx
@@ -9,8 +9,7 @@ The `browser-use` skill teaches your agent the [Browser Use CLI](/open-source/br
 ## Install
 
 ```bash
-uv tool install browser-use
-browser-use skill install
+npx skills add https://github.com/browser-use/browser-use --skill browser-use
 ```
 
 ## Links

--- a/docs/open-source/examples/skills/browser-use.mdx
+++ b/docs/open-source/examples/skills/browser-use.mdx
@@ -4,17 +4,26 @@ description: "Automates browser interactions for web testing, form filling, scre
 icon: "terminal"
 ---
 
-The `browser-use` skill teaches your agent the full [Browser Use CLI](/open-source/browser-use-cli) command set — a fast, persistent browser it drives directly: `open`, `state`, `click`, `input`, `screenshot`, and more. A background daemon keeps the browser open across commands (~50ms per call), and the agent can connect to your real Chrome (preserving logins) or to a cloud browser.
+The `browser-use` skill teaches your agent the [Browser Use CLI](/open-source/browser-use-cli). The CLI runs Python in the browser to do actions online. The agent can connect to your real Chrome, preserving logins, or to a Browser Use cloud browser.
 
 ## Install
 
 ```bash
-npx skills add https://github.com/browser-use/browser-use --skill browser-use
+uv tool install browser-use
+browser-use skill install
 ```
 
 ## Links
 
 <CardGroup cols={2}>
-  <Card title="skills.sh" icon="up-right-from-square" href="https://www.skills.sh/browser-use/browser-use/browser-use" />
-  <Card title="Source" icon="github" href="https://github.com/browser-use/browser-use/tree/main/skills/browser-use" />
+  <Card
+    title="skills.sh"
+    icon="up-right-from-square"
+    href="https://www.skills.sh/browser-use/browser-use/browser-use"
+  />
+  <Card
+    title="Source"
+    icon="github"
+    href="https://github.com/browser-use/browser-use/tree/main/skills/browser-use"
+  />
 </CardGroup>

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -744,7 +744,7 @@ The Browser Use CLI (`browser-use`) is the command-line interface for the Browse
 
 2. **Cloud platform management** — a generic REST passthrough to the Browser Use API (v2 and v3) for managing agent tasks, cloud browser sessions, profiles, workspaces, files, skills, and billing. Anything available in the cloud dashboard is accessible from the terminal.
 
-The core browser workflow is: navigate to a page, run `state` to get numbered element indices, then interact using those indices. The cloud workflow is: `cloud login` to authenticate, then use `cloud v2`/`cloud v3` commands to hit any API endpoint, or `cloud connect` to provision and drive a cloud browser directly.
+The core browser workflow is: pass Python to `browser-use`, inspect the page, then interact using the Browser Harness helpers. Use `browser-use auth login` or `BROWSER_USE_API_KEY` for Browser Use Cloud auth.
 
 ## Installation
 
@@ -842,8 +842,8 @@ browser-use connect
 # Use a specific Chrome profile
 browser-use --profile "Default" open https://gmail.com
 
-# Cloud browser (zero-config, requires API key)
-browser-use cloud connect
+# Cloud browser auth
+browser-use auth login
 
 # Connect to an existing browser via CDP URL
 browser-use --cdp-url http://localhost:9222 open https://example.com
@@ -852,7 +852,7 @@ browser-use --cdp-url http://localhost:9222 open https://example.com
 browser-use --cdp-url ws://localhost:9222/devtools/browser/... state
 ```
 
-After `connect` or `cloud connect`, all subsequent commands go to that browser — no extra flags needed.
+After authenticating, use Browser Harness helpers from `browser-use` to start or connect to cloud browser sessions.
 
 ## All Commands
 
@@ -950,33 +950,17 @@ Generic REST passthrough to the Browser-Use Cloud API, plus cloud browser provis
 
 | Command | Description |
 |---------|-------------|
-| `cloud connect` | Provision cloud browser and connect (zero-config, auto-manages profile) |
-| `cloud login <api-key>` | Save API key |
-| `cloud logout` | Remove API key |
-| `cloud close` | Disconnect and stop cloud browser |
-| `cloud v2 GET <path>` | GET request to API v2 |
-| `cloud v2 POST <path> '<json>'` | POST request to API v2 |
-| `cloud v3 POST <path> '<json>'` | POST request to API v3 |
-| `cloud v2 poll <task-id>` | Poll task until done |
-| `cloud v2 --help` | Show API v2 endpoints (from OpenAPI spec) |
-| `cloud v3 --help` | Show API v3 endpoints |
+| `auth login` | Sign in to Browser Use Cloud |
+| `auth status` | Show Browser Use Cloud auth state |
+| `auth logout` | Remove stored Browser Use Cloud auth |
+| `--doctor` | Diagnose install, daemon, and browser state |
 
-`cloud connect` provisions a cloud browser with a persistent profile (auto-created on first use), connects via CDP, and prints a live URL. For custom browser settings (proxy, timeout, specific profile), use `cloud v2 POST /browsers` directly.
+Cloud browser sessions are managed through the Browser Harness helpers available inside `browser-use`.
 
 ```bash
-# Save API key (or set BROWSER_USE_API_KEY env var)
-browser-use cloud login sk-abc123...
-
-# Provision a cloud browser and connect
-browser-use cloud connect
-browser-use state                    # works normally
-browser-use close                    # disconnects AND stops cloud browser
-
-# List browsers
-browser-use cloud v2 GET /browsers
-
-# Create a task
-browser-use cloud v2 POST /tasks '{"task":"Search for AI news","url":"https://google.com"}'
+browser-use auth login
+browser-use auth status
+browser-use --doctor
 
 # Poll until done
 browser-use cloud v2 poll <task-id>
@@ -1002,7 +986,7 @@ Expose local dev servers to cloud browsers via Cloudflare tunnels.
 # Example: Test local dev server with cloud browser
 npm run dev &                              # localhost:3000
 browser-use tunnel 3000                    # → https://abc.trycloudflare.com
-browser-use cloud connect                  # Provision cloud browser
+browser-use auth login                     # Authenticate for cloud browsers
 browser-use open https://abc.trycloudflare.com
 ```
 
@@ -1018,7 +1002,7 @@ The binary is managed at `~/.browser-use/bin/profile-use` and auto-downloaded on
 | `profile list` | List detected browsers and profiles |
 | `profile sync --all` | Sync all profiles to cloud |
 | `profile sync --browser "Google Chrome" --profile "Default"` | Sync specific profile |
-| `profile auth --apikey <key>` | Set API key (shared with `cloud login`) |
+| `profile auth --apikey <key>` | Set API key |
 | `profile inspect --browser "Google Chrome" --profile "Default"` | Inspect cookies locally |
 | `profile update` | Download/update the profile-use binary |
 
@@ -1039,7 +1023,7 @@ browser-use state                              # talks to 'default' daemon
 # Named sessions
 browser-use --session work open https://example.com
 browser-use --session work state
-browser-use --session cloud cloud connect
+browser-use --session cloud auth status
 
 # List active sessions
 browser-use sessions
@@ -5393,4 +5377,3 @@ Source: https://docs.browser-use.com/open-source/development/get-help
 1. Check our [GitHub Issues](https://github.com/browser-use/browser-use/issues)
 2. Ask in our [Discord community](https://link.browser-use.com/discord)
 3. Get support for your enterprise with support@browser-use.com
-

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -738,436 +738,108 @@ Any provider with an OpenAI-compatible endpoint works via `ChatOpenAI` with a cu
 Source: https://docs.browser-use.com/open-source/browser-use-cli
 
 
-The Browser Use CLI (`browser-use`) is the command-line interface for the Browser Use platform. It does two things:
+The Browser Use CLI (`browser-use`) is the command-line interface for the Browser Use platform. It uses [Browser Harness](https://github.com/browser-use/browser-harness) to allow for:
 
-1. **Direct browser control** — navigate pages, click elements, fill forms, upload files, take screenshots, run JavaScript. Supports three browser modes: managed headless Chromium, real Chrome with existing user profiles and logins, and cloud-hosted browsers via the Browser Use Cloud API. A persistent background daemon keeps the browser alive between commands for fast ~50ms latency.
+- **Direct browser control** — agents run Python to do actions in the browser.
+- **Three browser modes** — you can use with local Chrome or Chromium with your existing tabs, cookies, extensions, and logins; Browser Use cloud browsers; or any browser reachable through a CDP endpoint.
+- **Agent-ready setup** — install the skill into Claude Code, Codex, and other coding agents so they know when and how to call the CLI.
 
-2. **Cloud platform management** — a generic REST passthrough to the Browser Use API (v2 and v3) for managing agent tasks, cloud browser sessions, profiles, workspaces, files, skills, and billing. Anything available in the cloud dashboard is accessible from the terminal.
+To try the hosted agent directly, use [Browser Use Cloud](https://cloud.browser-use.com?utm_source=docs&utm_medium=browser-use-cli&utm_campaign=v4), or install the skill.
 
-The core browser workflow is: pass Python to `browser-use`, inspect the page, then interact using the Browser Harness helpers. Use `browser-use auth login` or `BROWSER_USE_API_KEY` for Browser Use Cloud auth.
+## Install the CLI
 
-## Installation
-
-### Prerequisites
-
-| Platform | Requirements |
-|----------|-------------|
-| **macOS** | Python 3.11+ (installer will use Homebrew if needed) |
-| **Linux** | Python 3.11+ (installer will use apt if needed) |
-| **Windows** | [Git for Windows](https://git-scm.com/download/win), Python 3.11+ |
-
-### One-Line Install (Recommended)
-
-**macOS / Linux:**
 ```bash
-curl -fsSL https://browser-use.com/cli/install.sh | bash
+uv tool install browser-use
+browser-use --help
 ```
 
-**Windows** (run in PowerShell):
-```powershell
-& "C:\Program Files\Git\bin\bash.exe" -c 'curl -fsSL https://browser-use.com/cli/install.sh | bash'
-```
+For one-off runs without a permanent tool install, use `uvx browser-use`.
 
-### Install the Skill
+## Install the Agent Skill
 
-The CLI is most powerful when paired with its skill, which gives your coding agent full context on every command, flag, and workflow. It is **highly recommended** to install the skill alongside the CLI:
+This adds Browser Use instructions to Claude Code, Codex, and other coding agents:
 
 ```bash
 npx skills add https://github.com/browser-use/browser-use --skill browser-use
 ```
 
-### Post-Install
+The skill is discoverable from [skills.sh](https://skills.sh/browser-use/browser-use/browser-use).
+
+## Use Python Directly
+
+Pass Python to the CLI. Use `uvx browser-use` for one-off runs, or `browser-use` if you installed it:
+
 ```bash
-browser-use doctor   # Validate installation
-browser-use setup    # Run setup wizard (optional)
+uvx browser-use <<'PY'
+new_tab("https://example.com")
+print(page_info())
+PY
 ```
 
-### Manual Installation
+The `<<'PY'` form is for Unix-compatible shells such as bash, zsh, Git Bash, or WSL. In PowerShell, pipe a here-string instead:
 
-If you prefer not to use the one-line installer:
-
-```bash
-# 1. Install the package
-uv pip install browser-use
-
-# 2. Install Chromium
-browser-use install
-
-# 3. Validate
-browser-use doctor
+```powershell
+@'
+new_tab("https://example.com")
+print(page_info())
+'@ | uvx browser-use
 ```
 
-### From Source
+## Local Browser Setup
+
+The default local flow attaches to your running Chrome or Chromium through CDP. This preserves the browser state the user already has locally: open tabs, cookies, extensions, and logged-in sessions. It is the right default for desktop work where the user can approve Chrome's remote-debugging prompt.
+
+You can also point the CLI at any existing CDP browser by setting `BU_CDP_URL` or `BU_CDP_WS` before running `browser-use`. Use that for managed Chrome instances, Playwright-launched browsers, or infrastructure that already exposes a DevTools endpoint.
+
+If the CLI cannot connect, run:
+
 ```bash
-uv pip install -e .
+browser-use --doctor
 ```
 
-## Quick Start
+If Chrome asks whether to allow remote debugging, approve it and rerun the command.
+
+## Cloud Browsers
+
+Use Browser Use cloud browsers when the agent runs on a headless machine, needs an isolated browser, needs parallel browser sessions, or needs Browser Use Cloud features such as persistent cloud profiles, proxy routing, CAPTCHA handling, and live browser viewing.
+
+The Browser Harness-backed CLI keeps cloud sessions explicit. You authenticate once, start a named cloud browser, then use that name for later commands:
 
 ```bash
-# Open a webpage (starts browser automatically)
-browser-use open https://example.com
-
-# See clickable elements with their indices
-browser-use state
-
-# Click an element by index
-browser-use click 5
-
-# Type text into focused element
-browser-use type "Hello World"
-
-# Fill a specific input field (click + type)
-browser-use input 3 "john@example.com"
-
-# Take a screenshot
-browser-use screenshot output.png
-
-# Close the browser
-browser-use close
-```
-
-## Browser Modes
-
-```bash
-# Default: headless Chromium
-browser-use open https://example.com
-
-# Visible browser window
-browser-use --headed open https://example.com
-
-# Connect to user's Chrome (preserves logins/cookies)
-browser-use connect
-
-# Use a specific Chrome profile
-browser-use --profile "Default" open https://gmail.com
-
-# Cloud browser auth
 browser-use auth login
-
-# Connect to an existing browser via CDP URL
-browser-use --cdp-url http://localhost:9222 open https://example.com
-
-# WebSocket CDP URL also works
-browser-use --cdp-url ws://localhost:9222/devtools/browser/... state
 ```
 
-After authenticating, use Browser Harness helpers from `browser-use` to start or connect to cloud browser sessions.
-
-## All Commands
-
-### Navigation
-| Command | Description |
-|---------|-------------|
-| `open <url>` | Navigate to URL |
-| `back` | Go back in history |
-| `scroll down` | Scroll down |
-| `scroll up` | Scroll up |
-| `scroll down --amount 1000` | Scroll by pixels |
-
-### Inspection
-| Command | Description |
-|---------|-------------|
-| `state` | Get URL, title, and clickable elements |
-| `screenshot [path]` | Take screenshot (base64 if no path) |
-| `screenshot --full path.png` | Full page screenshot |
-
-### Interaction
-| Command | Description |
-|---------|-------------|
-| `click <index>` | Click element by index |
-| `click <x> <y>` | Click at pixel coordinates |
-| `type "text"` | Type into focused element |
-| `input <index> "text"` | Click element, then type |
-| `keys "Enter"` | Send keyboard keys |
-| `keys "Control+a"` | Send key combination |
-| `select <index> "value"` | Select dropdown option |
-| `upload <index> <path>` | Upload file to file input element |
-| `hover <index>` | Hover over element |
-| `dblclick <index>` | Double-click element |
-| `rightclick <index>` | Right-click element |
-
-### Tabs
-| Command | Description |
-|---------|-------------|
-| `tab list` | List all tabs |
-| `tab new [url]` | Open new tab (blank or with URL) |
-| `tab switch <index>` | Switch to tab by index |
-| `tab close [index...]` | Close tab(s) (current if no index) |
-
-### Cookies
-| Command | Description |
-|---------|-------------|
-| `cookies get` | Get all cookies |
-| `cookies get --url <url>` | Get cookies for URL |
-| `cookies set <name> <value>` | Set a cookie |
-| `cookies set name val --domain .example.com --secure` | Set with options |
-| `cookies set name val --same-site Strict` | SameSite: Strict, Lax, None |
-| `cookies set name val --expires 1735689600` | Set expiration timestamp |
-| `cookies clear` | Clear all cookies |
-| `cookies clear --url <url>` | Clear cookies for URL |
-| `cookies export <file>` | Export to JSON file |
-| `cookies import <file>` | Import from JSON file |
-
-### Wait
-| Command | Description |
-|---------|-------------|
-| `wait selector "css"` | Wait for element to be visible |
-| `wait selector ".loading" --state hidden` | Wait for element to disappear |
-| `wait text "Success"` | Wait for text to appear |
-| `wait selector "h1" --timeout 5000` | Custom timeout (ms) |
-
-### Get (Information Retrieval)
-| Command | Description |
-|---------|-------------|
-| `get title` | Get page title |
-| `get html` | Get full page HTML |
-| `get html --selector "h1"` | Get HTML of element |
-| `get text <index>` | Get text content of element |
-| `get value <index>` | Get value of input/textarea |
-| `get attributes <index>` | Get all attributes of element |
-| `get bbox <index>` | Get bounding box (x, y, width, height) |
-
-### JavaScript & Data
-| Command | Description |
-|---------|-------------|
-| `eval "js code"` | Execute JavaScript |
-| `extract "query"` | Extract data with LLM (not yet implemented) |
-
-### Python (Persistent Session)
 ```bash
-browser-use python "x = 42"           # Set variable
-browser-use python "print(x)"         # Access variable (prints: 42)
-browser-use python "print(browser.url)"  # Access browser
-browser-use python --vars             # Show defined variables
-browser-use python --reset            # Clear namespace
-browser-use python --file script.py   # Run Python file
+browser-use <<'PY'
+start_remote_daemon("work")
+PY
+
+BU_NAME=work browser-use <<'PY'
+new_tab("https://example.com")
+print(page_info())
+PY
 ```
 
-## Cloud API
+Use short, task-specific names when you have multiple agents or sub-agents running in parallel. Each name maps to its own remote browser daemon.
 
-Generic REST passthrough to the Browser-Use Cloud API, plus cloud browser provisioning.
-
-| Command | Description |
-|---------|-------------|
-| `auth login` | Sign in to Browser Use Cloud |
-| `auth status` | Show Browser Use Cloud auth state |
-| `auth logout` | Remove stored Browser Use Cloud auth |
-| `--doctor` | Diagnose install, daemon, and browser state |
-
-Cloud browser sessions are managed through the Browser Harness helpers available inside `browser-use`.
+Remote browsers bill until they stop or time out. When the task is done, ask whether to close the browser; if yes, run:
 
 ```bash
+BU_NAME=work browser-use <<'PY'
+stop_remote_daemon("work")
+PY
+```
+
+## Useful Commands
+
+```bash
+browser-use --help
+browser-use --doctor
 browser-use auth login
 browser-use auth status
-browser-use --doctor
-
-# Poll until done
-browser-use cloud v2 poll <task-id>
-
-# Remove API key
-browser-use cloud logout
-```
-
-API key stored in `~/.browser-use/config.json` with `0600` permissions.
-
-## Tunnels
-
-Expose local dev servers to cloud browsers via Cloudflare tunnels.
-
-| Command | Description |
-|---------|-------------|
-| `tunnel <port>` | Start tunnel, get public URL |
-| `tunnel list` | List active tunnels |
-| `tunnel stop <port>` | Stop tunnel for port |
-| `tunnel stop --all` | Stop all tunnels |
-
-```bash
-# Example: Test local dev server with cloud browser
-npm run dev &                              # localhost:3000
-browser-use tunnel 3000                    # → https://abc.trycloudflare.com
-browser-use auth login                     # Authenticate for cloud browsers
-browser-use open https://abc.trycloudflare.com
-```
-
-## Profile Management
-
-The `profile` subcommand syncs local browser cookies to Browser-Use cloud.
-
-The binary is managed at `~/.browser-use/bin/profile-use` and auto-downloaded on first use.
-
-| Command | Description |
-|---------|-------------|
-| `profile` | Interactive sync wizard |
-| `profile list` | List detected browsers and profiles |
-| `profile sync --all` | Sync all profiles to cloud |
-| `profile sync --browser "Google Chrome" --profile "Default"` | Sync specific profile |
-| `profile auth --apikey <key>` | Set API key |
-| `profile inspect --browser "Google Chrome" --profile "Default"` | Inspect cookies locally |
-| `profile update` | Download/update the profile-use binary |
-
-## Session Management
-
-| Command | Description |
-|---------|-------------|
-| `sessions` | List active browser sessions |
-| `close` | Close current session's browser and daemon |
-| `close --all` | Close all sessions |
-| `--session NAME` | Target a named session (default: "default") |
-
-```bash
-# Default behavior unchanged
-browser-use open https://example.com           # uses session 'default'
-browser-use state                              # talks to 'default' daemon
-
-# Named sessions
-browser-use --session work open https://example.com
-browser-use --session work state
-browser-use --session cloud auth status
-
-# List active sessions
-browser-use sessions
-
-# Close specific session
-browser-use --session work close
-
-# Close all sessions
-browser-use close --all
-
-# Env var fallback
-BROWSER_USE_SESSION=work browser-use state
-```
-
-## Global Options
-
-| Option | Description |
-|--------|-------------|
-| `--headed` | Show browser window |
-| `--profile [NAME]` | Use real Chrome (bare `--profile` uses "Default") |
-| `--connect` | Auto-discover and connect to running Chrome via CDP (prefer `connect` command instead) |
-| `--cdp-url <url>` | Connect to existing browser via CDP URL (`http://` or `ws://`) |
-| `--session NAME` | Target a named session (default: "default", env: `BROWSER_USE_SESSION`) |
-| `--json` | Output as JSON |
-| `--mcp` | Run as MCP server via stdin/stdout |
-
-## Configuration
-
-```bash
-browser-use config list                            # Show all config values
-browser-use config set cloud_connect_proxy jp      # Set a value
-browser-use config get cloud_connect_proxy         # Get a value
-browser-use config unset cloud_connect_timeout     # Remove a value
-browser-use doctor                                 # Shows config + diagnostics
-browser-use setup                                  # Interactive post-install setup
-```
-
-Config stored in `~/.browser-use/config.json`.
-
-## Examples
-
-### Fill a Form
-```bash
-browser-use open https://example.com/contact
-browser-use state
-# Shows: [0] input "Name", [1] input "Email", [2] button "Submit"
-browser-use input 0 "John Doe"
-browser-use input 1 "john@example.com"
-browser-use click 2
-```
-
-### Extract Data with JavaScript
-```bash
-browser-use open https://news.ycombinator.com
-browser-use eval "Array.from(document.querySelectorAll('.titleline a')).slice(0,5).map(a => a.textContent)"
-```
-
-### Python Automation
-```bash
-browser-use open https://example.com
-browser-use python "
-for i in range(5):
-    browser.scroll('down')
-    browser.wait(0.5)
-browser.screenshot('scrolled.png')
-"
-```
-
-## Generate Templates
-
-```bash
-browser-use init                          # Interactive template selection
-browser-use init --list                   # List available templates
-browser-use init --template basic         # Generate specific template
-browser-use init --output my_script.py    # Specify output file
-browser-use init --force                  # Overwrite existing files
-```
-
-## How It Works
-
-The CLI uses a multi-session daemon architecture:
-
-1. First command starts a background daemon for that session (browser stays open)
-2. Subsequent commands communicate via Unix socket (or TCP on Windows)
-3. Browser persists across commands for fast interaction
-4. Each `--session` gets its own daemon, socket, and PID file in `~/.browser-use/`
-5. Daemon auto-starts when needed, auto-exits when browser dies, or stops with `browser-use close`
-
-This gives you ~50ms command latency instead of waiting for browser startup each time.
-
-### File Layout
-
-All CLI-managed files live under `~/.browser-use/` (override with `BROWSER_USE_HOME`):
-
-```
-~/.browser-use/
-├── config.json          # API key, settings (shared with profile-use)
-├── bin/
-│   └── profile-use      # Managed Go binary (auto-downloaded)
-├── tunnels/
-│   ├── {port}.json      # Tunnel metadata
-│   └── {port}.log       # Tunnel logs
-├── default.state.json   # Daemon lifecycle state (phase, PID, config)
-├── default.sock         # Daemon socket (ephemeral)
-├── default.pid          # Daemon PID (ephemeral)
-└── cli.log              # Daemon log
-```
-
-## Windows Troubleshooting
-
-Install x64 Python (runs via emulation):
-```powershell
-winget install Python.Python.3.11 --architecture x64
-```
-
-Set the version explicitly:
-```powershell
-$env:PY_PYTHON=3.11
-```
-
-Restart your terminal. If still not working:
-```powershell
-# Check PATH
-echo $env:PATH
-
-# Or run via Git Bash
-& "C:\Program Files\Git\bin\bash.exe" -c 'browser-use --help'
-```
-
-Kill zombie processes:
-```powershell
-# Find browser-use Python processes
-wmic process where "name='python.exe' and commandline like '%browser%use%'" get processid
-
-# Kill by PID
-taskkill /PID <pid> /F
-```
-
-Delete and reinstall:
-```powershell
-# Kill browser-use Python processes
-wmic process where "name='python.exe' and commandline like '%browser%use%'" call terminate
-Remove-Item -Recurse -Force "$env:USERPROFILE\.browser-use-env"
-# Then run installer again
+npx skills add https://github.com/browser-use/browser-use --skill browser-use
+browser-use skill show
+browser-use telemetry status
 ```
 
 
@@ -1730,7 +1402,9 @@ curl -fsSL https://browser-use.com/terminal/install.sh | sh
 | Open the interactive Terminal app | `browser` |
 | Run a one-shot Terminal agent task | `browser-use-terminal run-openai "..."` |
 | Use Terminal runtime from Python | `browser_use.beta.Agent` |
-| Directly control a browser with low-level commands | `browser-use open https://example.com` |
+| Drive the browser from a coding assistant | `browser-use-terminal browser exec` |
+| Register the skill with coding assistants | `browser-use-terminal skill install` |
+| Directly control a browser with Python | `browser-use <<'PY' ... PY` |
 
 ### Python Cannot Find `browser_use.beta`
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates docs for Browser Use CLI v3 to a Python‑first, Browser Harness–backed flow with `uv` install, `browser-use auth` for auth, REST-based agent signup, and named cloud browsers driven via Python helpers and `BU_NAME`. Removes remaining `cloud signup`/`cloud connect` content and cleans up generated refs.

- **Docs**
  - Install: `uv tool install browser-use`; one‑off `uvx browser-use`; add PowerShell here‑string.
  - Auth: use `browser-use auth login` / `auth status`; add `--doctor`.
  - Cloud usage: start/stop named remote browsers in Python (`start_remote_daemon("name")` / `stop_remote_daemon("name")`), run follow‑ups with `BU_NAME=name browser-use <<'PY' ... PY`.
  - Local usage: default to attach to running Chrome via CDP; document `BU_CDP_URL` / `BU_CDP_WS`.
  - Agent signup: REST flow only; then `export BROWSER_USE_API_KEY=bu_...` and `browser-use auth status`; claim via REST link.
  - Tutorials (Claude Code, Hermes, OpenClaw): move to `uv`, `npx skills add`, `auth login`, REST self‑registration, and Python heredocs driving named cloud browsers.
  - CLI guide: rewritten around Browser Harness and Python snippets; drop legacy REST passthrough tables (`cloud v2/v3`) and old `cloud connect` commands; add a short “Useful commands”; align Terminal docs (“Which command should I use?”) to Python.
  - x402 guide: asyncio‑safe Python/TS and BYO‑client snippets, wallet balance checks, top‑ups for existing API keys, and clearer troubleshooting.
  - Generated refs: synced `llms-full` across sections and removed remaining `cloud signup`/`cloud connect` remnants.

- **Migration**
  - Install with `uv tool install browser-use` (or `uvx browser-use`).
  - Auth with `browser-use auth login` / `auth status` (replaces `browser-use cloud login` / `cloud connect`).
  - Cloud sessions: `start_remote_daemon("<name>")`, run with `BU_NAME=<name>`, stop with `stop_remote_daemon("<name>")`.
  - Agent self‑registration via REST; then set `BROWSER_USE_API_KEY` and verify with `auth status`.

<sup>Written for commit a243189fc11eaa54f13b9b06dee317d16bc1019f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

