### PR TITLE
docs: fix agent paths and add profile example

### DIFF
--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -28,7 +28,8 @@ Keep the browser session ID returned by `POST /api/v4/browsers`, then call
 refunds unused browser time.
 
 **Create and reuse a login profile:** Create one profile per end user, then pass
-its ID in `browserSettings.profileId` on later browsers or agent runs:
+its ID as top-level `profileId` when creating browsers, or as
+`browserSettings.profileId` on agent runs:
 ```bash
 profile=$(curl -sS https://api.browser-use.com/api/v4/profiles \
   -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -27,6 +27,24 @@ Keep the browser session ID returned by `POST /api/v4/browsers`, then call
 `PATCH /api/v4/browsers/{id}` with `{"action":"stop"}`. This stops billing and
 refunds unused browser time.
 
+**Create and reuse a login profile:** Create one profile per end user, then pass
+its ID in `browserSettings.profileId` on later browsers or agent runs:
+```bash
+profile=$(curl -sS https://api.browser-use.com/api/v4/profiles \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"My user"}')
+export BROWSER_USE_PROFILE_ID=$(echo "$profile" | jq -r .id)
+
+curl -sS https://api.browser-use.com/api/v4/browsers \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"profileId\":\"$BROWSER_USE_PROFILE_ID\",\"proxyCountryCode\":\"us\"}"
+```
+Log in once in that browser, stop it, then use the same profile ID to start the
+next browser already logged in. Full guide:
+https://docs.browser-use.com/cloud/guides/authentication
+
 **Current TypeScript SDK typing:** Pass `model` explicitly. Prefer
 `gpt-5.6-luna`, the recommended V4 model; if the generated union does not yet
 include it, use `grok-4.5` or call `POST /api/v4/runs` directly. Whenever

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -527,6 +527,22 @@
       "destination": "/cloud/browser/playwright-puppeteer-selenium"
     },
     {
+      "source": "/cloud/connect",
+      "destination": "/cloud/browser/playwright-puppeteer-selenium"
+    },
+    {
+      "source": "/cloud/playwright",
+      "destination": "/cloud/browser/playwright-puppeteer-selenium"
+    },
+    {
+      "source": "/cloud/browser/playwright",
+      "destination": "/cloud/browser/playwright-puppeteer-selenium"
+    },
+    {
+      "source": "/cloud/browsers/playwright",
+      "destination": "/cloud/browser/playwright-puppeteer-selenium"
+    },
+    {
       "source": "/quickstart",
       "destination": "/open-source/quickstart"
     },

--- a/docs/generate-llms-txt.sh
+++ b/docs/generate-llms-txt.sh
@@ -286,7 +286,8 @@ Keep the browser session ID returned by `POST /api/v4/browsers`, then call
 refunds unused browser time.
 
 **Create and reuse a login profile:** Create one profile per end user, then pass
-its ID in `browserSettings.profileId` on later browsers or agent runs:
+its ID as top-level `profileId` when creating browsers, or as
+`browserSettings.profileId` on agent runs:
 ```bash
 profile=$(curl -sS https://api.browser-use.com/api/v4/profiles \
   -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \

--- a/docs/generate-llms-txt.sh
+++ b/docs/generate-llms-txt.sh
@@ -285,6 +285,24 @@ Keep the browser session ID returned by `POST /api/v4/browsers`, then call
 `PATCH /api/v4/browsers/{id}` with `{"action":"stop"}`. This stops billing and
 refunds unused browser time.
 
+**Create and reuse a login profile:** Create one profile per end user, then pass
+its ID in `browserSettings.profileId` on later browsers or agent runs:
+```bash
+profile=$(curl -sS https://api.browser-use.com/api/v4/profiles \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"My user"}')
+export BROWSER_USE_PROFILE_ID=$(echo "$profile" | jq -r .id)
+
+curl -sS https://api.browser-use.com/api/v4/browsers \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"profileId\":\"$BROWSER_USE_PROFILE_ID\",\"proxyCountryCode\":\"us\"}"
+```
+Log in once in that browser, stop it, then use the same profile ID to start the
+next browser already logged in. Full guide:
+https://docs.browser-use.com/cloud/guides/authentication
+
 **Current TypeScript SDK typing:** Pass `model` explicitly. Prefer
 `gpt-5.6-luna`, the recommended V4 model; if the generated union does not yet
 include it, use `grok-4.5` or call `POST /api/v4/runs` directly. Whenever

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -28,7 +28,8 @@ Keep the browser session ID returned by `POST /api/v4/browsers`, then call
 refunds unused browser time.
 
 **Create and reuse a login profile:** Create one profile per end user, then pass
-its ID in `browserSettings.profileId` on later browsers or agent runs:
+its ID as top-level `profileId` when creating browsers, or as
+`browserSettings.profileId` on agent runs:
 ```bash
 profile=$(curl -sS https://api.browser-use.com/api/v4/profiles \
   -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -27,6 +27,24 @@ Keep the browser session ID returned by `POST /api/v4/browsers`, then call
 `PATCH /api/v4/browsers/{id}` with `{"action":"stop"}`. This stops billing and
 refunds unused browser time.
 
+**Create and reuse a login profile:** Create one profile per end user, then pass
+its ID in `browserSettings.profileId` on later browsers or agent runs:
+```bash
+profile=$(curl -sS https://api.browser-use.com/api/v4/profiles \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"My user"}')
+export BROWSER_USE_PROFILE_ID=$(echo "$profile" | jq -r .id)
+
+curl -sS https://api.browser-use.com/api/v4/browsers \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"profileId\":\"$BROWSER_USE_PROFILE_ID\",\"proxyCountryCode\":\"us\"}"
+```
+Log in once in that browser, stop it, then use the same profile ID to start the
+next browser already logged in. Full guide:
+https://docs.browser-use.com/cloud/guides/authentication
+
 **Current TypeScript SDK typing:** Pass `model` explicitly. Prefer
 `gpt-5.6-luna`, the recommended V4 model; if the generated union does not yet
 include it, use `grok-4.5` or call `POST /api/v4/runs` directly. Whenever


### PR DESCRIPTION
## Summary

- redirect four common Cloud browser paths to the Playwright, Puppeteer, and Selenium guide
- add a copy-ready V4 profile create/reuse example to `llms.txt`
- keep the example in the generator so docs builds do not erase it

## Why

Agents currently guess four paths that return 404 before they find the working browser connection guide. The agent-readable index also links to profiles without showing how to create and reuse one.

## Checks

- `bash docs/generate-llms-txt.sh` (idempotent)
- `npx --yes mintlify@latest broken-links`
- `python3 -m json.tool docs/docs.json`
- redirect sources are unique and the target page exists
- V4 OpenAPI contains `/profiles`, `ProfileCreateRequest`, and `profileId`
- `git diff --check`
