### PR TITLE
Docs/browser use cli 3

### DIFF
--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1855,12 +1855,12 @@ curl -fsSL https://browser-use.com/cli/install.sh | bash
 browser-use doctor
 ```
 
-**3. Install the skill**
+**3. Set up the agent**
 
-Ask your OpenClaw agent to install it directly from [ClawHub](https://clawhub.ai/ShawnPana/browser-use), or install from [skills.sh](https://skills.sh/browser-use/browser-use/browser-use):
+Paste this setup prompt into your OpenClaw agent:
 
-```bash
-npx skills add https://github.com/browser-use/browser-use --skill browser-use
+```text
+Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
 ```
 
 Once the skill is loaded, OpenClaw agents can use the `browser-use` CLI to navigate pages, click elements, fill forms, take screenshots, extract data, and more. The skill file teaches the agent the full command set.

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1860,7 +1860,7 @@ browser-use doctor
 Paste this setup prompt into your OpenClaw agent:
 
 ```text
-Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
+Install or upgrade browser-use with `uv tool install --python 3.12 --upgrade --force 'browser-use @ git+https://github.com/browser-use/browser-use.git'`, run `browser-use skill install`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
 ```
 
 Once the skill is loaded, OpenClaw agents can use the `browser-use` CLI to navigate pages, click elements, fill forms, take screenshots, extract data, and more. The skill file teaches the agent the full command set.

--- a/docs/cloud/tutorials/integrations/claude-code.mdx
+++ b/docs/cloud/tutorials/integrations/claude-code.mdx
@@ -19,12 +19,12 @@ uv tool install browser-use
 browser-use doctor
 ```
 
-**3. Install the skill**
+**3. Register the skill**
 
-Install the Browser Use skill into Claude Code:
+Register the Browser Use skill with the installed CLI:
 
 ```bash
-npx skills add https://github.com/browser-use/browser-use --skill browser-use
+browser-use skill install
 ```
 
 **4. Authenticate for cloud browsers**
@@ -55,7 +55,7 @@ Install the Browser Use CLI and skill:
 
 ```bash
 uv tool install browser-use
-npx skills add https://github.com/browser-use/browser-use --skill browser-use
+browser-use skill install
 ```
 
 Claude Code can follow the [REST flow](/cloud/agent-signup#rest-flow) to request and verify a challenge, then put the returned key in its shell environment:

--- a/docs/cloud/tutorials/integrations/hermes-agent.mdx
+++ b/docs/cloud/tutorials/integrations/hermes-agent.mdx
@@ -68,12 +68,12 @@ uv tool install browser-use
 browser-use doctor
 ```
 
-**3. Install the skill**
+**3. Register the skill**
 
-Install the Browser Use skill into Hermes:
+Register the Browser Use skill with the installed CLI:
 
 ```bash
-npx skills add https://github.com/browser-use/browser-use --skill browser-use
+browser-use skill install
 ```
 
 Or ask Hermes directly in chat to install it.
@@ -106,7 +106,7 @@ Install the Browser Use CLI and skill:
 
 ```bash
 uv tool install browser-use
-npx skills add https://github.com/browser-use/browser-use --skill browser-use
+browser-use skill install
 ```
 
 The agent can follow the [REST flow](/cloud/agent-signup#rest-flow) to request and verify a challenge, then use the returned API key.

--- a/docs/cloud/tutorials/integrations/openclaw.mdx
+++ b/docs/cloud/tutorials/integrations/openclaw.mdx
@@ -87,7 +87,7 @@ browser-use doctor
 Paste this setup prompt into your OpenClaw agent:
 
 ```text
-Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
+Install or upgrade browser-use with `uv tool install --python 3.12 --upgrade --force 'browser-use @ git+https://github.com/browser-use/browser-use.git'`, run `browser-use skill install`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
 ```
 
 Once the skill is loaded, OpenClaw agents can use the `browser-use` CLI to drive pages through Browser Harness and Python helpers.

--- a/docs/cloud/tutorials/integrations/openclaw.mdx
+++ b/docs/cloud/tutorials/integrations/openclaw.mdx
@@ -82,12 +82,12 @@ uv tool install browser-use
 browser-use doctor
 ```
 
-**3. Install the skill**
+**3. Set up the agent**
 
-Install the Browser Use skill into your coding agent:
+Paste this setup prompt into your OpenClaw agent:
 
-```bash
-npx skills add https://github.com/browser-use/browser-use --skill browser-use
+```text
+Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
 ```
 
 Once the skill is loaded, OpenClaw agents can use the `browser-use` CLI to drive pages through Browser Harness and Python helpers.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1855,12 +1855,12 @@ curl -fsSL https://browser-use.com/cli/install.sh | bash
 browser-use doctor
 ```
 
-**3. Install the skill**
+**3. Set up the agent**
 
-Ask your OpenClaw agent to install it directly from [ClawHub](https://clawhub.ai/ShawnPana/browser-use), or install from [skills.sh](https://skills.sh/browser-use/browser-use/browser-use):
+Paste this setup prompt into your OpenClaw agent:
 
-```bash
-npx skills add https://github.com/browser-use/browser-use --skill browser-use
+```text
+Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
 ```
 
 Once the skill is loaded, OpenClaw agents can use the `browser-use` CLI to navigate pages, click elements, fill forms, take screenshots, extract data, and more. The skill file teaches the agent the full command set.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1860,7 +1860,7 @@ browser-use doctor
 Paste this setup prompt into your OpenClaw agent:
 
 ```text
-Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
+Install or upgrade browser-use with `uv tool install --python 3.12 --upgrade --force 'browser-use @ git+https://github.com/browser-use/browser-use.git'`, run `browser-use skill install`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
 ```
 
 Once the skill is loaded, OpenClaw agents can use the `browser-use` CLI to navigate pages, click elements, fill forms, take screenshots, extract data, and more. The skill file teaches the agent the full command set.

--- a/docs/open-source/browser-use-cli.mdx
+++ b/docs/open-source/browser-use-cli.mdx
@@ -26,7 +26,7 @@ For one-off runs without a permanent tool install, use `uvx browser-use`.
 Paste this setup prompt into Claude Code, Codex, or another coding agent:
 
 ```text
-Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
+Install or upgrade browser-use with `uv tool install --python 3.12 --upgrade --force 'browser-use @ git+https://github.com/browser-use/browser-use.git'`, run `browser-use skill install`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
 ```
 
 The skill is discoverable from [skills.sh](https://skills.sh/browser-use/browser-use/browser-use).

--- a/docs/open-source/browser-use-cli.mdx
+++ b/docs/open-source/browser-use-cli.mdx
@@ -21,12 +21,12 @@ browser-use --help
 
 For one-off runs without a permanent tool install, use `uvx browser-use`.
 
-## Install the Agent Skill
+## Set Up Your Agent
 
-This adds Browser Use instructions to Claude Code, Codex, and other coding agents:
+Paste this setup prompt into Claude Code, Codex, or another coding agent:
 
-```bash
-npx skills add https://github.com/browser-use/browser-use --skill browser-use
+```text
+Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
 ```
 
 The skill is discoverable from [skills.sh](https://skills.sh/browser-use/browser-use/browser-use).
@@ -103,7 +103,6 @@ browser-use --help
 browser-use --doctor
 browser-use auth login
 browser-use auth status
-npx skills add https://github.com/browser-use/browser-use --skill browser-use
 browser-use skill show
 browser-use telemetry status
 ```

--- a/docs/open-source/examples/skills/browser-use.mdx
+++ b/docs/open-source/examples/skills/browser-use.mdx
@@ -9,7 +9,7 @@ The `browser-use` skill teaches your agent the [Browser Use CLI](/open-source/br
 ## Install
 
 ```text
-Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
+Install or upgrade browser-use with `uv tool install --python 3.12 --upgrade --force 'browser-use @ git+https://github.com/browser-use/browser-use.git'`, run `browser-use skill install`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
 ```
 
 ## Links

--- a/docs/open-source/examples/skills/browser-use.mdx
+++ b/docs/open-source/examples/skills/browser-use.mdx
@@ -8,8 +8,8 @@ The `browser-use` skill teaches your agent the [Browser Use CLI](/open-source/br
 
 ## Install
 
-```bash
-npx skills add https://github.com/browser-use/browser-use --skill browser-use
+```text
+Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
 ```
 
 ## Links

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -755,12 +755,12 @@ browser-use --help
 
 For one-off runs without a permanent tool install, use `uvx browser-use`.
 
-## Install the Agent Skill
+## Set Up Your Agent
 
-This adds Browser Use instructions to Claude Code, Codex, and other coding agents:
+Paste this setup prompt into Claude Code, Codex, or another coding agent:
 
-```bash
-npx skills add https://github.com/browser-use/browser-use --skill browser-use
+```text
+Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
 ```
 
 The skill is discoverable from [skills.sh](https://skills.sh/browser-use/browser-use/browser-use).
@@ -837,7 +837,6 @@ browser-use --help
 browser-use --doctor
 browser-use auth login
 browser-use auth status
-npx skills add https://github.com/browser-use/browser-use --skill browser-use
 browser-use skill show
 browser-use telemetry status
 ```

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -760,7 +760,7 @@ For one-off runs without a permanent tool install, use `uvx browser-use`.
 Paste this setup prompt into Claude Code, Codex, or another coding agent:
 
 ```text
-Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
+Install or upgrade browser-use with `uv tool install --python 3.12 --upgrade --force 'browser-use @ git+https://github.com/browser-use/browser-use.git'`, run `browser-use skill install`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
 ```
 
 The skill is discoverable from [skills.sh](https://skills.sh/browser-use/browser-use/browser-use).


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Revamps docs for Browser Use CLI v3: switches to `uv` install and pivots to Python-first control via Browser Harness. Standardizes skill registration with `browser-use skill install` and replaces `npx` steps with a pasteable agent setup prompt across guides.

- **Migration**
  - Install with `uv tool install browser-use` (or `uvx browser-use` for one-offs).
  - Use `browser-use auth login` and `browser-use auth status` instead of `cloud login`.
  - Agent self-registration now follows the REST flow; set `BROWSER_USE_API_KEY=bu_...` and run `browser-use auth status`; claim via the REST endpoint.
  - Cloud browsers are named: start with `start_remote_daemon("<name>")`, run with `BU_NAME=<name> browser-use <<'PY' ... PY`, stop with `stop_remote_daemon("<name>")`.
  - Register the skill with `browser-use skill install`. Docs rename to “Register the skill”/“Set up the agent” and add a paste prompt that runs `uv tool install --python 3.12 --upgrade --force 'browser-use @ git+https://github.com/browser-use/browser-use.git'`, then `browser-use skill install`, and connects to your browser (Claude Code, Hermes, OpenClaw, OSS examples). Remaining `npx skills add` snippets are removed.
  - x402 guide expanded with async examples and balance/top‑up usage via `https://x402.api.browser-use.com`; minor formatting fixes included.

<sup>Written for commit a35d36c195a449cfd8812971d9d0097546a130f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

