### PR TITLE
docs: add Magnus and Aitor as release guardians

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -37,7 +37,7 @@ Both registries use OIDC trusted publishing. **No static tokens, no secrets to r
 
 - **PyPI**: trusted publishing configured at https://pypi.org/manage/project/browser-use-sdk/settings/publishing/ (Owner: browser-use, Repository: sdk, Workflow: publish.yml, Environment: release).
 - **npm**: trusted publishing configured at https://www.npmjs.com/package/browser-use-sdk/access (same four fields, Allowed action: npm publish).
-- The `release` environment requires approval from a reviewer other than the release author (`prevent_self_review: true`). Reviewers: gregpr07, LarsenCundric.
+- The `release` environment requires approval from a reviewer other than the release author (`prevent_self_review: true`). Release guardians: `gregpr07`, `LarsenCundric`, `sauravpanda`, `MagMueller` (Magnus), and `reformedot` (Aitor). This list is configured in GitHub Settings → Environments → `release`; keep the repository settings and this runbook synchronized.
 
 If a trusted publisher binding is ever revoked or misconfigured, publishing will fail at the publish step with a clear OIDC error from the registry. The release tag stays cut (you can re-dispatch after re-binding).
 
@@ -78,7 +78,7 @@ Follow existing patterns in the codebase. Read before writing.
 1. Run `task test`. Fix failures (max 3 attempts, then escalate).
 2. Optionally run `task test:live` if backend is reachable.
 3. Confirm version bump with user → bump both packages → save snapshots → commit.
-4. **Merge the bump PR to main.** The `auto-release-on-version-bump` workflow creates the GitHub Release for `v$NEW_VERSION` at the bump commit, which fires `publish.yml`. See the "Releasing" section above for the full flow. Ping a release reviewer (gregpr07 or LarsenCundric, whoever is NOT you) to approve at the `release` environment gate in the Actions tab. On approval: npm + PyPI publish in parallel, ~3-5 minutes. If publish fails: the GitHub Release stays as the rollback handle; investigate, fix, re-cut a new patch version.
+4. **Merge the bump PR to main.** The `auto-release-on-version-bump` workflow creates the GitHub Release for `v$NEW_VERSION` at the bump commit, which fires `publish.yml`. See the "Releasing" section above for the full flow. Ping any release guardian other than the release author (`gregpr07`, `LarsenCundric`, `sauravpanda`, `MagMueller`, or `reformedot`) to approve at the `release` environment gate in the Actions tab. On approval: npm + PyPI publish in parallel, ~3-5 minutes. If publish fails: the GitHub Release stays as the rollback handle; investigate, fix, re-cut a new patch version.
 
 ---
 


### PR DESCRIPTION
## Summary

- add Magnus (`MagMueller`) and Aitor (`reformedot`) to the documented SDK release guardians
- document the complete intended reviewer set for the protected `release` environment
- clarify that self-review remains blocked and the runbook must stay synchronized with GitHub Environment settings

## Validation

- `git diff --check`

## Operational note

GitHub Environment reviewers are repository settings, not file-backed configuration. Merging this PR updates the auditable runbook but does not itself grant release-approval access; the `release` environment reviewer setting must be updated to match.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Magnus (`MagMueller`) and Aitor (`reformedot`) as release guardians and documents the complete approver set for the `release` environment. Clarifies that self-approval remains blocked and the runbook must match GitHub Environment settings.

- Guardians are `gregpr07`, `LarsenCundric`, `sauravpanda`, `MagMueller`, `reformedot`; ping any guardian other than the release author at the `release` gate.
- Required: Update GitHub Settings → Environments → `release` reviewers to this list; merging this PR does not grant access.

<sup>Written for commit 75ed652ca2990f34e8f8fec0bbff5536db7cad04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

