### PR TITLE
[codex] Clarify open-source telemetry wording

### DIFF
--- a/docs/open-source/development/monitoring/telemetry.mdx
+++ b/docs/open-source/development/monitoring/telemetry.mdx
@@ -7,7 +7,7 @@ mode: "wide"
 
 ## Overview
 
-Browser Use is free under the MIT license. To help us continue improving the library, we collect anonymous usage data with [PostHog](https://posthog.com) . This information helps us understand how the library is used, fix bugs more quickly, and prioritize new features.
+Browser Use is free under the MIT license. To help us continue improving the library, we collect usage telemetry with [PostHog](https://posthog.com). Telemetry may include usage metadata and task-level data such as task instructions, URLs visited, action traces, errors, and final results. We may use this information to operate, debug, secure, analyze, develop, and improve Browser Use and related offerings, including by creating aggregated, de-identified, or sanitized datasets and workflow patterns in accordance with our Terms of Service and Privacy Policy.
 
 
 ## Opting Out


### PR DESCRIPTION
## Summary
- removes the claim that open-source telemetry is anonymous
- describes the task-level telemetry fields that may be collected
- keeps the existing opt-out instructions intact

## Validation
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified open-source telemetry docs: removed the “anonymous” claim, listed task-level data collected with PostHog, and noted how telemetry may be used with links to our Terms and Privacy Policy. Opt-out instructions remain unchanged.

<sup>Written for commit 2adc63898f6645af06fb6d14980fb2eb1eba1d77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

