### PR TITLE
Link generated LLM docs to product map and pricing

### DIFF
--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -10,6 +10,8 @@
 - Dashboard: https://cloud.browser-use.com
 - Create API key: https://cloud.browser-use.com/settings?tab=api-keys&new=1
 - Docs: https://docs.browser-use.com
+- Product map: https://browser-use.com/llms.txt — Choose between Hosted Agents, Browser Infrastructure, and the Open Source Library.
+- Pricing: https://browser-use.com/pricing.md — Current plans, credits, browser and proxy rates, model token prices, and billing behavior.
 - OpenAPI spec (v4): https://docs.browser-use.com/cloud/openapi/v4.json
 - Open-source repo: https://github.com/browser-use/browser-use — The open-source Python library. Note: the open-source API is different from the Cloud SDK. If you want the easiest path to production with managed infrastructure, use the Cloud SDK below.
 

--- a/docs/generate-llms-txt.sh
+++ b/docs/generate-llms-txt.sh
@@ -249,6 +249,8 @@ cat > "$CLOUD_INDEX" << 'HEADER'
 - Dashboard: https://cloud.browser-use.com
 - Create API key: https://cloud.browser-use.com/settings?tab=api-keys&new=1
 - Docs: https://docs.browser-use.com
+- Product map: https://browser-use.com/llms.txt — Choose between Hosted Agents, Browser Infrastructure, and the Open Source Library.
+- Pricing: https://browser-use.com/pricing.md — Current plans, credits, browser and proxy rates, model token prices, and billing behavior.
 - OpenAPI spec (v4): https://docs.browser-use.com/cloud/openapi/v4.json
 - Open-source repo: https://github.com/browser-use/browser-use — The open-source Python library. Note: the open-source API is different from the Cloud SDK. If you want the easiest path to production with managed infrastructure, use the Cloud SDK below.
 
@@ -300,6 +302,7 @@ cat > "$OS_INDEX" << 'HEADER'
 
 - GitHub: https://github.com/browser-use/browser-use
 - Docs: https://docs.browser-use.com/open-source/introduction
+- Product map: https://browser-use.com/llms.txt — Compare the Open Source Library with Hosted Agents and Browser Infrastructure.
 
 Install: `pip install browser-use`
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10,6 +10,8 @@
 - Dashboard: https://cloud.browser-use.com
 - Create API key: https://cloud.browser-use.com/settings?tab=api-keys&new=1
 - Docs: https://docs.browser-use.com
+- Product map: https://browser-use.com/llms.txt — Choose between Hosted Agents, Browser Infrastructure, and the Open Source Library.
+- Pricing: https://browser-use.com/pricing.md — Current plans, credits, browser and proxy rates, model token prices, and billing behavior.
 - OpenAPI spec (v4): https://docs.browser-use.com/cloud/openapi/v4.json
 - Open-source repo: https://github.com/browser-use/browser-use — The open-source Python library. Note: the open-source API is different from the Cloud SDK. If you want the easiest path to production with managed infrastructure, use the Cloud SDK below.
 

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -13,7 +13,6 @@ Full SDK reference in a single page.
 
   Try [Browser Use Cloud](https://docs.browser-use.com/cloud/introduction) for our SOTA model, stealth browsers, CAPTCHA solving, and managed infrastructure.
 
-
 # Human Quickstart
 Source: https://docs.browser-use.com/open-source/quickstart
 
@@ -168,7 +167,6 @@ if __name__ == "__main__":
 
 See [Browser Use Cloud](https://docs.browser-use.com/cloud/quickstart) for how to sync your cookies to the cloud.
 
-
 # Prompts for Vibecoders
 Source: https://docs.browser-use.com/open-source/vibecoding
 
@@ -178,7 +176,6 @@ Source: https://docs.browser-use.com/open-source/vibecoding
 1. Copy all content [🔗  from here](https://github.com/browser-use/browser-use/blob/main/AGENTS.md) (~9k tokens)
 2. Paste it into your project
 3. Prompt your coding agent (Cursor, Claude, etc.) "Help me get started with Browser Use"
-
 
 # Supported Models
 Source: https://docs.browser-use.com/open-source/supported-models
@@ -191,6 +188,8 @@ Browser Use natively supports 15+ LLM providers. Most providers accept any model
 ### Browser Use [example](https://github.com/browser-use/browser-use/blob/main/examples/models/browser_use_llm.py)
 
 `ChatBrowserUse()` is our optimized in-house model, matching the accuracy of top models while completing tasks **3-5x** faster. [See our blog post→](https://browser-use.com/posts/speed-matters)
+
+  Read the [bu-2-0 model card](/open-source/bu-2-0-model-card) for details on intended use, inputs and outputs, tools, benchmarks, judge setup, and limitations.
 
 ```python
 from browser_use import Agent, ChatBrowserUse
@@ -733,18 +732,17 @@ Any provider with an OpenAI-compatible endpoint works via `ChatOpenAI` with a cu
 **Examples available:**
 - [Novita](https://github.com/browser-use/browser-use/blob/main/examples/models/novita.py)
 
-
 # Browser Use CLI
 Source: https://docs.browser-use.com/open-source/browser-use-cli
 
 
-The Browser Use CLI (`browser-use`) is the command-line interface for the Browser Use platform. It uses [Browser Harness](https://github.com/browser-use/browser-harness) to allow for:
+The Browser Use CLI (`browser-use`) gives coding agents a direct browser-control surface backed by [Browser Harness](https://github.com/browser-use/browser-harness):
 
 - **Direct browser control** — agents run Python to do actions in the browser.
 - **Three browser modes** — you can use with local Chrome or Chromium with your existing tabs, cookies, extensions, and logins; Browser Use cloud browsers; or any browser reachable through a CDP endpoint.
 - **Agent-ready setup** — install the skill into Claude Code, Codex, and other coding agents so they know when and how to call the CLI.
 
-To try the hosted agent directly, use [Browser Use Cloud](https://cloud.browser-use.com?utm_source=docs&utm_medium=browser-use-cli&utm_campaign=v4), or install the skill.
+Try out Browser Use CLI with an agent in [Browser Use Cloud](https://cloud.browser-use.com?utm_source=docs&utm_medium=browser-use-cli&utm_campaign=v4), or install the skill to try it yourself locally.
 
 ## Install the CLI
 
@@ -841,7 +839,6 @@ browser-use skill show
 browser-use telemetry status
 ```
 
-
 # Browser Use Terminal
 Source: https://docs.browser-use.com/open-source/browser-use-terminal
 
@@ -868,9 +865,7 @@ Give this employee admin permission in Azure.
 Research the top Hacker News stories and summarize the points.
 ```
 
-<video
-  controls
-  className="w-full aspect-video rounded-xl">
+<video controls className="w-full aspect-video rounded-xl">
   <source
 src="https://media.githubusercontent.com/media/browser-use/sdk/rust-terminal-docs/docs/static/terminal_demo.mp4"
 type="video/mp4"
@@ -881,15 +876,18 @@ type="video/mp4"
   />
 </video>
 
-You can use Browser Use Terminal in three ways:
+You can use Browser Use Terminal in four ways:
 
-| Surface | What it is for |
-| --- | --- |
-| **TUI** | The interactive terminal app you launch with `browser`. Best for normal, hands-on use. |
-| **CLI** | Scriptable commands such as `browser-use-terminal run-openai`. Best for automation and one-off tasks. |
-| **Python** | `browser_use.beta.Agent`, backed by the same Rust runtime. Best when you want browser-use code with terminal runtime behavior. |
+| Surface               | What it is for                                                                                                                                                                                |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **TUI**               | The interactive terminal app you launch with `browser`. Best for normal, hands-on use.                                                                                                        |
+| **CLI**               | Scriptable commands such as `browser-use-terminal run-openai`. Best for automation and one-off tasks.                                                                                         |
+| **Python**            | `browser_use.beta.Agent`, backed by the same Rust runtime. Best when you want browser-use code with terminal runtime behavior.                                                                |
+| **Coding assistants** | A skill plus the `browser-use-terminal browser` commands let Claude Code, Codex, OpenCode, and other agents drive the browser. See [Use From Coding Assistants](#use-from-coding-assistants). |
 
-Browser Use Terminal is separate from the lower-level `browser-use` CLI. Use `browser` for the Terminal TUI, `browser-use-terminal` for Terminal task commands, and `browser-use` for direct browser-control commands.
+  Browser Use Terminal is separate from the lower-level `browser-use` CLI. Use
+  `browser` for the Terminal TUI, `browser-use-terminal` for Terminal task
+  commands, and `browser-use` for direct browser-control commands.
 
 ## Terms
 
@@ -936,25 +934,25 @@ uv pip install browser-use
 
 In the TUI, type `/` to open the command palette. These are the main commands:
 
-| Command | What it does |
-| --- | --- |
-| `/task` | Start a new task. |
-| `/model` | Choose the model and provider. |
-| `/auth` | Sign in to a provider. |
-| `/browser` | Change the browser backend. |
-| `/profile` | Choose the default Chrome profile. |
-| `/history` | Browse previous tasks. |
-| `/context` | Inspect context window attribution. |
-| `/secrets` | Save passwords and 2FA setup keys for website logins. |
-| `/import-passwords` | Import saved logins from 1Password. |
-| `/domains` | Allow or block which sites the agent can visit. |
-| `/sync-cookies` | Sync local cookies. |
-| `/email` | Give the agent a disposable inbox for sign-ups, links, and codes. |
-| `/goal` | Set or view the goal for a long-running task. |
-| `/feedback` | Report a bug or share feedback. |
-| `/update` | Install the latest release. |
-| `/reload` | Restart the UI in this terminal. |
-| `/exit` | Quit Browser Use Terminal. |
+| Command             | What it does                                                      |
+| ------------------- | ----------------------------------------------------------------- |
+| `/task`             | Start a new task.                                                 |
+| `/model`            | Choose the model and provider.                                    |
+| `/auth`             | Sign in to a provider.                                            |
+| `/browser`          | Change the browser backend.                                       |
+| `/profile`          | Choose the default Chrome profile.                                |
+| `/history`          | Browse previous tasks.                                            |
+| `/context`          | Inspect context window attribution.                               |
+| `/secrets`          | Save passwords and 2FA setup keys for website logins.             |
+| `/import-passwords` | Import saved logins from 1Password.                               |
+| `/domains`          | Allow or block which sites the agent can visit.                   |
+| `/sync-cookies`     | Sync local cookies.                                               |
+| `/email`            | Give the agent a disposable inbox for sign-ups, links, and codes. |
+| `/goal`             | Set or view the goal for a long-running task.                     |
+| `/feedback`         | Report a bug or share feedback.                                   |
+| `/update`           | Install the latest release.                                       |
+| `/reload`           | Restart the UI in this terminal.                                  |
+| `/exit`             | Quit Browser Use Terminal.                                        |
 
 ## Run Browser Tasks
 
@@ -1029,6 +1027,44 @@ async def main():
 asyncio.run(main())
 ```
 
+## Use From Coding Assistants
+
+Browser Use Terminal plugs into any coding assistant that can run shell commands. A skill teaches the assistant the CLI, and the CLI gives it the full browser runtime: page interaction through Python helpers, screenshots saved as files, profiles, and more.
+
+The fastest setup is to paste this URL into your assistant and let it bootstrap everything (install, skill registration, browser setup, verification):
+
+```text
+https://browser-use.com/skill
+```
+
+To set it up manually instead:
+
+```bash
+curl -fsSL https://browser-use.com/terminal/install.sh | sh
+browser-use-terminal skill install
+```
+
+`skill install` writes the skill into every detected assistant home: `~/.claude/skills/` (Claude Code, also read by OpenCode), `~/.codex/skills/` (Codex), `~/.config/opencode/skills/`, and `~/.agents/skills/`. For other assistants, persist the output of `browser-use-terminal skill show` wherever that assistant reads instructions.
+
+The assistant then drives the browser with commands:
+
+```bash
+browser-use-terminal browser exec <<'PY'
+new_tab("https://example.com")
+wait_for_load()
+print(page_info()["title"])
+print(capture_screenshot())
+PY
+```
+
+How it works:
+
+- The browser auto-connects per the remembered preference (`browser-use-terminal browser preference use local|cloud|managed-headless`) and persists across invocations; Python variables do not.
+- Screenshots are saved as files and the absolute path is printed, so assistants view them with their native file tools: Claude Code `Read`, Codex `view_image`, OpenCode `read`, Gemini CLI `read_file`.
+- `--session <name>` gives parallel workstreams isolated artifact dirs, event logs, and managed browsers.
+- Stop persistent browsers with `browser-use-terminal browser recover stop-owned-browser` (managed) or `browser-use-terminal browser recover stop-owned-remote` (cloud).
+- Everything is recorded in the same event log as the TUI: `browser-use-terminal events browser-cli-<session>`.
+
 ## Configure Models
 
 ### TUI
@@ -1078,13 +1114,13 @@ agent = Agent(
 
 Supported Python model classes:
 
-| Python model class | Example |
-| --- | --- |
-| `ChatOpenAI` | `ChatOpenAI(model="gpt-5.5")` |
-| `ChatAnthropic` | `ChatAnthropic(model="claude-sonnet-4-6")` |
-| `ChatLiteLLM` | `ChatLiteLLM(model="openai/gpt-5.5")` |
-| `ChatDeepSeek` | `ChatDeepSeek(model="deepseek-v4-pro")` |
-| `ChatOpenRouter` | `ChatOpenRouter(model="openai/gpt-5.5")` |
+| Python model class | Example                                    |
+| ------------------ | ------------------------------------------ |
+| `ChatOpenAI`       | `ChatOpenAI(model="gpt-5.5")`              |
+| `ChatAnthropic`    | `ChatAnthropic(model="claude-sonnet-4-6")` |
+| `ChatLiteLLM`      | `ChatLiteLLM(model="openai/gpt-5.5")`      |
+| `ChatDeepSeek`     | `ChatDeepSeek(model="deepseek-v4-pro")`    |
+| `ChatOpenRouter`   | `ChatOpenRouter(model="openai/gpt-5.5")`   |
 
 ## Choose A Browser
 
@@ -1396,14 +1432,14 @@ curl -fsSL https://browser-use.com/terminal/install.sh | sh
 
 ### Which Command Should I Use?
 
-| Goal | Command |
-| --- | --- |
-| Open the interactive Terminal app | `browser` |
-| Run a one-shot Terminal agent task | `browser-use-terminal run-openai "..."` |
-| Use Terminal runtime from Python | `browser_use.beta.Agent` |
-| Drive the browser from a coding assistant | `browser-use-terminal browser exec` |
-| Register the skill with coding assistants | `browser-use-terminal skill install` |
-| Directly control a browser with Python | `browser-use <<'PY' ... PY` |
+| Goal                                      | Command                                 |
+| ----------------------------------------- | --------------------------------------- |
+| Open the interactive Terminal app         | `browser`                               |
+| Run a one-shot Terminal agent task        | `browser-use-terminal run-openai "..."` |
+| Use Terminal runtime from Python          | `browser_use.beta.Agent`                |
+| Drive the browser from a coding assistant | `browser-use-terminal browser exec`     |
+| Register the skill with coding assistants | `browser-use-terminal skill install`    |
+| Directly control a browser with Python    | `browser-use <<'PY' ... PY`             |
 
 ### Python Cannot Find `browser_use.beta`
 
@@ -1418,30 +1454,30 @@ python -c "from browser_use.beta import Agent; print('ok')"
 
 When you use `browser_use.beta.Agent`, these Python settings are forwarded to the Rust terminal SDK:
 
-| Python setting | Terminal SDK field |
-| --- | --- |
-| `llm.provider`, inferred from the chat model | `llm.provider` |
-| `llm.model` | `llm.model` |
-| `llm_timeout` | `llm.timeout` |
-| `headless` | `browser.headless` |
-| `keep_alive` | `browser.keep_alive` |
-| `cloud_profile_id`, `profile_id` | `browser.profile_id` |
+| Python setting                                   | Terminal SDK field           |
+| ------------------------------------------------ | ---------------------------- |
+| `llm.provider`, inferred from the chat model     | `llm.provider`               |
+| `llm.model`                                      | `llm.model`                  |
+| `llm_timeout`                                    | `llm.timeout`                |
+| `headless`                                       | `browser.headless`           |
+| `keep_alive`                                     | `browser.keep_alive`         |
+| `cloud_profile_id`, `profile_id`                 | `browser.profile_id`         |
 | `cloud_proxy_country_code`, `proxy_country_code` | `browser.proxy_country_code` |
-| `cdp_url` | `browser.cdp_url` |
-| `headers` / CDP headers | `browser.cdp_headers` |
-| `user_agent` | `browser.user_agent` |
-| `viewport` | `browser.viewport` |
-| `window_size` | `browser.window_size` |
-| `storage_state` | `browser.storage_state` |
-| `downloads_path` | `browser.downloads_path` |
-| `allowed_domains` | `browser.allowed_domains` |
-| `prohibited_domains` | `browser.blocked_domains` |
-| `state_dir` | `browser.state_dir` |
-| `no_viewport` | `browser.no_viewport` |
-| `accept_downloads` | `browser.accept_downloads` |
-| `output_model_schema` | `output_schema` |
-| `calculate_cost` | `calculate_cost` |
-| `max_actions_per_step` | `max_actions_per_step` |
+| `cdp_url`                                        | `browser.cdp_url`            |
+| `headers` / CDP headers                          | `browser.cdp_headers`        |
+| `user_agent`                                     | `browser.user_agent`         |
+| `viewport`                                       | `browser.viewport`           |
+| `window_size`                                    | `browser.window_size`        |
+| `storage_state`                                  | `browser.storage_state`      |
+| `downloads_path`                                 | `browser.downloads_path`     |
+| `allowed_domains`                                | `browser.allowed_domains`    |
+| `prohibited_domains`                             | `browser.blocked_domains`    |
+| `state_dir`                                      | `browser.state_dir`          |
+| `no_viewport`                                    | `browser.no_viewport`        |
+| `accept_downloads`                               | `browser.accept_downloads`   |
+| `output_model_schema`                            | `output_schema`              |
+| `calculate_cost`                                 | `calculate_cost`             |
+| `max_actions_per_step`                           | `max_actions_per_step`       |
 
 The same Python `Agent` instance can continue a terminal-backed session across follow-up runs.
 
@@ -1475,7 +1511,6 @@ printf '%s' "$BASE32_TOTP_SEED" | browser-use-terminal secrets set \
   --stdin
 ```
 
-
 # Configuration
 Source: https://docs.browser-use.com/open-source/customize/agent/basics
 
@@ -1502,7 +1537,6 @@ The agent is executed using the async `run()` method:
 - `max_steps` (default: `100`): Maximum number of steps an agent can take.
 
 Check out all customizable parameters <a href="/open-source/customize/agent/all-parameters"> here</a>. 
-
 
 # Prompting Guide
 Source: https://docs.browser-use.com/open-source/customize/agent/prompting-guide
@@ -1595,7 +1629,6 @@ Robust data extraction:
 
 The key to effective prompting is being specific about actions.
 
-
 # Output Format
 Source: https://docs.browser-use.com/open-source/customize/agent/output-format
 
@@ -1638,7 +1671,6 @@ See all helper methods in the [AgentHistoryList source code](https://github.com/
 ## Structured Output
 
 For structured output, use the `output_model_schema` parameter with a Pydantic model. [Example](https://github.com/browser-use/browser-use/blob/main/examples/features/custom_output.py).
-
 
 # All Parameters
 Source: https://docs.browser-use.com/open-source/customize/agent/all-parameters
@@ -1781,7 +1813,6 @@ export TIMEOUT_BrowserStateRequestEvent=60.0
 export TIMEOUT_AgentEventBusStop=10.0
 ```
 
-
 # Configuration
 Source: https://docs.browser-use.com/open-source/customize/browser/basics
 
@@ -1807,7 +1838,6 @@ agent = Agent(
 async def main():
 	await agent.run()
 ```
-
 
 # Authentication
 Source: https://docs.browser-use.com/open-source/customize/browser/authentication
@@ -2135,7 +2165,6 @@ agent = Agent(
 await agent.run()
 ```
 
-
 # Real Browser
 Source: https://docs.browser-use.com/open-source/customize/browser/real-browser
 
@@ -2208,7 +2237,6 @@ browser = Browser(
 | macOS | `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` | `~/Library/Application Support/Google/Chrome` |
 | Windows | `C:\Program Files\Google\Chrome\Application\chrome.exe` | `%LocalAppData%\Google\Chrome\User Data` |
 | Linux | `/usr/bin/google-chrome` or `/usr/bin/chromium` | `~/.config/google-chrome` |
-
 
 # Remote Browser
 Source: https://docs.browser-use.com/open-source/customize/browser/remote
@@ -2292,7 +2320,6 @@ agent = Agent(
     browser=browser,
 )
 ```
-
 
 # All Parameters
 Source: https://docs.browser-use.com/open-source/customize/browser/all-parameters
@@ -2479,7 +2506,6 @@ for p in profiles:
 ]
 ```
 
-
 # Overview
 Source: https://docs.browser-use.com/open-source/customize/tools/basics
 
@@ -2509,7 +2535,6 @@ agent = Agent(
 The agent injects parameters by name matching, so using the wrong name will cause your tool to fail silently.
 
 Use `browser_session` parameter in tools for deterministic [Actor](/open-source/legacy/actor/basics) actions.
-
 
 # Available Tools
 Source: https://docs.browser-use.com/open-source/customize/tools/available
@@ -2556,7 +2581,6 @@ Source: https://docs.browser-use.com/open-source/customize/tools/available
 
 ### Task Completion
 - **`done`** - Complete the task (always available)
-
 
 # Add Tools
 Source: https://docs.browser-use.com/open-source/customize/tools/add
@@ -2726,7 +2750,6 @@ async def my_action(browser_session: BrowserSession) -> ActionResult:  # CORRECT
 3. **Return `ActionResult`** - not plain strings (though strings work, `ActionResult` provides more control)
 4. **Parameter names must match exactly** - see [Available Objects](#available-objects) for the full list of injectable parameters
 
-
 # Remove Tools
 Source: https://docs.browser-use.com/open-source/customize/tools/remove
 
@@ -2738,7 +2761,6 @@ from browser_use import Tools
 tools = Tools(exclude_actions=['search', 'wait'])
 agent = Agent(task='...', llm=llm, tools=tools)
 ```
-
 
 # Response Format
 Source: https://docs.browser-use.com/open-source/customize/tools/response
@@ -2816,7 +2838,6 @@ def finish_task() -> ActionResult:
         success=True         # Task succeeded 
     )
 ```
-
 
 # MCP Server
 Source: https://docs.browser-use.com/open-source/customize/integrations/mcp-server
@@ -3046,7 +3067,6 @@ uvx --from 'browser-use[cli]' browser-use --mcp
 - Check out [MCP documentation](https://modelcontextprotocol.io/) to learn more about the protocol
 - Join our [Discord](https://link.browser-use.com/discord) for support and discussions
 
-
 # Basics
 Source: https://docs.browser-use.com/open-source/legacy/actor/basics
 
@@ -3100,7 +3120,6 @@ async def main():
 - **Immediate Returns**: `get_elements_by_css_selector()` doesn't wait for visibility
 - **Manual Timing**: You handle navigation timing and waiting
 - **JavaScript Format**: `evaluate()` requires arrow function format: `() => {}`
-
 
 # Examples
 Source: https://docs.browser-use.com/open-source/legacy/actor/examples
@@ -3211,7 +3230,6 @@ await mouse.scroll(x=0, y=100, delta_y=-500)
 - Implement retry logic for flaky elements
 - Call `browser.stop()` to clean up resources
 
-
 # All Parameters
 Source: https://docs.browser-use.com/open-source/legacy/actor/all-parameters
 
@@ -3297,7 +3315,6 @@ Coordinate-based mouse operations.
 - `down(button='left')`, `up(button='left')` - Press/release buttons
 - `scroll(x=0, y=0, delta_x=None, delta_y=None)` - Scroll at coordinates
 
-
 # Quickstart
 Source: https://docs.browser-use.com/open-source/legacy/sandbox/quickstart
 
@@ -3346,7 +3363,6 @@ await task(url="https://example.com")
 
 For more parameters and events, see the other tabs in this section.
 
-
 # Events
 Source: https://docs.browser-use.com/open-source/legacy/sandbox/events
 
@@ -3376,7 +3392,6 @@ async def task(browser: Browser):
 ```
 
 All callbacks can be sync or async.
-
 
 # All Parameters
 Source: https://docs.browser-use.com/open-source/legacy/sandbox/all-parameters
@@ -3408,7 +3423,6 @@ async def task(browser: Browser):
     agent = Agent(task="your task", browser=browser, llm=ChatBrowserUse())
     await agent.run()
 ```
-
 
 # Fast Agent
 Source: https://docs.browser-use.com/open-source/examples/templates/fast-agent
@@ -3505,7 +3519,6 @@ agent = Agent(
 )
 ```
 
-
 # Follow up tasks
 Source: https://docs.browser-use.com/open-source/examples/templates/follow-up-tasks
 
@@ -3549,7 +3562,6 @@ asyncio.run(main())
 5. **Break down long flows**: If you have very long flows, you can keep the browser alive and send new agents to it.
 
 The browser session remains active throughout the entire chain, preserving all cookies, local storage, and page state.
-
 
 # Parallel Agents
 Source: https://docs.browser-use.com/open-source/examples/templates/parallel-browser
@@ -3596,7 +3608,6 @@ async def main():
 ```
 
 > **Note:** This is experimental, and agents might conflict each other.
-
 
 # Playwright Integration
 Source: https://docs.browser-use.com/open-source/examples/templates/playwright-integration
@@ -3994,7 +4005,6 @@ if __name__ == '__main__':
 	asyncio.run(main())
 ```
 
-
 # Sensitive Data
 Source: https://docs.browser-use.com/open-source/examples/templates/sensitive-data
 
@@ -4039,7 +4049,6 @@ async def main():
 - Use `Browser(allowed_domains=[...])` to restrict navigation
 - Set `use_vision=False` to prevent screenshot leaks  
 - Use `storage_state='./auth.json'` for login cookies instead of passwords when possible
-
 
 # Secure Setup
 Source: https://docs.browser-use.com/open-source/examples/templates/secure
@@ -4102,7 +4111,6 @@ asyncio.run(main())
 
 For enterprise deployments contact support@browser-use.com.
 
-
 # More Examples
 Source: https://docs.browser-use.com/open-source/examples/templates/more-examples
 
@@ -4114,7 +4122,6 @@ Source: https://docs.browser-use.com/open-source/examples/templates/more-example
 ### 🤝 Contributing Examples
 
 Have a great use case? **[Submit a pull request](https://github.com/browser-use/browser-use/pulls)** with your example!
-
 
 # Ad-Use (Ad Generator)
 Source: https://docs.browser-use.com/open-source/examples/apps/ad-use
@@ -4207,7 +4214,6 @@ Generated ads are saved in the `output/` directory with:
 
 Full implementation: [https://github.com/browser-use/browser-use/tree/main/examples/apps/ad-use](https://github.com/browser-use/browser-use/tree/main/examples/apps/ad-use)
 
-
 # Vibetest-Use (Automated QA)
 Source: https://docs.browser-use.com/open-source/examples/apps/vibetest-use
 
@@ -4298,7 +4304,6 @@ claude mcp add vibetest /full/path/to/vibetest-use/.venv/bin/vibetest-mcp \
 ## Source Code
 
 Full implementation: [https://github.com/browser-use/vibetest-use](https://github.com/browser-use/vibetest-use)
-
 
 # News-Use (News Monitor)
 Source: https://docs.browser-use.com/open-source/examples/apps/news-use
@@ -4429,7 +4434,6 @@ async def monitor_with_filters():
 
 Full implementation: [https://github.com/browser-use/browser-use/tree/main/examples/apps/news-use](https://github.com/browser-use/browser-use/tree/main/examples/apps/news-use)
 
-
 # Msg-Use (WhatsApp Sender)
 Source: https://docs.browser-use.com/open-source/examples/apps/msg-use
 
@@ -4550,6 +4554,144 @@ The scheduler processes natural language and outputs structured results:
 
 Full implementation: [https://github.com/browser-use/browser-use/tree/main/examples/apps/msg-use](https://github.com/browser-use/browser-use/tree/main/examples/apps/msg-use)
 
+# Overview
+Source: https://docs.browser-use.com/open-source/examples/skills/overview
+
+
+Browser Use ships a set of [agent skills](https://www.skills.sh/browser-use/browser-use) — self-contained `SKILL.md` bundles that teach a coding agent (Claude Code, Cursor, OpenClaw, Hermes, and others) how to use Browser Use. Each skill is installable from [skills.sh](https://www.skills.sh/browser-use/browser-use) with one command.
+
+## Install
+
+Every skill installs through the [skills CLI](https://www.skills.sh) with the same pattern — swap in the skill name with `--skill`:
+
+```bash
+npx skills add https://github.com/browser-use/browser-use --skill <name>
+```
+
+For example, to install the QA skill:
+
+```bash
+npx skills add https://github.com/browser-use/browser-use --skill qa
+```
+
+The skills CLI drops the skill into your agent's skills directory (e.g. `.claude/skills/` for Claude Code). Your agent picks it up automatically — no extra wiring.
+
+## Available skills
+
+Drive a browser directly from the CLI — navigate, click, fill forms, screenshot, and extract data.
+Reference for Browser Use Cloud — the hosted REST API (v2 & v3) and the Python/TypeScript SDKs.
+Reference for writing Python against the `browser-use` library — Agent, Browser, Tools, and more.
+QA-test any site or local dev server and return a 1–5 quality score with evidence.
+Control a headless browser from a sandboxed remote machine (cloud VMs, CI, coding agents).
+Pay for Browser Use Cloud per request from a crypto wallet — no signup or API key.
+
+## Source
+
+All skills live in the [`skills/` directory](https://github.com/browser-use/browser-use/tree/main/skills) of the `browser-use` repo.
+
+# browser-use
+Source: https://docs.browser-use.com/open-source/examples/skills/browser-use
+
+
+The `browser-use` skill teaches your agent the [Browser Use CLI](/open-source/browser-use-cli). The CLI runs Python in the browser to do actions online. The agent can connect to your real Chrome, preserving logins, or to a Browser Use cloud browser.
+
+## Install
+
+```text
+Install or upgrade browser-use with `uv tool install --python 3.12 --upgrade --force 'browser-use @ git+https://github.com/browser-use/browser-use.git'`, run `browser-use skill install`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
+```
+
+## Links
+
+  <Card
+title="skills.sh"
+icon="up-right-from-square"
+href="https://www.skills.sh/browser-use/browser-use/browser-use"
+  />
+  <Card
+title="Source"
+icon="github"
+href="https://github.com/browser-use/browser-use/tree/main/skills/browser-use"
+  />
+
+# cloud
+Source: https://docs.browser-use.com/open-source/examples/skills/cloud
+
+
+The `cloud` skill gives your agent a reference for [Browser Use Cloud](https://docs.browser-use.com/cloud/quickstart): the REST API (v2 and v3), the `browser-use-sdk` (Python and TypeScript), `X-Browser-Use-API-Key` authentication, cloud sessions, browser profiles and profile sync, CDP WebSocket access, stealth browsers, residential proxies, CAPTCHA handling, webhooks, workspaces, the skills marketplace, `liveUrl` streaming, pricing, and integration patterns (chat UI, subagents, n8n/Make/Zapier, Playwright/Puppeteer/Selenium).
+
+For the open-source Python library (`Agent`, `Browser`, `Tools`), use the [`open-source`](/open-source/examples/skills/open-source) skill instead.
+
+## Install
+
+```bash
+npx skills add https://github.com/browser-use/browser-use --skill cloud
+```
+
+## Links
+
+
+# open-source
+Source: https://docs.browser-use.com/open-source/examples/skills/open-source
+
+
+The `open-source` skill gives your agent a reference for writing Python against the [`browser-use` library](/open-source/quickstart): `Agent`, `Browser`, and `Tools` configuration, supported LLM models (15+ providers), the Actor API, custom tools, lifecycle hooks, MCP server setup, sensitive-data handling, prompting strategies, and monitoring/observability with Laminar or OpenLIT.
+
+For the Cloud API/SDK, use the [`cloud`](/open-source/examples/skills/cloud) skill. To drive a browser directly via CLI, use the [`browser-use`](/open-source/examples/skills/browser-use) skill.
+
+## Install
+
+```bash
+npx skills add https://github.com/browser-use/browser-use --skill open-source
+```
+
+## Links
+
+
+# qa
+Source: https://docs.browser-use.com/open-source/examples/skills/qa
+
+
+The `qa` skill drives a website with a real browser, judges how well it does the thing you asked about, and returns a **score from 1 (broken) to 5 (excellent)** with evidence — the deliverable is a verdict, not a screenshot dump. Use it to test, QA, evaluate, or score a site, page, flow, or app, including a local dev server (e.g. `localhost:5173`) which it tunnels out automatically. It runs on a real Browser Use cloud browser.
+
+## Install
+
+```bash
+npx skills add https://github.com/browser-use/browser-use --skill qa
+```
+
+## Links
+
+
+# remote-browser
+Source: https://docs.browser-use.com/open-source/examples/skills/remote-browser
+
+
+The `remote-browser` skill is for agents running on **sandboxed remote machines** (cloud VMs, CI, coding agents) that need to control a headless browser. It uses the same [Browser Use CLI](/open-source/browser-use-cli) workflow as the [`browser-use`](/open-source/examples/skills/browser-use) skill — `open`, `state`, `click`, `input`, `screenshot`, `close` — plus headless Chromium, cloud browsers, CDP connection, and tunnels to expose local dev servers.
+
+## Install
+
+```bash
+npx skills add https://github.com/browser-use/browser-use --skill remote-browser
+```
+
+## Links
+
+
+# x402
+Source: https://docs.browser-use.com/open-source/examples/skills/x402
+
+
+The `x402` skill walks your agent through setting up [Browser Use Cloud payments with x402](https://docs.browser-use.com/cloud/guides/x402) — pay per request from a crypto wallet (USDC on Base mainnet), with no signup, API key, or credit card. It guides wallet setup, funding, writing the key to `.env`, and a ~$1 test run. The SDK is the easiest path, and non-SDK flows are available via x402-aware client libraries. Use it when you want pay-per-use access without an API key.
+
+## Install
+
+```bash
+npx skills add https://github.com/browser-use/browser-use --skill x402
+```
+
+## Links
+
 
 # Local Development Setup
 Source: https://docs.browser-use.com/open-source/development/setup/local-setup
@@ -4598,7 +4740,6 @@ For common development tasks
 uv run examples/simple.py
 ```
 
-
 # Contribution Guide
 Source: https://docs.browser-use.com/open-source/development/setup/contribution-guide
 
@@ -4633,7 +4774,6 @@ Source: https://docs.browser-use.com/open-source/development/setup/contribution-
 3. Submit a PR
 
 We are overwhelmed with Issues. Feel free to bump your issues/PRs with comments periodically if you need faster feedback.
-
 
 # Lifecycle Hooks
 Source: https://docs.browser-use.com/open-source/customize/hooks
@@ -4751,7 +4891,6 @@ When working with agent hooks, you have access to the entire `Agent` instance. H
 
 ---
 
-
 # Observability
 Source: https://docs.browser-use.com/open-source/development/monitoring/observability
 
@@ -4850,7 +4989,6 @@ browser-use auth
 ```
 
 **Note**: Authentication uses OAuth Device Flow - you must complete the auth process while the command is running. Links expire when the polling stops.
-
 
 # OpenLIT
 Source: https://docs.browser-use.com/open-source/development/monitoring/openlit
@@ -4980,14 +5118,13 @@ OpenLIT uses OpenTelemetry internally, so it integrates seamlessly with:
 
 Simply configure OpenLIT to export to your existing OTLP-compatible endpoint.
 
-
 # Telemetry
 Source: https://docs.browser-use.com/open-source/development/monitoring/telemetry
 
 
 ## Overview
 
-Browser Use is free under the MIT license. To help us continue improving the library, we collect anonymous usage data with [PostHog](https://posthog.com) . This information helps us understand how the library is used, fix bugs more quickly, and prioritize new features.
+Browser Use is free under the MIT license. To help us continue improving the library, we collect usage telemetry with [PostHog](https://posthog.com). Telemetry may include usage metadata and task-level data such as task instructions, URLs visited, action traces, errors, and final results. We may use this information to operate, debug, secure, analyze, develop, and improve Browser Use and related offerings, including by creating aggregated, de-identified, or sanitized datasets and workflow patterns in accordance with our Terms of Service and Privacy Policy.
 
 
 ## Opting Out
@@ -5012,7 +5149,6 @@ os.environ["ANONYMIZED_TELEMETRY"] = "false"
 
 By using Browser Use services, you agree to our [Terms of Service](https://browser-use.com/legal/terms-of-service) and
 [Privacy Policy](https://browser-use.com/privacy/).
-
 
 # Costs
 Source: https://docs.browser-use.com/open-source/development/monitoring/costs
@@ -5040,7 +5176,6 @@ print(f"Token usage: {history.usage}")
 usage_summary = await agent.token_cost_service.get_usage_summary()
 print(f"Usage summary: {usage_summary}")
 ```
-
 
 # Get Help
 Source: https://docs.browser-use.com/open-source/development/get-help

--- a/docs/open-source/llms.txt
+++ b/docs/open-source/llms.txt
@@ -4,6 +4,7 @@
 
 - GitHub: https://github.com/browser-use/browser-use
 - Docs: https://docs.browser-use.com/open-source/introduction
+- Product map: https://browser-use.com/llms.txt — Compare the Open Source Library with Hosted Agents and Browser Infrastructure.
 
 Install: `pip install browser-use`
 
@@ -13,7 +14,7 @@ Install: `pip install browser-use`
 - [Human Quickstart](https://docs.browser-use.com/open-source/quickstart): Install and run your first AI browser agent in minutes. Python setup with pip, environment variables, and a working example.
 - [Prompts for Vibecoders](https://docs.browser-use.com/open-source/vibecoding): Complete Python SDK reference for AI coding agents. Paste into Claude Code, Cursor, or Copilot for instant integration.
 - [Supported Models](https://docs.browser-use.com/open-source/supported-models): Choose between Claude, Gemini, Llama, DeepSeek, and more. Configuration examples for each provider.
-- [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli): Fast, persistent browser automation from the command line.
+- [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli): Direct browser control for coding agents.
 - [Browser Use Terminal](https://docs.browser-use.com/open-source/browser-use-terminal): Use the terminal app for browser agents, or use the same runtime from Python.
 
 ## Agent
@@ -64,6 +65,15 @@ Install: `pip install browser-use`
 - [News-Use (News Monitor)](https://docs.browser-use.com/open-source/examples/apps/news-use): Monitor news websites and extract articles with sentiment analysis using browser agents and Google Gemini.
 - [Msg-Use (WhatsApp Sender)](https://docs.browser-use.com/open-source/examples/apps/msg-use): AI-powered WhatsApp message scheduler using browser agents and Gemini. Schedule personalized messages in natural language.
 
+## Skills
+- [Overview](https://docs.browser-use.com/open-source/examples/skills/overview): Install Browser Use as an agent skill. Drop browser automation, cloud, QA, and payments into Claude Code, Cursor, and any agent that supports SKILL.md.
+- [browser-use](https://docs.browser-use.com/open-source/examples/skills/browser-use): Automates browser interactions for web testing, form filling, screenshots, and data extraction. Use when the agent needs to navigate websites, interact with web pages, fill forms, take screenshots, or extract information.
+- [cloud](https://docs.browser-use.com/open-source/examples/skills/cloud): Documentation reference for using Browser Use Cloud — the hosted API and SDK for browser automation.
+- [open-source](https://docs.browser-use.com/open-source/examples/skills/open-source): Documentation reference for writing Python code using the browser-use open-source library.
+- [qa](https://docs.browser-use.com/open-source/examples/skills/qa): QA-test a website or web app and return a 1–5 quality score (5 = flawless, 1 = broken) with evidence.
+- [remote-browser](https://docs.browser-use.com/open-source/examples/skills/remote-browser): Controls a local browser from a sandboxed remote machine. Use when the agent runs in a sandbox (no GUI) and needs to navigate, interact, screenshot, or expose local dev servers via tunnels.
+- [x402](https://docs.browser-use.com/open-source/examples/skills/x402): Set up Browser Use Cloud payments with x402 — pay per request from a crypto wallet (USDC on Base mainnet), no signup or API key.
+
 ## Development
 - [Get Help](https://docs.browser-use.com/open-source/development/get-help): Get help — join 20k+ developers on Discord, search GitHub issues, or ask the community.
 
@@ -79,4 +89,3 @@ Install: `pip install browser-use`
 - [OpenLIT](https://docs.browser-use.com/open-source/development/monitoring/openlit): Complete observability with OpenLIT tracing.
 - [Telemetry](https://docs.browser-use.com/open-source/development/monitoring/telemetry): Understanding Browser Use's telemetry
 - [Costs](https://docs.browser-use.com/open-source/development/monitoring/costs): Track token usage and API costs for your browser automation tasks
-


### PR DESCRIPTION
## Summary

- link every generated Cloud `llms.txt` entry point to the cross-product Browser Use manifest
- link Cloud indexes directly to the machine-readable pricing source so agents do not invent plan and usage prices
- link the generated Open Source index back to the same product chooser
- regenerate the checked-in indexes; this also brings the Open Source index/full export in sync with the current `docs.json` navigation and MDX sources

Companion website PR: https://github.com/browser-use/website/pull/339

## Resulting structure

- `browser-use.com/llms.txt`: Hosted Agents / Browser Infrastructure / Open Source product map
- `browser-use.com/pricing.md`: plans and usage pricing
- `docs.browser-use.com/cloud/llms.txt`: generated Cloud Agent + Browser catalog
- `docs.browser-use.com/open-source/llms.txt`: generated Open Source catalog

## Verification

- `bash -n docs/generate-llms-txt.sh`
- ran `docs/generate-llms-txt.sh` twice and verified an identical diff hash
- verified root and `/cloud/` Cloud indexes are byte-identical
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Link all generated LLM indexes to the cross‑product map and machine‑readable pricing to guide model agents to the right product and prevent made‑up prices. Regenerated Cloud and Open Source indexes and updated the generator to emit these links.

- **New Features**
  - Cloud and root `llms.txt`: add Product map (`https://browser-use.com/llms.txt`) and Pricing (`https://browser-use.com/pricing.md`) links.
  - Open Source `llms.txt`: add Product map link; `llms-full.txt`: expand with Skills docs, coding‑assistant usage, and minor copy/layout fixes.
  - `docs/generate-llms-txt.sh`: emits Product map and Pricing in Cloud; Product map in Open Source. Regenerated indexes; root and `/cloud/` are byte‑identical.

<sup>Written for commit d3a0b8f1ba58ae8d8812c6f395a8b861781cc643. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

