### PR TITLE
fix: bump js-yaml to 4.3.1

### DIFF
--- a/browser-use-node/package.json
+++ b/browser-use-node/package.json
@@ -108,7 +108,7 @@
       "ws": "8.21.1",
       "picomatch@4": "4.0.5",
       "postcss": "8.5.24",
-      "js-yaml@4": "4.3.0",
+      "js-yaml@4": "4.3.1",
       "esbuild": "0.28.1",
       "brace-expansion": "5.0.8"
     }

--- a/browser-use-node/pnpm-lock.yaml
+++ b/browser-use-node/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   ws: 8.21.1
   picomatch@4: 4.0.5
   postcss: 8.5.24
-  js-yaml@4: 4.3.0
+  js-yaml@4: 4.3.1
   esbuild: 0.28.1
   brace-expansion: 5.0.8
 
@@ -722,8 +722,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   json-schema-traverse@1.0.0:
@@ -1300,7 +1300,7 @@ snapshots:
       colorette: 1.4.0
       https-proxy-agent: 7.0.6(supports-color@10.2.2)
       js-levenshtein: 1.1.6
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 5.1.9
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
@@ -1661,7 +1661,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Summary

- bump the `js-yaml@4` override from 4.3.0 to 4.3.1
- regenerate the pnpm lockfile with the patched package integrity
- resolve high-severity advisory GHSA-5p4m-2wfm-xmqj

[ENG-5863](https://linear.app/browser-use/issue/ENG-5863/fix-dependabot-vulnerabilities-in-browser-usesdk-1-alert-1-high)

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm test` (141 tests)
- `pnpm typecheck`
- `pnpm build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves the high-severity `js-yaml` advisory (GHSA-5p4m-2wfm-xmqj) by bumping the `js-yaml@4` override from 4.3.0 to 4.3.1 and regenerating the pnpm lockfile.

<sup>Written for commit 9eb85ca7956d3767a7ef49ba10cf9bf2d918e665. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

