### PR TITLE
docs: add rerunnable Cloud scripts guide

### DIFF
--- a/docs/cloud/agent/scripts.mdx
+++ b/docs/cloud/agent/scripts.mdx
@@ -50,7 +50,8 @@ first = client.runs.create(
     Save a script at scripts/extract_top_stories.py that collects the same
     fields. The script must send a fresh request to the live page every time it
     runs. Do not hard-code story titles, save the page HTML, or read an old
-    result. Print JSON with source_url, fetched_at, source_sha256, and stories.
+    result. Print JSON with source_url set to https://news.ycombinator.com/ and
+    include fetched_at, source_sha256, and stories.
 
     Run the script twice and save the outputs as proof/run-1.json and
     proof/run-2.json. Confirm both outputs have a fresh fetched_at value and
@@ -79,7 +80,8 @@ const first = await client.runs.create({
     Save a script at scripts/extract_top_stories.py that collects the same
     fields. The script must send a fresh request to the live page every time it
     runs. Do not hard-code story titles, save the page HTML, or read an old
-    result. Print JSON with source_url, fetched_at, source_sha256, and stories.
+    result. Print JSON with source_url set to https://news.ycombinator.com/ and
+    include fetched_at, source_sha256, and stories.
 
     Run the script twice and save the outputs as proof/run-1.json and
     proof/run-2.json. Confirm both outputs have a fresh fetched_at value and

--- a/docs/cloud/agent/scripts.mdx
+++ b/docs/cloud/agent/scripts.mdx
@@ -1,13 +1,16 @@
 ---
-title: Scripts
-description: "Save tested browser scripts in a workspace and reuse them on later runs."
+title: Rerunnable scripts
+description: "Save a Browser Use task as a rerunnable script for repeated live data extraction and self-healing runs."
 icon: file-code
 ---
 
-Scripts turn a successful browser run into a reusable
-[workspace](/cloud/agent/workspaces) asset. The agent writes and tests the
-helper once. Later runs execute it first and repair it only when the site
-changes.
+Teach a Cloud agent a repeated browser task once. It can save the working code
+in its [workspace](/cloud/agent/workspaces). Later runs reuse that script,
+fetch fresh data from the live site, and repair the code if the site changed.
+
+This pattern works well for repeated data extraction, checks, and reports. The
+example below collects the top five Hacker News stories. The first run writes
+and tests the script. Every later run sends a new request to the live page.
 
 <img
   src="/cloud/images/v4-scripts-light.svg"
@@ -22,25 +25,150 @@ changes.
   className="hidden dark:block"
 />
 
-Create one workspace for the workflow, then use these prompts with the same
-`workspace_id` / `workspaceId`. The [run code](/cloud/agent/quickstart) does not
-change.
+<Note>
+  The file stays. The running process does not. Each later run starts an agent
+  again, but it can reuse the code instead of rebuilding the browser workflow.
+</Note>
 
-## First run
+## Save the working script
 
-```text
-Get the top five Hacker News stories as JSON.
+Create one workspace, then ask the first run to do the job and save a tested
+script:
 
-Then reproduce exactly what you did as helper functions or a script. Test it,
-save it in this workspace, and add a README with instructions for using it again.
+<CodeGroup>
+```python Python
+from browser_use_sdk.v4 import BrowserUse
+
+client = BrowserUse()
+workspace = client.workspaces.create(name="live-hn-data")
+
+first = client.runs.create(
+    """
+    Open https://news.ycombinator.com/ and return the top five story titles and
+    URLs as JSON.
+
+    Save a script at scripts/extract_top_stories.py that collects the same
+    fields. The script must send a fresh request to the live page every time it
+    runs. Do not hard-code story titles, save the page HTML, or read an old
+    result. Print JSON with source_url, fetched_at, source_sha256, and stories.
+
+    Run the script twice and save the outputs as proof/run-1.json and
+    proof/run-2.json. Confirm both outputs have a fresh fetched_at value and
+    five stories. Add scripts/README.md with the command to run it again.
+    """,
+    model="grok-4.5",
+    workspace_id=workspace.id,
+)
+client.runs.wait_for_completion(first.id)
+
+saved = client.workspaces.files(workspace.id, prefix="scripts/")
+print([file.path for file in saved.files])
+print(f"Keep this workspace ID: {workspace.id}")
 ```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v4";
 
-## Later runs
+const client = new BrowserUse();
+const workspace = await client.workspaces.create({ name: "live-hn-data" });
 
-```text
-Use the existing workspace script to get the top ten Hacker News stories.
-Follow its README. Only fix and retest the script if it no longer works.
+const first = await client.runs.create({
+  task: `
+    Open https://news.ycombinator.com/ and return the top five story titles and
+    URLs as JSON.
+
+    Save a script at scripts/extract_top_stories.py that collects the same
+    fields. The script must send a fresh request to the live page every time it
+    runs. Do not hard-code story titles, save the page HTML, or read an old
+    result. Print JSON with source_url, fetched_at, source_sha256, and stories.
+
+    Run the script twice and save the outputs as proof/run-1.json and
+    proof/run-2.json. Confirm both outputs have a fresh fetched_at value and
+    five stories. Add scripts/README.md with the command to run it again.
+  `,
+  model: "grok-4.5",
+  workspaceId: workspace.id,
+});
+await client.runs.waitForCompletion(first.id);
+
+const saved = await client.workspaces.files(workspace.id, {
+  prefix: "scripts/",
+});
+console.log(saved.files.map((file) => file.path));
+console.log(`Keep this workspace ID: ${workspace.id}`);
 ```
+</CodeGroup>
 
-This is faster and cheaper for repeated workflows, but it still starts an agent
-and uses tokens. The script is reusable and self-healing—not zero-LLM execution.
+## Rerun it later
+
+Copy the workspace ID from the first process. Pass that ID without a session ID
+to start a new conversation with the saved files:
+
+<CodeGroup>
+```python Python
+from browser_use_sdk.v4 import BrowserUse
+
+client = BrowserUse()
+workspace_id = "your-workspace-id"
+
+later = client.runs.create(
+    """
+    Run python scripts/extract_top_stories.py and return its JSON. Check that
+    fetched_at is current, source_url is https://news.ycombinator.com/, and it
+    has five stories. If the script fails or the result is malformed, inspect
+    the live page and repair the saved script before returning the new result.
+    """,
+    model="grok-4.5",
+    workspace_id=workspace_id,
+)
+result = client.runs.wait_for_completion(later.id)
+print(result.result)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v4";
+
+const client = new BrowserUse();
+const workspaceId = "your-workspace-id";
+
+const later = await client.runs.create({
+  task: `
+    Run python scripts/extract_top_stories.py and return its JSON. Check that
+    fetched_at is current, source_url is https://news.ycombinator.com/, and it
+    has five stories. If the script fails or the result is malformed, inspect
+    the live page and repair the saved script before returning the new result.
+  `,
+  model: "grok-4.5",
+  workspaceId,
+});
+const result = await client.runs.waitForCompletion(later.id);
+console.log(result.result);
+```
+</CodeGroup>
+
+## Live data, not a cached answer
+
+The saved script must request the source page on every execution. `fetched_at`
+shows when the request ran, and `source_sha256` identifies the response body.
+The data can stay the same between two runs when the page has not changed. The
+script still fetched it again.
+
+Do not put old output, page HTML, or fixed values inside the script. Save output
+files only as optional history or proof.
+
+## Can rerunnable tasks be cheaper at scale?
+
+Reusing code can remove browser steps and model work that would otherwise be
+repeated on every extraction. Every later run still starts a model and uses
+tokens, so the savings depend on the task, site, and model. Compare the cost and
+duration of the first run with later runs in your own project before making a
+savings claim.
+
+## Workspace or session?
+
+- Pass `workspace_id` / `workspaceId` for a new conversation with the same
+  files. The new run gets a new browser.
+- Pass `session_id` / `sessionId` to continue the old conversation and its
+  workspace. Cloud can also reuse that session's browser while it is still
+  alive.
+
+A saved script can break when a site changes. Ask the agent to check the live
+result and self-heal the script instead of trusting stale output.

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -778,7 +778,8 @@ first = client.runs.create(
     Save a script at scripts/extract_top_stories.py that collects the same
     fields. The script must send a fresh request to the live page every time it
     runs. Do not hard-code story titles, save the page HTML, or read an old
-    result. Print JSON with source_url, fetched_at, source_sha256, and stories.
+    result. Print JSON with source_url set to https://news.ycombinator.com/ and
+    include fetched_at, source_sha256, and stories.
 
     Run the script twice and save the outputs as proof/run-1.json and
     proof/run-2.json. Confirm both outputs have a fresh fetched_at value and
@@ -807,7 +808,8 @@ const first = await client.runs.create({
     Save a script at scripts/extract_top_stories.py that collects the same
     fields. The script must send a fresh request to the live page every time it
     runs. Do not hard-code story titles, save the page HTML, or read an old
-    result. Print JSON with source_url, fetched_at, source_sha256, and stories.
+    result. Print JSON with source_url set to https://news.ycombinator.com/ and
+    include fetched_at, source_sha256, and stories.
 
     Run the script twice and save the outputs as proof/run-1.json and
     proof/run-2.json. Confirm both outputs have a fresh fetched_at value and

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -731,14 +731,17 @@ Download URLs expire after 60 seconds. See the [workspace API
 reference](https://docs.browser-use.com/cloud/api-v4/workspaces/list-workspace-files) for pagination and
 limits.
 
-# Scripts
+# Rerunnable scripts
 Source: https://docs.browser-use.com/cloud/agent/scripts
 
 
-Scripts turn a successful browser run into a reusable
-[workspace](https://docs.browser-use.com/cloud/agent/workspaces) asset. The agent writes and tests the
-helper once. Later runs execute it first and repair it only when the site
-changes.
+Teach a Cloud agent a repeated browser task once. It can save the working code
+in its [workspace](https://docs.browser-use.com/cloud/agent/workspaces). Later runs reuse that script,
+fetch fresh data from the live site, and repair the code if the site changed.
+
+This pattern works well for repeated data extraction, checks, and reports. The
+example below collects the top five Hacker News stories. The first run writes
+and tests the script. Every later run sends a new request to the live page.
 
 <img
   src="/cloud/images/v4-scripts-light.svg"
@@ -753,28 +756,147 @@ changes.
   className="hidden dark:block"
 />
 
-Create one workspace for the workflow, then use these prompts with the same
-`workspace_id` / `workspaceId`. The [run code](https://docs.browser-use.com/cloud/agent/quickstart) does not
-change.
+  The file stays. The running process does not. Each later run starts an agent
+  again, but it can reuse the code instead of rebuilding the browser workflow.
 
-## First run
+## Save the working script
 
-```text
-Get the top five Hacker News stories as JSON.
+Create one workspace, then ask the first run to do the job and save a tested
+script:
 
-Then reproduce exactly what you did as helper functions or a script. Test it,
-save it in this workspace, and add a README with instructions for using it again.
+```python Python
+from browser_use_sdk.v4 import BrowserUse
+
+client = BrowserUse()
+workspace = client.workspaces.create(name="live-hn-data")
+
+first = client.runs.create(
+    """
+    Open https://news.ycombinator.com/ and return the top five story titles and
+    URLs as JSON.
+
+    Save a script at scripts/extract_top_stories.py that collects the same
+    fields. The script must send a fresh request to the live page every time it
+    runs. Do not hard-code story titles, save the page HTML, or read an old
+    result. Print JSON with source_url, fetched_at, source_sha256, and stories.
+
+    Run the script twice and save the outputs as proof/run-1.json and
+    proof/run-2.json. Confirm both outputs have a fresh fetched_at value and
+    five stories. Add scripts/README.md with the command to run it again.
+    """,
+    model="grok-4.5",
+    workspace_id=workspace.id,
+)
+client.runs.wait_for_completion(first.id)
+
+saved = client.workspaces.files(workspace.id, prefix="scripts/")
+print([file.path for file in saved.files])
+print(f"Keep this workspace ID: {workspace.id}")
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v4";
+
+const client = new BrowserUse();
+const workspace = await client.workspaces.create({ name: "live-hn-data" });
+
+const first = await client.runs.create({
+  task: `
+    Open https://news.ycombinator.com/ and return the top five story titles and
+    URLs as JSON.
+
+    Save a script at scripts/extract_top_stories.py that collects the same
+    fields. The script must send a fresh request to the live page every time it
+    runs. Do not hard-code story titles, save the page HTML, or read an old
+    result. Print JSON with source_url, fetched_at, source_sha256, and stories.
+
+    Run the script twice and save the outputs as proof/run-1.json and
+    proof/run-2.json. Confirm both outputs have a fresh fetched_at value and
+    five stories. Add scripts/README.md with the command to run it again.
+  `,
+  model: "grok-4.5",
+  workspaceId: workspace.id,
+});
+await client.runs.waitForCompletion(first.id);
+
+const saved = await client.workspaces.files(workspace.id, {
+  prefix: "scripts/",
+});
+console.log(saved.files.map((file) => file.path));
+console.log(`Keep this workspace ID: ${workspace.id}`);
 ```
 
-## Later runs
+## Rerun it later
 
-```text
-Use the existing workspace script to get the top ten Hacker News stories.
-Follow its README. Only fix and retest the script if it no longer works.
+Copy the workspace ID from the first process. Pass that ID without a session ID
+to start a new conversation with the saved files:
+
+```python Python
+from browser_use_sdk.v4 import BrowserUse
+
+client = BrowserUse()
+workspace_id = "your-workspace-id"
+
+later = client.runs.create(
+    """
+    Run python scripts/extract_top_stories.py and return its JSON. Check that
+    fetched_at is current, source_url is https://news.ycombinator.com/, and it
+    has five stories. If the script fails or the result is malformed, inspect
+    the live page and repair the saved script before returning the new result.
+    """,
+    model="grok-4.5",
+    workspace_id=workspace_id,
+)
+result = client.runs.wait_for_completion(later.id)
+print(result.result)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v4";
+
+const client = new BrowserUse();
+const workspaceId = "your-workspace-id";
+
+const later = await client.runs.create({
+  task: `
+    Run python scripts/extract_top_stories.py and return its JSON. Check that
+    fetched_at is current, source_url is https://news.ycombinator.com/, and it
+    has five stories. If the script fails or the result is malformed, inspect
+    the live page and repair the saved script before returning the new result.
+  `,
+  model: "grok-4.5",
+  workspaceId,
+});
+const result = await client.runs.waitForCompletion(later.id);
+console.log(result.result);
 ```
 
-This is faster and cheaper for repeated workflows, but it still starts an agent
-and uses tokens. The script is reusable and self-healing—not zero-LLM execution.
+## Live data, not a cached answer
+
+The saved script must request the source page on every execution. `fetched_at`
+shows when the request ran, and `source_sha256` identifies the response body.
+The data can stay the same between two runs when the page has not changed. The
+script still fetched it again.
+
+Do not put old output, page HTML, or fixed values inside the script. Save output
+files only as optional history or proof.
+
+## Can rerunnable tasks be cheaper at scale?
+
+Reusing code can remove browser steps and model work that would otherwise be
+repeated on every extraction. Every later run still starts a model and uses
+tokens, so the savings depend on the task, site, and model. Compare the cost and
+duration of the first run with later runs in your own project before making a
+savings claim.
+
+## Workspace or session?
+
+- Pass `workspace_id` / `workspaceId` for a new conversation with the same
+  files. The new run gets a new browser.
+- Pass `session_id` / `sessionId` to continue the old conversation and its
+  workspace. Cloud can also reuse that session's browser while it is still
+  alive.
+
+A saved script can break when a site changes. Ask the agent to check the live
+result and self-heal the script instead of trusting stale output.
 
 # Human in the loop
 Source: https://docs.browser-use.com/cloud/agent/human-in-the-loop
@@ -2416,6 +2538,16 @@ curl -X POST https://api.browser-use.com/api/v4/sessions/SESSION_ID/queue \
   -H "Content-Type: application/json" \
   -d '{"text": "Now open the top result", "interrupt": false}'
 ```
+
+## Direct browser control
+
+Use the browser endpoints when your code will control Chrome over CDP instead of asking a hosted agent to do the work:
+
+1. `POST /browsers` creates a browser and returns its `id` and `cdpUrl`.
+2. Use `cdpUrl` with a local Browser Use agent (`Browser(cdp_url=...)`), Browser Use CLI (`BU_CDP_URL`), Playwright, Puppeteer, or Selenium.
+3. `PATCH /browsers/{id}` with `{"action":"stop"}` stops the browser.
+
+See [remote Browser Use](/open-source/customize/browser/remote), [Browser Use CLI](/open-source/browser-use-cli), or [Playwright, Puppeteer, Selenium](https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium) for complete connection examples.
 
 ## SDKs
 

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -58,7 +58,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 - [Structured output](https://docs.browser-use.com/cloud/agent/structured-output): Ask for JSON and validate the V4 result in your application.
 - [Sessions](https://docs.browser-use.com/cloud/agent/sessions): Continue one conversation across multiple V4 runs.
 - [Workspaces & files](https://docs.browser-use.com/cloud/agent/workspaces): Persist files across V4 runs and conversations.
-- [Scripts](https://docs.browser-use.com/cloud/agent/scripts): Save tested browser scripts in a workspace and reuse them on later runs.
+- [Rerunnable scripts](https://docs.browser-use.com/cloud/agent/scripts): Save a Browser Use task as a rerunnable script for repeated live data extraction and self-healing runs.
 - [Human in the loop](https://docs.browser-use.com/cloud/agent/human-in-the-loop): Open the live browser, take over, then continue the same session.
 - [Observability](https://docs.browser-use.com/cloud/agent/observability): Poll ordered V4 events to monitor a run or build a custom UI.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -778,7 +778,8 @@ first = client.runs.create(
     Save a script at scripts/extract_top_stories.py that collects the same
     fields. The script must send a fresh request to the live page every time it
     runs. Do not hard-code story titles, save the page HTML, or read an old
-    result. Print JSON with source_url, fetched_at, source_sha256, and stories.
+    result. Print JSON with source_url set to https://news.ycombinator.com/ and
+    include fetched_at, source_sha256, and stories.
 
     Run the script twice and save the outputs as proof/run-1.json and
     proof/run-2.json. Confirm both outputs have a fresh fetched_at value and
@@ -807,7 +808,8 @@ const first = await client.runs.create({
     Save a script at scripts/extract_top_stories.py that collects the same
     fields. The script must send a fresh request to the live page every time it
     runs. Do not hard-code story titles, save the page HTML, or read an old
-    result. Print JSON with source_url, fetched_at, source_sha256, and stories.
+    result. Print JSON with source_url set to https://news.ycombinator.com/ and
+    include fetched_at, source_sha256, and stories.
 
     Run the script twice and save the outputs as proof/run-1.json and
     proof/run-2.json. Confirm both outputs have a fresh fetched_at value and

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -731,14 +731,17 @@ Download URLs expire after 60 seconds. See the [workspace API
 reference](https://docs.browser-use.com/cloud/api-v4/workspaces/list-workspace-files) for pagination and
 limits.
 
-# Scripts
+# Rerunnable scripts
 Source: https://docs.browser-use.com/cloud/agent/scripts
 
 
-Scripts turn a successful browser run into a reusable
-[workspace](https://docs.browser-use.com/cloud/agent/workspaces) asset. The agent writes and tests the
-helper once. Later runs execute it first and repair it only when the site
-changes.
+Teach a Cloud agent a repeated browser task once. It can save the working code
+in its [workspace](https://docs.browser-use.com/cloud/agent/workspaces). Later runs reuse that script,
+fetch fresh data from the live site, and repair the code if the site changed.
+
+This pattern works well for repeated data extraction, checks, and reports. The
+example below collects the top five Hacker News stories. The first run writes
+and tests the script. Every later run sends a new request to the live page.
 
 <img
   src="/cloud/images/v4-scripts-light.svg"
@@ -753,28 +756,147 @@ changes.
   className="hidden dark:block"
 />
 
-Create one workspace for the workflow, then use these prompts with the same
-`workspace_id` / `workspaceId`. The [run code](https://docs.browser-use.com/cloud/agent/quickstart) does not
-change.
+  The file stays. The running process does not. Each later run starts an agent
+  again, but it can reuse the code instead of rebuilding the browser workflow.
 
-## First run
+## Save the working script
 
-```text
-Get the top five Hacker News stories as JSON.
+Create one workspace, then ask the first run to do the job and save a tested
+script:
 
-Then reproduce exactly what you did as helper functions or a script. Test it,
-save it in this workspace, and add a README with instructions for using it again.
+```python Python
+from browser_use_sdk.v4 import BrowserUse
+
+client = BrowserUse()
+workspace = client.workspaces.create(name="live-hn-data")
+
+first = client.runs.create(
+    """
+    Open https://news.ycombinator.com/ and return the top five story titles and
+    URLs as JSON.
+
+    Save a script at scripts/extract_top_stories.py that collects the same
+    fields. The script must send a fresh request to the live page every time it
+    runs. Do not hard-code story titles, save the page HTML, or read an old
+    result. Print JSON with source_url, fetched_at, source_sha256, and stories.
+
+    Run the script twice and save the outputs as proof/run-1.json and
+    proof/run-2.json. Confirm both outputs have a fresh fetched_at value and
+    five stories. Add scripts/README.md with the command to run it again.
+    """,
+    model="grok-4.5",
+    workspace_id=workspace.id,
+)
+client.runs.wait_for_completion(first.id)
+
+saved = client.workspaces.files(workspace.id, prefix="scripts/")
+print([file.path for file in saved.files])
+print(f"Keep this workspace ID: {workspace.id}")
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v4";
+
+const client = new BrowserUse();
+const workspace = await client.workspaces.create({ name: "live-hn-data" });
+
+const first = await client.runs.create({
+  task: `
+    Open https://news.ycombinator.com/ and return the top five story titles and
+    URLs as JSON.
+
+    Save a script at scripts/extract_top_stories.py that collects the same
+    fields. The script must send a fresh request to the live page every time it
+    runs. Do not hard-code story titles, save the page HTML, or read an old
+    result. Print JSON with source_url, fetched_at, source_sha256, and stories.
+
+    Run the script twice and save the outputs as proof/run-1.json and
+    proof/run-2.json. Confirm both outputs have a fresh fetched_at value and
+    five stories. Add scripts/README.md with the command to run it again.
+  `,
+  model: "grok-4.5",
+  workspaceId: workspace.id,
+});
+await client.runs.waitForCompletion(first.id);
+
+const saved = await client.workspaces.files(workspace.id, {
+  prefix: "scripts/",
+});
+console.log(saved.files.map((file) => file.path));
+console.log(`Keep this workspace ID: ${workspace.id}`);
 ```
 
-## Later runs
+## Rerun it later
 
-```text
-Use the existing workspace script to get the top ten Hacker News stories.
-Follow its README. Only fix and retest the script if it no longer works.
+Copy the workspace ID from the first process. Pass that ID without a session ID
+to start a new conversation with the saved files:
+
+```python Python
+from browser_use_sdk.v4 import BrowserUse
+
+client = BrowserUse()
+workspace_id = "your-workspace-id"
+
+later = client.runs.create(
+    """
+    Run python scripts/extract_top_stories.py and return its JSON. Check that
+    fetched_at is current, source_url is https://news.ycombinator.com/, and it
+    has five stories. If the script fails or the result is malformed, inspect
+    the live page and repair the saved script before returning the new result.
+    """,
+    model="grok-4.5",
+    workspace_id=workspace_id,
+)
+result = client.runs.wait_for_completion(later.id)
+print(result.result)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v4";
+
+const client = new BrowserUse();
+const workspaceId = "your-workspace-id";
+
+const later = await client.runs.create({
+  task: `
+    Run python scripts/extract_top_stories.py and return its JSON. Check that
+    fetched_at is current, source_url is https://news.ycombinator.com/, and it
+    has five stories. If the script fails or the result is malformed, inspect
+    the live page and repair the saved script before returning the new result.
+  `,
+  model: "grok-4.5",
+  workspaceId,
+});
+const result = await client.runs.waitForCompletion(later.id);
+console.log(result.result);
 ```
 
-This is faster and cheaper for repeated workflows, but it still starts an agent
-and uses tokens. The script is reusable and self-healing—not zero-LLM execution.
+## Live data, not a cached answer
+
+The saved script must request the source page on every execution. `fetched_at`
+shows when the request ran, and `source_sha256` identifies the response body.
+The data can stay the same between two runs when the page has not changed. The
+script still fetched it again.
+
+Do not put old output, page HTML, or fixed values inside the script. Save output
+files only as optional history or proof.
+
+## Can rerunnable tasks be cheaper at scale?
+
+Reusing code can remove browser steps and model work that would otherwise be
+repeated on every extraction. Every later run still starts a model and uses
+tokens, so the savings depend on the task, site, and model. Compare the cost and
+duration of the first run with later runs in your own project before making a
+savings claim.
+
+## Workspace or session?
+
+- Pass `workspace_id` / `workspaceId` for a new conversation with the same
+  files. The new run gets a new browser.
+- Pass `session_id` / `sessionId` to continue the old conversation and its
+  workspace. Cloud can also reuse that session's browser while it is still
+  alive.
+
+A saved script can break when a site changes. Ask the agent to check the live
+result and self-heal the script instead of trusting stale output.
 
 # Human in the loop
 Source: https://docs.browser-use.com/cloud/agent/human-in-the-loop
@@ -2416,6 +2538,16 @@ curl -X POST https://api.browser-use.com/api/v4/sessions/SESSION_ID/queue \
   -H "Content-Type: application/json" \
   -d '{"text": "Now open the top result", "interrupt": false}'
 ```
+
+## Direct browser control
+
+Use the browser endpoints when your code will control Chrome over CDP instead of asking a hosted agent to do the work:
+
+1. `POST /browsers` creates a browser and returns its `id` and `cdpUrl`.
+2. Use `cdpUrl` with a local Browser Use agent (`Browser(cdp_url=...)`), Browser Use CLI (`BU_CDP_URL`), Playwright, Puppeteer, or Selenium.
+3. `PATCH /browsers/{id}` with `{"action":"stop"}` stops the browser.
+
+See [remote Browser Use](/open-source/customize/browser/remote), [Browser Use CLI](/open-source/browser-use-cli), or [Playwright, Puppeteer, Selenium](https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium) for complete connection examples.
 
 ## SDKs
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -58,7 +58,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 - [Structured output](https://docs.browser-use.com/cloud/agent/structured-output): Ask for JSON and validate the V4 result in your application.
 - [Sessions](https://docs.browser-use.com/cloud/agent/sessions): Continue one conversation across multiple V4 runs.
 - [Workspaces & files](https://docs.browser-use.com/cloud/agent/workspaces): Persist files across V4 runs and conversations.
-- [Scripts](https://docs.browser-use.com/cloud/agent/scripts): Save tested browser scripts in a workspace and reuse them on later runs.
+- [Rerunnable scripts](https://docs.browser-use.com/cloud/agent/scripts): Save a Browser Use task as a rerunnable script for repeated live data extraction and self-healing runs.
 - [Human in the loop](https://docs.browser-use.com/cloud/agent/human-in-the-loop): Open the live browser, take over, then continue the same session.
 - [Observability](https://docs.browser-use.com/cloud/agent/observability): Poll ordered V4 events to monitor a run or build a custom UI.
 


### PR DESCRIPTION
## What changed

- adds a guide for turning repeated browser work into rerunnable scripts in a V4 workspace
- uses repeated Hacker News extraction instead of a pricing-page example
- requires every script run to fetch the live page and expose `fetched_at` plus `source_sha256`
- shows how a later run can reuse and repair the saved script when the site changes
- explains the difference between `workspace_id` and `session_id`
- fixes the review findings by creating a new client in each later-run snippet and using `grok-4.5` in both Python and TypeScript

## Cost boundary

Reusing a script can remove repeated browser steps and model work, but later runs still start a model and use tokens. I did not claim a fixed saving because no authorized live V4 API key was available for a billed first-run versus later-run comparison.

## Checks

- controlled proof: two script executions made two HTTP requests and returned different page text
- public proof: two live Hacker News executions each returned five current stories with a new `fetched_at`
- `bash docs/generate-llms-txt.sh`
- Mintlify broken-links: no broken links
- Python V4 SDK: 22 passed
- TypeScript: `tsc --noEmit`
- TypeScript non-live suite: 141 passed
- `git diff --check`

The full live V4 create, save, and later-run flow was not run because no authorized API key was available.
