### PR TITLE
docs: rework CLI page cloud CTA copy

### DIFF
--- a/docs/open-source/browser-use-cli.mdx
+++ b/docs/open-source/browser-use-cli.mdx
@@ -10,7 +10,7 @@ The Browser Use CLI (`browser-use`) gives coding agents a direct browser-control
 - **Three browser modes** — you can use with local Chrome or Chromium with your existing tabs, cookies, extensions, and logins; Browser Use cloud browsers; or any browser reachable through a CDP endpoint.
 - **Agent-ready setup** — install the skill into Claude Code, Codex, and other coding agents so they know when and how to call the CLI.
 
-To try the hosted agent directly, use [Browser Use Cloud](https://cloud.browser-use.com?utm_source=docs&utm_medium=browser-use-cli&utm_campaign=v4), or install the skill.
+Try out Browser Use CLI with an agent in [Browser Use Cloud](https://cloud.browser-use.com?utm_source=docs&utm_medium=browser-use-cli&utm_campaign=v4), or install the skill to try it yourself locally.
 
 ## Install the CLI
 


### PR DESCRIPTION
## What

Rewrites the cloud CTA sentence on the Browser Use CLI docs page (`/open-source/browser-use-cli`):

**Before:** "To try the hosted agent directly, use [Browser Use Cloud](…), or install the skill."

**After:** "Try out Browser Use CLI with an agent in [Browser Use Cloud](…), or install the skill to try it yourself locally."

## Why

Since the CLI 3.0 launch, the page has had ~1,800 views but the tagged cloud link recorded zero clicks (verified end-to-end in PostHog — tracking works; the copy just wasn't landing). The new copy frames the cloud path as trying the CLI itself with an agent, rather than a detour to a different product, and clarifies the skill path as the local option.

The existing UTM parameters (`utm_source=docs&utm_medium=browser-use-cli&utm_campaign=v4`) are unchanged, so click-through will be measurable on the same PostHog funnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the cloud CTA on the `/open-source/browser-use-cli` docs page to position Browser Use Cloud as a way to try the CLI with an agent, and clarify the skill as the local option. UTM parameters remain the same to preserve existing PostHog tracking.

<sup>Written for commit 82c04fe8aa7efc8378ae289a1e3a8b2f464570d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

