### PR TITLE
docs(v4): recommend GPT-5.6 Luna

### DIFF
--- a/docs/cloud/agent/models.mdx
+++ b/docs/cloud/agent/models.mdx
@@ -8,10 +8,10 @@ Pass one of these API strings as `model` when creating a run:
 
 | Model | API string | Input | Cache read | Output | BYOK |
 | ----- | ---------- | ----: | ---------: | -----: | ---- |
+| GPT-5.6 Luna (recommended) | `gpt-5.6-luna` | \$0.24 | \$0.024 | \$1.44 | OpenAI |
 | Claude Opus 5 | `claude-opus-5` | \$6.00 | \$0.60 | \$30.00 | Anthropic |
 | Grok 4.5 | `grok-4.5` | \$2.40 | \$0.36 | \$7.20 | — |
-| GPT-5.6 | `gpt-5.6` | \$6.00 | \$0.60 | \$36.00 | OpenAI |
-| Gemini 3.5 Flash | `gemini-3.5-flash` | \$1.80 | \$0.18 | \$10.80 | Google |
+| GPT-5.6 Sol | `gpt-5.6-sol` | \$6.00 | \$0.60 | \$36.00 | OpenAI |
 | MiniMax M3 | `minimax-m3` | \$0.36 | \$0.072 | \$1.44 | — |
 
 Token prices are USD per 1 million tokens. Browser sessions
@@ -19,9 +19,9 @@ Token prices are USD per 1 million tokens. Browser sessions
 proxyless/BYOP) are charged separately. See [full pricing](https://browser-use.com/pricing).
 
 <Tip>
-  **Grok 4.5** gives the best balance of price and accuracy. **MiniMax M3** is
-  the default and cheapest option; use **Claude Opus 5** when accuracy matters
-  most.
+  We recommend **GPT-5.6 Luna** for most tasks. It combines near-Opus benchmark
+  performance with the lowest token price and fastest median response time in
+  current V4 production traffic. Use **Claude Opus 5** for maximum intelligence.
 </Tip>
 
 <Note>
@@ -37,7 +37,7 @@ from browser_use_sdk.v4 import BrowserUse
 client = BrowserUse()
 run = client.runs.create(
     "Compare three project-management tools",
-    model="grok-4.5",
+    model="gpt-5.6-luna",
 )
 ```
 ```typescript TypeScript
@@ -46,14 +46,14 @@ import { BrowserUse } from "browser-use-sdk/v4";
 const client = new BrowserUse();
 const run = await client.runs.create({
   task: "Compare three project-management tools",
-  model: "grok-4.5",
+  model: "gpt-5.6-luna",
 });
 ```
 ```bash curl
 curl https://api.browser-use.com/api/v4/runs \
   -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"task":"Compare three PM tools","model":"grok-4.5"}'
+  -d '{"task":"Compare three PM tools","model":"gpt-5.6-luna"}'
 ```
 </CodeGroup>
 

--- a/docs/cloud/agent/models.mdx
+++ b/docs/cloud/agent/models.mdx
@@ -21,7 +21,7 @@ proxyless/BYOP) are charged separately. See [full pricing](https://browser-use.c
 <Tip>
   We recommend **GPT-5.6 Luna** for most tasks. It combines near-Opus benchmark
   performance with the lowest token price and fastest median response time in
-  current V4 production traffic. Use **Claude Opus 5** for maximum intelligence.
+  current V4 production traffic.
 </Tip>
 
 <Note>


### PR DESCRIPTION
## Summary

- add GPT-5.6 Luna first in the public V4 model table and mark it recommended
- replace the legacy GPT-5.6 alias and retired Gemini row with the current GPT-5.6 Sol picker model
- recommend Luna for near-Opus benchmark performance, the lowest token price, and the fastest current median response time
- remove the Opus maximum-intelligence claim
- update Python, TypeScript, and curl examples to use Luna

## Validation

- branch is current with latest main
- git diff --check
- verified all five current V4 picker model strings against the Cloud model registry
- verified Luna pricing against the Cloud pricing registry