### PR TITLE
fix(x402): enforce documented payment ceiling

### DIFF
--- a/browser-use-node/src/core/x402.ts
+++ b/browser-use-node/src/core/x402.ts
@@ -20,11 +20,56 @@ export const X402_BASE_URL_DEFAULT = "https://x402.api.browser-use.com/api/v3";
 export const X402_BASE_URL_DEFAULT_V2 = "https://x402.api.browser-use.com/api/v2";
 export const X402_BALANCE_BASE_URL_DEFAULT = "https://api.browser-use.com/api/v3";
 
+const USDC_ATOMIC_UNITS_PER_DOLLAR = 1_000_000;
+
 export interface X402WalletBalance {
   wallet: string;
   project_id: string;
   total_credits_usd: number;
   additional_credits_usd: number;
+}
+
+function paymentAmount(requirement: unknown): bigint | null {
+  if (!requirement || typeof requirement !== "object") return null;
+  const fields = requirement as Record<string, unknown>;
+  const amount = fields.amount ?? fields.maxAmountRequired;
+  if (typeof amount !== "string" && typeof amount !== "number" && typeof amount !== "bigint") {
+    return null;
+  }
+  try {
+    return BigInt(amount);
+  } catch {
+    return null;
+  }
+}
+
+function maxPaymentAtomicUnits(maxPaymentUsd: number): bigint {
+  if (!Number.isFinite(maxPaymentUsd) || maxPaymentUsd <= 0) {
+    throw new RangeError("x402MaxPaymentUsd must be a positive finite number.");
+  }
+  const atomicUnits = Math.floor(maxPaymentUsd * USDC_ATOMIC_UNITS_PER_DOLLAR);
+  if (!Number.isSafeInteger(atomicUnits) || atomicUnits < 1) {
+    throw new RangeError("x402MaxPaymentUsd must resolve to at least one USDC atomic unit.");
+  }
+  return BigInt(atomicUnits);
+}
+
+/** Add a hard USD ceiling to an x402 client. */
+export function applyX402MaxPaymentUsd(
+  client: X402Client,
+  maxPaymentUsd: number,
+): X402Client {
+  if (typeof client?.registerPolicy !== "function") {
+    throw new TypeError("The supplied x402 client does not support payment policies.");
+  }
+  const maxAtomicUnits = maxPaymentAtomicUnits(maxPaymentUsd);
+  client.registerPolicy((_version: number, requirements: unknown[]) =>
+    requirements.filter((requirement) => {
+      const amount = paymentAmount(requirement);
+      return amount !== null && amount <= maxAtomicUnits;
+    }),
+  );
+  return client;
 }
 
 function buildWalletAuthMessage(address: string, issuedAt: string, nonce: string): string {
@@ -83,6 +128,7 @@ const MISSING_X402 =
 /** Build a ready-to-use x402 client from an EVM private key (`0x...`). */
 export async function x402ClientFromPrivateKey(
   privateKey: `0x${string}` | string,
+  maxPaymentUsd = 1,
 ): Promise<X402Client> {
   let viem;
   let fetchPkg;
@@ -102,7 +148,7 @@ export async function x402ClientFromPrivateKey(
   const signer = viem.privateKeyToAccount(key as `0x${string}`);
   const client = new fetchPkg.x402Client();
   client.register("eip155:*", new evmPkg.ExactEvmScheme(signer));
-  return client;
+  return applyX402MaxPaymentUsd(client, maxPaymentUsd);
 }
 
 /** Wrap a fetch with x402 payment handling. */

--- a/browser-use-node/src/v2/client.ts
+++ b/browser-use-node/src/v2/client.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { HttpClient } from "../core/http.js";
 import {
   X402_BASE_URL_DEFAULT_V2,
+  applyX402MaxPaymentUsd,
   type X402Client,
   wrapFetchWithX402,
   x402ClientFromPrivateKey,
@@ -29,6 +30,11 @@ export interface BrowserUseOptions {
   x402?: X402Client;
   /** EVM wallet private key for x402 mode (also reads `BROWSER_USE_X402_PRIVATE_KEY`). */
   x402PrivateKey?: string;
+  /**
+   * Reject x402 payment requirements above this USD amount. Defaults to $1
+   * when the SDK builds the x402 client from a private key.
+   */
+  x402MaxPaymentUsd?: number;
 }
 
 export type RunTaskOptions = Partial<Omit<CreateTaskBody, "task">> &
@@ -55,7 +61,14 @@ export class BrowserUse {
       // backend credits the API key's project instead of one keyed to the wallet.
       const topupKey = options.apiKey ?? process.env.BROWSER_USE_API_KEY ?? "";
       const fetchPromise = (async () => {
-        const x402Client = options.x402 ?? (await x402ClientFromPrivateKey(x402PrivateKey!));
+        const x402Client = options.x402
+          ? options.x402MaxPaymentUsd === undefined
+            ? options.x402
+            : applyX402MaxPaymentUsd(options.x402, options.x402MaxPaymentUsd)
+          : await x402ClientFromPrivateKey(
+              x402PrivateKey!,
+              options.x402MaxPaymentUsd ?? 1,
+            );
         return wrapFetchWithX402(globalThis.fetch, x402Client);
       })();
       // Suppress unhandled-rejection warnings if the user constructs the client

--- a/browser-use-node/src/v3/client.ts
+++ b/browser-use-node/src/v3/client.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { HttpClient } from "../core/http.js";
 import {
   X402_BASE_URL_DEFAULT,
+  applyX402MaxPaymentUsd,
   type X402Client,
   wrapFetchWithX402,
   x402ClientFromPrivateKey,
@@ -41,6 +42,11 @@ export interface BrowserUseOptions {
    * `BROWSER_USE_X402_PRIVATE_KEY`.
    */
   x402PrivateKey?: string;
+  /**
+   * Reject x402 payment requirements above this USD amount. Defaults to $1
+   * when the SDK builds the x402 client from a private key.
+   */
+  x402MaxPaymentUsd?: number;
 }
 
 export type RunSessionOptions = Partial<Omit<RunTaskRequest, "task">> &
@@ -66,7 +72,14 @@ export class BrowserUse {
       // to the wallet.
       const topupKey = options.apiKey ?? process.env.BROWSER_USE_API_KEY ?? "";
       const fetchPromise = (async () => {
-        const x402Client = options.x402 ?? (await x402ClientFromPrivateKey(x402PrivateKey!));
+        const x402Client = options.x402
+          ? options.x402MaxPaymentUsd === undefined
+            ? options.x402
+            : applyX402MaxPaymentUsd(options.x402, options.x402MaxPaymentUsd)
+          : await x402ClientFromPrivateKey(
+              x402PrivateKey!,
+              options.x402MaxPaymentUsd ?? 1,
+            );
         return wrapFetchWithX402(globalThis.fetch, x402Client);
       })();
       // Suppress unhandled-rejection warnings if the user constructs the client

--- a/browser-use-node/tests/x402.test.ts
+++ b/browser-use-node/tests/x402.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { applyX402MaxPaymentUsd } from "../src/core/x402.js";
+
+describe("x402 payment cap", () => {
+  it("filters v2 and v1 payment requirements above the USD cap", () => {
+    const registerPolicy = vi.fn();
+    const client = { registerPolicy };
+
+    applyX402MaxPaymentUsd(client, 0.75);
+
+    const policy = registerPolicy.mock.calls[0][0] as (
+      version: number,
+      requirements: unknown[],
+    ) => unknown[];
+    expect(
+      policy(2, [
+        { amount: "750000" },
+        { amount: "750001" },
+        { amount: "not-a-number" },
+      ]),
+    ).toEqual([{ amount: "750000" }]);
+    expect(
+      policy(1, [
+        { maxAmountRequired: "749999" },
+        { maxAmountRequired: "1000000" },
+      ]),
+    ).toEqual([{ maxAmountRequired: "749999" }]);
+  });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    "rejects invalid caps (%s)",
+    (cap) => {
+      expect(() => applyX402MaxPaymentUsd({ registerPolicy: vi.fn() }, cap)).toThrow(
+        /positive finite number/,
+      );
+    },
+  );
+
+  it("rejects clients that cannot enforce a policy", () => {
+    expect(() => applyX402MaxPaymentUsd({}, 1)).toThrow(/does not support payment policies/);
+  });
+});

--- a/browser-use-python/src/browser_use_sdk/_core/x402.py
+++ b/browser-use-python/src/browser_use_sdk/_core/x402.py
@@ -14,6 +14,7 @@ nothing in this file is imported.
 from __future__ import annotations
 
 import importlib
+from decimal import Decimal, InvalidOperation, ROUND_FLOOR
 from typing import Any
 
 # Public alias for optional x402.x402Client type
@@ -26,6 +27,8 @@ X402_BASE_URL_DEFAULT_V2 = "https://x402.api.browser-use.com/api/v2"
 
 # Balance check is served on the regular (non-x402) host
 X402_BALANCE_BASE_URL_DEFAULT = "https://api.browser-use.com/api/v3"
+
+_USDC_ATOMIC_UNITS_PER_DOLLAR = Decimal("1000000")
 
 
 def _build_wallet_auth_message(address: str, issued_at: str, nonce: str) -> str:
@@ -97,7 +100,43 @@ def _missing_x402() -> ImportError:
     )
 
 
-def x402_client_from_private_key(private_key: str) -> X402Client:
+def _max_payment_atomic_units(max_payment_usd: float | str) -> int:
+    try:
+        amount = Decimal(str(max_payment_usd))
+    except (InvalidOperation, ValueError) as e:
+        raise ValueError("x402_max_payment_usd must be a positive finite number") from e
+    if not amount.is_finite() or amount <= 0:
+        raise ValueError("x402_max_payment_usd must be a positive finite number")
+    atomic_units = int(
+        (amount * _USDC_ATOMIC_UNITS_PER_DOLLAR).to_integral_value(
+            rounding=ROUND_FLOOR
+        )
+    )
+    if atomic_units < 1:
+        raise ValueError(
+            "x402_max_payment_usd must resolve to at least one USDC atomic unit"
+        )
+    return atomic_units
+
+
+def apply_x402_max_payment_usd(
+    client: X402Client, max_payment_usd: float | str
+) -> X402Client:
+    """Add a hard USD ceiling to an x402 client."""
+    try:
+        x402_pkg = importlib.import_module("x402")
+    except ImportError as e:
+        raise _missing_x402() from e
+    register_policy = getattr(client, "register_policy", None)
+    if not callable(register_policy):
+        raise TypeError("The supplied x402 client does not support payment policies")
+    register_policy(x402_pkg.max_amount(_max_payment_atomic_units(max_payment_usd)))
+    return client
+
+
+def x402_client_from_private_key(
+    private_key: str, *, max_payment_usd: float | str = 1.0
+) -> X402Client:
     """Build a ready-to-use ``x402Client`` from an EVM private key.
 
     Equivalent to::
@@ -121,7 +160,7 @@ def x402_client_from_private_key(private_key: str) -> X402Client:
     account = eth_account.Account.from_key(private_key)
     client = x402_pkg.x402Client()
     register_pkg.register_exact_evm_client(client, evm_pkg.EthAccountSigner(account))
-    return client
+    return apply_x402_max_payment_usd(client, max_payment_usd)
 
 
 def x402_async_httpx_client(

--- a/browser-use-python/src/browser_use_sdk/v2/client.py
+++ b/browser-use-python/src/browser_use_sdk/v2/client.py
@@ -8,7 +8,11 @@ from typing import Any, TypeVar, overload
 from pydantic import BaseModel
 
 from .._core.http import AsyncHttpClient, SyncHttpClient
-from .._core.x402 import X402_BASE_URL_DEFAULT_V2, x402_client_from_private_key
+from .._core.x402 import (
+    X402_BASE_URL_DEFAULT_V2,
+    apply_x402_max_payment_usd,
+    x402_client_from_private_key,
+)
 from ..generated.v2.models import SessionSettings, TaskCreatedResponse
 from .resources.billing import AsyncBilling, Billing
 from .resources.browsers import AsyncBrowsers, Browsers
@@ -25,13 +29,24 @@ _V2_BASE_URL = "https://api.browser-use.com/api/v2"
 T = TypeVar("T")
 
 
-def _resolve_x402(x402: Any | None, x402_private_key: str | None) -> Any | None:
+def _resolve_x402(
+    x402: Any | None,
+    x402_private_key: str | None,
+    x402_max_payment_usd: float | str | None,
+) -> Any | None:
     """Resolve x402 client from explicit args + env vars. Returns None if unused."""
     if x402 is not None:
+        if x402_max_payment_usd is not None:
+            return apply_x402_max_payment_usd(x402, x402_max_payment_usd)
         return x402
     key = x402_private_key or os.environ.get("BROWSER_USE_X402_PRIVATE_KEY")
     if key:
-        return x402_client_from_private_key(key)
+        return x402_client_from_private_key(
+            key,
+            max_payment_usd=(
+                1.0 if x402_max_payment_usd is None else x402_max_payment_usd
+            ),
+        )
     return None
 
 
@@ -377,8 +392,11 @@ class AsyncBrowserUse:
         max_retries: int = 3,
         x402: Any | None = None,
         x402_private_key: str | None = None,
+        x402_max_payment_usd: float | str | None = None,
     ) -> None:
-        x402_client = _resolve_x402(x402, x402_private_key)
+        x402_client = _resolve_x402(
+            x402, x402_private_key, x402_max_payment_usd
+        )
         if x402_client is not None:
             topup_key = api_key or os.environ.get("BROWSER_USE_API_KEY") or ""
             self._http = AsyncHttpClient(

--- a/browser-use-python/src/browser_use_sdk/v3/client.py
+++ b/browser-use-python/src/browser_use_sdk/v3/client.py
@@ -9,7 +9,11 @@ from pydantic import BaseModel
 
 from .._core import _UNSET
 from .._core.http import AsyncHttpClient, SyncHttpClient
-from .._core.x402 import X402_BASE_URL_DEFAULT, x402_client_from_private_key
+from .._core.x402 import (
+    X402_BASE_URL_DEFAULT,
+    apply_x402_max_payment_usd,
+    x402_client_from_private_key,
+)
 from .resources.billing import AsyncBilling, Billing as BillingResource
 from .resources.browsers import AsyncBrowsers, Browsers as BrowsersResource
 from .resources.profiles import AsyncProfiles, Profiles as ProfilesResource
@@ -23,13 +27,24 @@ _V3_BASE_URL = "https://api.browser-use.com/api/v3"
 T = TypeVar("T")
 
 
-def _resolve_x402(x402: Any | None, x402_private_key: str | None) -> Any | None:
+def _resolve_x402(
+    x402: Any | None,
+    x402_private_key: str | None,
+    x402_max_payment_usd: float | str | None,
+) -> Any | None:
     """Resolve x402 client from explicit args + env vars. Returns None if unused."""
     if x402 is not None:
+        if x402_max_payment_usd is not None:
+            return apply_x402_max_payment_usd(x402, x402_max_payment_usd)
         return x402
     key = x402_private_key or os.environ.get("BROWSER_USE_X402_PRIVATE_KEY")
     if key:
-        return x402_client_from_private_key(key)
+        return x402_client_from_private_key(
+            key,
+            max_payment_usd=(
+                1.0 if x402_max_payment_usd is None else x402_max_payment_usd
+            ),
+        )
     return None
 
 
@@ -352,8 +367,11 @@ class AsyncBrowserUse:
         use_own_key: bool | None = None,
         x402: Any | None = None,
         x402_private_key: str | None = None,
+        x402_max_payment_usd: float | str | None = None,
     ) -> None:
-        x402_client = _resolve_x402(x402, x402_private_key)
+        x402_client = _resolve_x402(
+            x402, x402_private_key, x402_max_payment_usd
+        )
         if x402_client is not None:
             topup_key = api_key or os.environ.get("BROWSER_USE_API_KEY") or ""
             self._http = AsyncHttpClient(

--- a/browser-use-python/tests/test_x402.py
+++ b/browser-use-python/tests/test_x402.py
@@ -1,0 +1,61 @@
+"""Unit tests for the optional x402 payment ceiling."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from browser_use_sdk._core import x402 as x402_helpers
+
+
+class FakeRequirement:
+    def __init__(self, amount: int) -> None:
+        self.amount = amount
+
+    def get_amount(self) -> int:
+        return self.amount
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.policy: Any = None
+
+    def register_policy(self, policy: Any) -> FakeClient:
+        self.policy = policy
+        return self
+
+
+def test_x402_payment_cap_filters_requirements(monkeypatch: pytest.MonkeyPatch) -> None:
+    def max_amount(limit: int) -> Any:
+        return lambda _version, requirements: [
+            item for item in requirements if item.get_amount() <= limit
+        ]
+
+    real_import = x402_helpers.importlib.import_module
+
+    def fake_import(name: str) -> Any:
+        if name == "x402":
+            return SimpleNamespace(max_amount=max_amount)
+        return real_import(name)
+
+    monkeypatch.setattr(x402_helpers.importlib, "import_module", fake_import)
+    client = FakeClient()
+
+    returned = x402_helpers.apply_x402_max_payment_usd(client, "0.75")
+
+    assert returned is client
+    filtered = client.policy(2, [FakeRequirement(750_000), FakeRequirement(750_001)])
+    assert [item.amount for item in filtered] == [750_000]
+
+
+@pytest.mark.parametrize("cap", [0, -1, "nan", "inf", "bad"])
+def test_x402_payment_cap_rejects_invalid_values(cap: float | str) -> None:
+    with pytest.raises(ValueError, match="positive finite number"):
+        x402_helpers._max_payment_atomic_units(cap)
+
+
+def test_x402_payment_cap_requires_atomic_unit() -> None:
+    with pytest.raises(ValueError, match="at least one USDC atomic unit"):
+        x402_helpers._max_payment_atomic_units("0.0000001")

--- a/docs/cloud/guides/x402-agent-wallets.mdx
+++ b/docs/cloud/guides/x402-agent-wallets.mdx
@@ -21,7 +21,9 @@ Give your agent a wallet with a few dollars of USDC in it, and it can run Browse
 <Note>
   Payments to Browser Use are **credit top-ups, not per-call fees**: each x402
   payment (\$5 default, \$1 minimum) buys prepaid credit for a project tied to
-  your wallet, and unused credit carries over. See [pricing and
+  your wallet, and unused credit carries over. A new paid request still makes a
+  new x402 payment; exact management and follow-up requests for the resulting
+  session ID are free. See [pricing and
   credits](/cloud/guides/x402#pricing-and-credits).
 </Note>
 

--- a/docs/cloud/guides/x402.mdx
+++ b/docs/cloud/guides/x402.mdx
@@ -9,6 +9,11 @@ description: "Pay for Browser Use Cloud with crypto (USDC on Base). ~30 seconds 
 
 x402 lets your code, or an autonomous AI agent, pay Browser Use Cloud directly with cryptocurrency. No account signup, no credit card, and no API key is needed. Your wallet is your identity.
 
+<Warning>
+  x402 currently supports the V2 and V3 APIs. It does not support API V4 yet.
+  Use a standard Browser Use API key for V4 runs.
+</Warning>
+
 <Note>
 
 **New to crypto?** Here's the gist:
@@ -120,6 +125,13 @@ const client = new BrowserUse(); // auto-detects from env
   Python x402 is async-only: use `AsyncBrowserUse`, not `BrowserUse`.
 </Note>
 
+<Note>
+  `x402_max_payment_usd` / `x402MaxPaymentUsd` is a hard ceiling, not a
+  spend trigger. The SDK rejects every payment option above it. A new paid
+  request to the x402 host still receives a payment challenge even when the
+  wallet project has unused Browser Use credit.
+</Note>
+
 ## Raw HTTP quickstart
 
 Use this if you're in a language we don't ship an SDK for (Go, Rust, Ruby, etc.), or if you want to use other x402 APIs from the same client library. Hit `https://x402.api.browser-use.com` directly with any [x402 client library](https://github.com/coinbase/x402#all-available-reference-sdks):
@@ -152,7 +164,9 @@ async def main():
 asyncio.run(main())
 ```
 
-`https://x402.api.browser-use.com` exposes the same routes as `https://api.browser-use.com`. It supports every `/api/v2/*` and `/api/v3/*` route, gated by an x402 challenge instead of API key auth.
+`https://x402.api.browser-use.com` supports every `/api/v2/*` and `/api/v3/*`
+route. It does not expose `/api/v4/*`. Paid requests are gated by an x402
+challenge instead of API key auth.
 
 ## What you need
 
@@ -166,10 +180,17 @@ You do **not** need ETH for gas. We use [EIP-3009](https://eips.ethereum.org/EIP
 
 ## Pricing and credits
 
-The SDK first authenticates requests with a free, single-use wallet signature. If
-the wallet project does not exist yet or has insufficient credits, the backend
-marks the response as requiring a top-up, and the SDK makes one x402 payment. The
-default SDK cap is `$1.00` USDC per payment.
+The x402 host challenges every new paid request. The SDK filters out payment
+options above `x402_max_payment_usd` / `x402MaxPaymentUsd`, signs one remaining
+option, and retries the request. The default SDK cap is `$1.00` USDC per
+payment. That payment becomes prepaid credit on the wallet's Browser Use
+project, then the request spends from the project's balance.
+
+Creating another session is another paid request, so it triggers another x402
+payment even when the project still has credit. Polling, reading messages,
+stopping, deleting, and sending a follow-up to a session created by that wallet
+are free when the request includes the exact session ID. The balance helper is
+also free because it uses a single-use wallet signature.
 
 <Warning>
   **Mid-task drain still terminates the task.** Browser Use sessions run on a
@@ -222,9 +243,14 @@ When the backend sees both a payment and a valid API key, the credit goes to the
 - Adding credits via crypto when you already have a regular Browser Use account
 - Multi-wallet setups funding one shared account
 
+Each paid request sent through the x402 host makes a new payment. After a
+top-up, use a normal `BrowserUse` client with the API key and the default
+`https://api.browser-use.com` host to spend the existing balance without making
+another x402 payment.
+
 ## Checking your credit balance
 
-When you sign up the normal way, Browser Use creates an **account** for you (we call it a "project") that holds your credits and runs your tasks, and you log into it with an API key. When you pay with **only a wallet** (no API key), there's no signup step — so the very first time you pay, Browser Use automatically creates one of these same accounts for you and ties it to your wallet. From then on it behaves exactly like a normal account. The only difference is how you prove it's yours: instead of an API key, you sign with your wallet.
+When you sign up the normal way, Browser Use creates an **account** for you (we call it a "project") that holds your credits and runs your tasks, and you log into it with an API key. When you pay with **only a wallet** (no API key), there's no signup step — so the very first time you pay, Browser Use automatically creates one of these same accounts for you and ties it to your wallet. The free wallet signature currently reads that project's balance. It does not replace API-key authentication for ordinary API requests.
 
 This balance is your **Browser Use credit balance** — the prepaid USD you've added to that account through x402 payments, minus what your tasks have spent.
 
@@ -280,17 +306,13 @@ The response contains:
 
 ## How it works
 
-Your code asks for something. If your Browser Use credit balance needs a top-up,
-the SDK authorizes up to your configured payment cap; otherwise it proceeds
-without moving wallet funds.
+Your code asks for something on the x402 host:
 
-A bit more detail:
-
-1. Your code makes a request (e.g. "run this task").
-2. The SDK signs a free, request-bound wallet authentication message.
-3. If the server explicitly requests a top-up, the SDK signs one capped payment and retries.
-4. Coinbase moves the USDC on-chain, and we add the same amount to your project's credit balance.
-5. Status polls use free wallet authentication while the task runs.
+1. The server returns an x402 challenge for a paid V2 or V3 route.
+2. The SDK removes every option above your configured payment cap.
+3. The SDK signs one remaining payment and retries the request.
+4. Coinbase moves the USDC on-chain, and Browser Use adds the same amount to your project's credit balance.
+5. The request runs against that project. Exact management requests for the resulting session ID are free.
 
 ## Wallet setup
 
@@ -344,7 +366,7 @@ register_exact_evm_client(
     EthAccountSigner(Account.from_key(key)),
     policies=[max_amount(1_000_000)],
 )
-client = AsyncBrowserUse(x402=x402, x402_private_key=key)
+client = AsyncBrowserUse(x402=x402)
 
 ```
 
@@ -360,13 +382,20 @@ x402.register("eip155:*", new ExactEvmScheme(privateKeyToAccount(key)));
 x402.registerPolicy((_version, requirements) =>
   requirements.filter(({ amount }) => BigInt(amount) <= 1_000_000n),
 );
-const client = new BrowserUse({ x402, x402PrivateKey: key });
+const client = new BrowserUse({ x402 });
 ```
 </CodeGroup>
 
 ## Troubleshooting
 
 <AccordionGroup>
+  <Accordion title="Why did a second task make another payment?">
+    Every new paid request to the x402 host gets a fresh payment challenge. A
+    wallet-keyed project's existing credit does not currently bypass that
+    challenge. Reuse the same session for free follow-ups, or use a normal API
+    key client after topping up an existing account.
+  </Accordion>
+
   <Accordion title="HTTP 402 keeps coming back, never settles">
     Two likely causes:
 


### PR DESCRIPTION
## Summary

- add the documented `x402_max_payment_usd` and `x402MaxPaymentUsd` options to the Python and TypeScript V2/V3 clients
- default SDK-created x402 clients to a $1 per-payment ceiling and reject payment requirements above it
- cover V1 and V2 payment-requirement shapes, invalid caps, and custom clients
- correct the x402 guides to state the current V2/V3-only, repeated-payment, wallet-authentication, and free session-management boundaries

## Why

The public quickstart already passes these options, but SDK 3.11.1 does not implement them. Python raises `TypeError` before making a request. TypeScript does not declare the option, and untyped JavaScript ignores it. That means the advertised safety ceiling is not actually registered on SDK-created x402 clients.

This is adjacent to #221 but intentionally narrower. It makes the payment ceiling real and makes the current behavior explicit. It does **not** add generic wallet authentication, allow existing wallet-keyed credit to bypass a new payment challenge, add V4 x402 support, change the $1 minimum, or change the `upto` tier.

## Validation

- TypeScript: 147 tests pass
- TypeScript: type-check and CJS/ESM/declaration builds pass
- Python: 59 offline tests pass; 22 live or production tests deselected
- Python: pyright passes with 0 errors and 0 warnings
- Python: source distribution and wheel builds pass
- Mintlify broken-link check passes
- `llms.txt` generation is idempotent
- `git diff --check` passes

No wallet funds, payment, API key, customer data, or live Cloud request was used.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the documented `x402MaxPaymentUsd` / `x402_max_payment_usd` option in the Python and TypeScript V2/V3 clients. The option previously had no effect (Python raised `TypeError`, TypeScript never declared it); SDK-created x402 clients now reject payment requirements above the configured ceiling and default to $1 per payment.

**Details**
- Applies to SDK-built clients and custom x402 clients that support policy registration; invalid caps throw `RangeError`/`ValueError`.
- Covers V1 and V2 payment-requirement shapes.
- Corrects the x402 guides to state the current boundaries: V2/V3 only, every new paid request gets a payment challenge even with unused project credit, and exact session-management calls are free.

<sup>Written for commit 0bed23fecd3eecdc2a169a954747ea5dcbfb1b51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

