### PR TITLE
docs: refresh n8n integration for v4

### DIFF
--- a/docs/open-source/development/n8n-integration.mdx
+++ b/docs/open-source/development/n8n-integration.mdx
@@ -1,123 +1,67 @@
 ---
 title: 'n8n Integration'
-description: 'Learn how to integrate Browser Use with n8n workflows'
+description: 'Run Browser Use inside n8n with the official verified node'
 mode: "wide"
 ---
 
-# Browser Use n8n Integration
+# n8n
 
-Browser Use can be integrated with [n8n](https://n8n.io), a workflow automation platform, using our community node. This integration allows you to trigger browser automation tasks directly from your n8n workflows.
+Run Browser Use inside an n8n workflow with the official verified node.
 
-## Installing the n8n Community Node
+## Install
 
-There are several ways to install the Browser Use community node in n8n:
+1. In n8n, open **Settings → Community Nodes**.
+2. Install `n8n-nodes-browser-use-cloud`.
+3. Restart n8n if it asks you to.
 
-### Using n8n Desktop or Cloud
+Do not install `n8n-nodes-browser-use`. That is an older third-party package.
 
-1. Navigate to **Settings > Community Nodes**
-2. Click on **Install**
-3. Enter `n8n-nodes-browser-use` in the **Name** field
-4. Click **Install**
+## Add your key
 
-### Using a Self-hosted n8n Instance
+1. Create a Browser Use API key in [Browser Use Cloud](https://cloud.browser-use.com/settings?tab=api-keys&new=1).
+2. In n8n, create a **Browser Use API** credential.
+3. Paste the key.
+4. Leave the Base URL at its default value. The node picks the right API path from the API Version field.
 
-Run the following command in your n8n installation directory:
+## Run your first task
 
-```bash
-npm install n8n-nodes-browser-use
-```
+1. Add a trigger.
+2. Add the **Browser Use** node.
+3. Pick **v4**, **Run**, then **Run and Wait**.
+4. Add a task such as:
 
-### For Development
+   `Open browser-use.com and return the first three customer names shown on the home page.`
 
-If you want to develop with the n8n node:
+5. Run the workflow.
 
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/draphonix/n8n-nodes-browser-use.git
-   ```
-2. Install dependencies:
-   ```bash
-   cd n8n-nodes-browser-use
-   npm install
-   ```
-3. Build the code:
-   ```bash
-   npm run build
-   ```
-4. Link to your n8n installation:
-   ```bash
-   npm link
-   ```
-5. In your n8n installation directory:
-   ```bash
-   npm link n8n-nodes-browser-use
-   ```
+The node waits for the browser job and returns the result, status, cost, session ID, and event URL. Turn on **Extract Structured Data** when the next n8n node needs JSON.
 
-## Setting Up Browser Use Cloud API Credentials
+## Pick an API version
 
-To use the Browser Use node in n8n, you need to configure API credentials:
+| Version | Use it for |
+| --- | --- |
+| v4 | New workflows and hard, long browser jobs. New nodes start here. |
+| v3 | Faster or cheaper session jobs and standalone cloud browsers. |
+| v2 | Old workflows that still need v2-only settings. |
 
-1. Sign up for an account at [Browser Use Cloud](https://cloud.browser-use.com/new-api-key)
-2. Navigate to the Settings or API section
-3. Generate or copy your API key
-4. In n8n, create a new credential:
-   - Go to **Credentials** tab
-   - Click **Create New**
-   - Select **Browser Use Cloud API**
-   - Enter your API key
-   - Save the credential
+Existing workflows keep the version they were saved with. Updating the package does not move an old workflow to v4.
 
-## Using the Browser Use Node
+## Common fixes
 
-Once installed, you can add the Browser Use node to your workflows:
+**I only see the old task actions.**
 
-1. In your workflow editor, search for "Browser Use" in the nodes panel
-2. Add the node to your workflow
-3. Set-up the credentials
-4. Choose your saved credentials
-5. Select an operation:
-   - **Run Task**: Execute a browser automation task with natural language instructions
-   - **Get Task**: Retrieve task details
-   - **Get Task Status**: Check task execution status
-   - **Pause/Resume/Stop Task**: Control running tasks
-   - **Get Task Media**: Retrieve screenshots, videos, or PDFs
-   - **List Tasks**: Get a list of tasks
+Update `n8n-nodes-browser-use-cloud`, then add a new Browser Use node. New nodes use type version 2 and start on API v4.
 
-### Example: Running a Browser Task
+**My key fails.**
 
-Here's a simple example of how to use the Browser Use node to run a browser task:
+Make sure the credential uses `X-Browser-Use-API-Key` and leave the Base URL unchanged.
 
-1. Add the Browser Use node to your workflow
-2. Select the "Run Task" operation
-3. In the "Instructions" field, enter a natural language description of what you want the browser to do, for example:
-   ```
-   Go to example.com, take a screenshot of the homepage, and extract all the main heading texts
-   ```
-4. Optionally enable "Save Browser Data" to preserve cookies and session information
-5. Connect the node to subsequent nodes to process the results
+**The run takes a while.**
 
-## Workflow Examples
+Use **Run and Wait** and raise **Wait Timeout**. Set **Max Cost USD** when you want a hard spend limit.
 
-The Browser Use n8n node enables various automation scenarios:
+## Sources
 
-- **Web Scraping**: Extract data from websites on a schedule
-- **Form Filling**: Automate data entry across web applications
-- **Monitoring**: Check website status and capture visual evidence
-- **Report Generation**: Generate PDFs or screenshots of web dashboards
-- **Multi-step Processes**: Chain browser tasks together using session persistence
-
-## Troubleshooting
-
-If you encounter issues with the Browser Use node:
-
-- Verify your API key is valid and has sufficient credits
-- Check that your instructions are clear and specific
-- For complex tasks, consider breaking them into multiple steps
-- Refer to the [Browser Use documentation](/open-source/quickstart) for instruction best practices
-
-## Resources
-
-- [n8n Community Nodes Documentation](https://docs.n8n.io/integrations/community-nodes/)
-- [Browser Use Documentation](/open-source/quickstart)
-- [Browser Use Cloud](https://cloud.browser-use.com)
-- [n8n-nodes-browser-use GitHub Repository](https://github.com/draphonix/n8n-nodes-browser-use) 
+- [Official Browser Use n8n node](https://github.com/browser-use/n8n-nodes-browser-use)
+- [Browser Use API v4](https://docs.browser-use.com/cloud/api-v4)
+- [Verified Browser Use page on n8n](https://n8n.io/integrations/browser-use/)

--- a/docs/open-source/development/n8n-integration.mdx
+++ b/docs/open-source/development/n8n-integration.mdx
@@ -62,6 +62,6 @@ Use **Run and Wait** and raise **Wait Timeout**. Set **Max Cost USD** when you w
 
 ## Sources
 
-- [Official Browser Use n8n node](https://github.com/browser-use/n8n-nodes-browser-use)
+- [Official repo for `n8n-nodes-browser-use-cloud`](https://github.com/browser-use/n8n-nodes-browser-use)
 - [Browser Use API v4](https://docs.browser-use.com/cloud/api-v4)
 - [Verified Browser Use page on n8n](https://n8n.io/integrations/browser-use/)


### PR DESCRIPTION
## Summary
- point users to the verified `n8n-nodes-browser-use-cloud` package
- make API v4 the default path for new workflows
- replace stale v2-only actions and setup steps

## Verification
- one MDX file only
- current n8n page still shows the old Task actions and blank setup steps
- instructions checked against `n8n-nodes-browser-use-cloud` v1.2.1

No runtime code changes.