### PR TITLE
docs: link API reference to direct browser control

### DIFF
--- a/docs/cloud/api-v4-overview.mdx
+++ b/docs/cloud/api-v4-overview.mdx
@@ -61,10 +61,10 @@ curl -X POST https://api.browser-use.com/api/v4/sessions/SESSION_ID/queue \
 Use the browser endpoints when your code will control Chrome over CDP instead of asking a hosted agent to do the work:
 
 1. `POST /browsers` creates a browser and returns its `id` and `cdpUrl`.
-2. Connect Playwright or Puppeteer to `cdpUrl`.
+2. Use `cdpUrl` with a local Browser Use agent (`Browser(cdp_url=...)`), Browser Use CLI (`BU_CDP_URL`), Playwright, Puppeteer, or Selenium.
 3. `PATCH /browsers/{id}` with `{"action":"stop"}` stops the browser.
 
-See [Playwright, Puppeteer, Selenium](/cloud/browser/playwright-puppeteer-selenium) for complete create, connect, and stop examples.
+See [remote Browser Use](/open-source/customize/browser/remote), [Browser Use CLI](/open-source/browser-use-cli), or [Playwright, Puppeteer, Selenium](/cloud/browser/playwright-puppeteer-selenium) for complete connection examples.
 
 ## SDKs
 

--- a/docs/cloud/api-v4-overview.mdx
+++ b/docs/cloud/api-v4-overview.mdx
@@ -56,6 +56,16 @@ curl -X POST https://api.browser-use.com/api/v4/sessions/SESSION_ID/queue \
   -d '{"text": "Now open the top result", "interrupt": false}'
 ```
 
+## Direct browser control
+
+Use the browser endpoints when your code will control Chrome over CDP instead of asking a hosted agent to do the work:
+
+1. `POST /browsers` creates a browser and returns its `id` and `cdpUrl`.
+2. Connect Playwright or Puppeteer to `cdpUrl`.
+3. `PATCH /browsers/{id}` with `{"action":"stop"}` stops the browser.
+
+See [Playwright, Puppeteer, Selenium](/cloud/browser/playwright-puppeteer-selenium) for complete create, connect, and stop examples.
+
 ## SDKs
 
 The [Cloud SDK quick start](/cloud/agent/quickstart) wraps this loop — `runs.create()` then `runs.waitForCompletion()` / `runs.wait_for_completion()` — for TypeScript and Python.


### PR DESCRIPTION
## Why
2027.dev measured a browser-control run fetching extra docs pages because the API overview does not point directly to the create → connect → stop guide.

## What changed
Add a short “Direct browser control” section to the API overview with the three-step flow and a direct link to the existing Playwright, Puppeteer, and Selenium guide.

## Checks
- `git diff --check`
- verified the target route and endpoint names against the current docs