### PR TITLE
feat(v4): add workspace download helpers

### DIFF
--- a/browser-use-node/src/v4/resources/workspaces.ts
+++ b/browser-use-node/src/v4/resources/workspaces.ts
@@ -1,5 +1,6 @@
-import { readFile, stat } from "fs/promises";
-import { basename, extname } from "path";
+import { randomUUID } from "crypto";
+import { lstat, mkdir, open, readFile, rename, rm, stat } from "fs/promises";
+import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from "path";
 import type { HttpClient } from "../../core/http.js";
 import type { components } from "../../generated/v4/types.js";
 
@@ -7,6 +8,7 @@ type WorkspaceInfo = components["schemas"]["WorkspaceInfo"];
 type WorkspaceCreateRequest = components["schemas"]["WorkspaceCreateRequest"];
 type WorkspaceUpdateRequest = components["schemas"]["WorkspaceUpdateRequest"];
 type WorkspaceSizeInfo = components["schemas"]["WorkspaceSizeInfo"];
+type WorkspaceFileInfo = components["schemas"]["WorkspaceFileInfo"];
 type WorkspaceFileListResponse = components["schemas"]["WorkspaceFileListResponse"];
 type WorkspaceFileUploadRequest = components["schemas"]["WorkspaceFileUploadRequest"];
 type WorkspaceFileUploadResponse = components["schemas"]["WorkspaceFileUploadResponse"];
@@ -43,6 +45,73 @@ const MIME_TYPES: Record<string, string> = {
 
 function guessContentType(path: string): string {
   return MIME_TYPES[extname(path).toLowerCase()] ?? "application/octet-stream";
+}
+
+async function safeJoin(base: string, untrusted: string): Promise<string> {
+  const root = resolve(base);
+  const destination = resolve(root, untrusted);
+  const remainder = relative(root, destination);
+  if (remainder === ".." || remainder.startsWith(`..${sep}`) || isAbsolute(remainder)) {
+    throw new Error(`Path traversal detected: ${untrusted}`);
+  }
+
+  // Reject existing symlinked parents so a workspace-controlled path cannot
+  // redirect a bulk download outside the caller's destination directory.
+  let current = root;
+  const parentRemainder = relative(root, dirname(destination));
+  for (const component of parentRemainder.split(sep).filter(Boolean)) {
+    current = join(current, component);
+    try {
+      const info = await lstat(current);
+      if (info.isSymbolicLink() || !info.isDirectory()) {
+        throw new Error(`Path traversal detected: ${untrusted}`);
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      await mkdir(current);
+    }
+  }
+  return destination;
+}
+
+async function streamToPath(url: string, destination: string): Promise<void> {
+  await mkdir(dirname(destination), { recursive: true });
+  const temporary = join(
+    dirname(destination),
+    `.${basename(destination)}.${randomUUID()}.tmp`,
+  );
+  let output: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Download failed: ${response.status} ${response.statusText}`);
+    }
+    if (!response.body) {
+      throw new Error("Download failed: response body is empty");
+    }
+    output = await open(temporary, "wx");
+    for await (const chunk of response.body) {
+      let offset = 0;
+      while (offset < chunk.byteLength) {
+        const { bytesWritten } = await output.write(
+          chunk,
+          offset,
+          chunk.byteLength - offset,
+        );
+        if (bytesWritten === 0) {
+          throw new Error("Download failed: file write made no progress");
+        }
+        offset += bytesWritten;
+      }
+    }
+    await output.close();
+    output = undefined;
+    await rename(temporary, destination);
+  } catch (error) {
+    await output?.close().catch(() => undefined);
+    await rm(temporary, { force: true }).catch(() => undefined);
+    throw error;
+  }
 }
 
 export interface WorkspaceFilesParams {
@@ -157,5 +226,67 @@ export class Workspaces {
       if (!res.ok) throw new Error(`Upload failed: ${res.status} ${res.statusText}`);
     }
     return resp.files;
+  }
+
+  private async fileWithFreshUrl(workspaceId: string, path: string): Promise<WorkspaceFileInfo> {
+    let cursor: string | null | undefined;
+    while (true) {
+      const page = await this.files(workspaceId, {
+        prefix: path,
+        includeUrls: true,
+        cursor,
+      });
+      const match = page.files.find((file) => file.path === path);
+      if (match) return match;
+      if (!page.hasMore) throw new Error(`File not found in workspace: ${path}`);
+      if (!page.nextCursor) {
+        throw new Error("Workspace file response hasMore=true but no nextCursor");
+      }
+      cursor = page.nextCursor;
+    }
+  }
+
+  /** Download one exact workspace file with a fresh presigned URL. */
+  async download(
+    workspaceId: string,
+    path: string,
+    options: { to?: string } = {},
+  ): Promise<string> {
+    const file = await this.fileWithFreshUrl(workspaceId, path);
+    if (!file.url) {
+      throw new Error(`No download URL for ${JSON.stringify(path)}; ensure includeUrls=true`);
+    }
+    const destination = options.to ?? basename(file.path);
+    await streamToPath(file.url, destination);
+    return destination;
+  }
+
+  /**
+   * Download matching workspace files below `to`. Each file gets a fresh URL
+   * immediately before it streams, so earlier downloads cannot expire later URLs.
+   */
+  async downloadAll(
+    workspaceId: string,
+    options: { to?: string; prefix?: string } = {},
+  ): Promise<string[]> {
+    const destination = resolve(options.to ?? ".");
+    await mkdir(destination, { recursive: true });
+    const results: string[] = [];
+    let cursor: string | null | undefined;
+    while (true) {
+      const page = await this.files(workspaceId, {
+        prefix: options.prefix,
+        cursor,
+      });
+      for (const file of page.files) {
+        const local = await safeJoin(destination, file.path);
+        results.push(await this.download(workspaceId, file.path, { to: local }));
+      }
+      if (!page.hasMore) return results;
+      if (!page.nextCursor) {
+        throw new Error("Workspace file response hasMore=true but no nextCursor");
+      }
+      cursor = page.nextCursor;
+    }
   }
 }

--- a/browser-use-node/src/v4/resources/workspaces.ts
+++ b/browser-use-node/src/v4/resources/workspaces.ts
@@ -43,6 +43,8 @@ const MIME_TYPES: Record<string, string> = {
   ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
 };
 
+const DOWNLOAD_TIMEOUT_MS = 60_000;
+
 function guessContentType(path: string): string {
   return MIME_TYPES[extname(path).toLowerCase()] ?? "application/octet-stream";
 }
@@ -82,8 +84,11 @@ async function streamToPath(url: string, destination: string): Promise<void> {
   );
   let output: Awaited<ReturnType<typeof open>> | undefined;
   try {
-    const response = await fetch(url);
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+    });
     if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined);
       throw new Error(`Download failed: ${response.status} ${response.statusText}`);
     }
     if (!response.body) {

--- a/browser-use-node/tests/v4.test.ts
+++ b/browser-use-node/tests/v4.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, writeFileSync } from "fs";
+import { mkdtempSync, readFileSync, readdirSync, symlinkSync, writeFileSync } from "fs";
+import { open as openFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -452,6 +453,339 @@ describe("v4 workspaces", () => {
       await expect(workspaces.upload(WORKSPACE_ID)).rejects.toThrow(
         /At least one file path is required/,
       );
+    });
+  });
+
+  describe("download helpers", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("paginates to an exact file and streams it to disk", async () => {
+      const destination = join(mkdtempSync(join(tmpdir(), "bu-v4-download-")), "result.csv");
+      const url = "https://s3.example/get/reports/result.csv";
+      const http = {
+        get: vi.fn(async (_path: string, params?: Record<string, unknown>) =>
+          params?.cursor === "page-2"
+            ? {
+                files: [
+                  {
+                    path: "reports/result.csv",
+                    size: 6,
+                    lastModified: "2026-01-01T00:00:00Z",
+                    url,
+                  },
+                ],
+                nextCursor: null,
+                hasMore: false,
+              }
+            : {
+                files: [
+                  {
+                    path: "reports/result.csv.bak",
+                    size: 6,
+                    lastModified: "2026-01-01T00:00:00Z",
+                    url: null,
+                  },
+                ],
+                nextCursor: "page-2",
+                hasMore: true,
+              },
+        ),
+      };
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("result"));
+              controller.close();
+            },
+          }),
+        ),
+      );
+      const workspaces = new Workspaces(http as any);
+
+      const result = await workspaces.download(WORKSPACE_ID, "reports/result.csv", {
+        to: destination,
+      });
+
+      expect(result).toBe(destination);
+      expect(readFileSync(destination, "utf8")).toBe("result");
+      expect(http.get).toHaveBeenNthCalledWith(1, `/workspaces/${WORKSPACE_ID}/files`, {
+        prefix: "reports/result.csv",
+        includeUrls: true,
+        cursor: undefined,
+      });
+      expect(http.get).toHaveBeenNthCalledWith(2, `/workspaces/${WORKSPACE_ID}/files`, {
+        prefix: "reports/result.csv",
+        includeUrls: true,
+        cursor: "page-2",
+      });
+    });
+
+    it("retries partial file writes until the whole response chunk is saved", async () => {
+      const directory = mkdtempSync(join(tmpdir(), "bu-v4-short-write-"));
+      const destination = join(directory, "result.csv");
+      const probe = await openFile(join(directory, "probe"), "w");
+      const fileHandlePrototype = Object.getPrototypeOf(probe) as typeof probe;
+      const originalWrite = fileHandlePrototype.write;
+      await probe.close();
+      let writeCalls = 0;
+      vi.spyOn(fileHandlePrototype, "write").mockImplementation(async function (
+        buffer: Uint8Array,
+        offset = 0,
+        length = buffer.byteLength - offset,
+        position?: number | null,
+      ) {
+        writeCalls += 1;
+        return originalWrite.call(
+          this,
+          buffer,
+          offset,
+          Math.min(length, 2),
+          position,
+        );
+      });
+      const url = "https://s3.example/get/reports/result.csv";
+      const http = {
+        get: vi.fn(async () => ({
+          files: [
+            {
+              path: "reports/result.csv",
+              size: 6,
+              lastModified: "2026-01-01T00:00:00Z",
+              url,
+            },
+          ],
+          nextCursor: null,
+          hasMore: false,
+        })),
+      };
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("result"));
+              controller.close();
+            },
+          }),
+        ),
+      );
+      const workspaces = new Workspaces(http as any);
+
+      await workspaces.download(WORKSPACE_ID, "reports/result.csv", {
+        to: destination,
+      });
+
+      expect(readFileSync(destination, "utf8")).toBe("result");
+      expect(writeCalls).toBe(3);
+    });
+
+    it("preserves the destination and removes the temp file when a write makes no progress", async () => {
+      const directory = mkdtempSync(join(tmpdir(), "bu-v4-zero-write-"));
+      const destination = join(directory, "result.csv");
+      writeFileSync(destination, "previous");
+      const probe = await openFile(join(directory, "probe"), "w");
+      const fileHandlePrototype = Object.getPrototypeOf(probe) as typeof probe;
+      await probe.close();
+      vi.spyOn(fileHandlePrototype, "write").mockImplementation(async function (
+        buffer: Uint8Array,
+      ) {
+        return { bytesWritten: 0, buffer };
+      });
+      const url = "https://s3.example/get/reports/result.csv";
+      const http = {
+        get: vi.fn(async () => ({
+          files: [
+            {
+              path: "reports/result.csv",
+              size: 6,
+              lastModified: "2026-01-01T00:00:00Z",
+              url,
+            },
+          ],
+          nextCursor: null,
+          hasMore: false,
+        })),
+      };
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("result"));
+              controller.close();
+            },
+          }),
+        ),
+      );
+      const workspaces = new Workspaces(http as any);
+
+      await expect(
+        workspaces.download(WORKSPACE_ID, "reports/result.csv", { to: destination }),
+      ).rejects.toThrow(/file write made no progress/);
+
+      expect(readFileSync(destination, "utf8")).toBe("previous");
+      expect(readdirSync(directory).filter((name) => name.endsWith(".tmp"))).toEqual([]);
+    });
+
+    it("refreshes each URL only after the previous file finished", async () => {
+      const destination = mkdtempSync(join(tmpdir(), "bu-v4-download-all-"));
+      const firstUrl = "https://s3.example/get/reports/first.csv";
+      const secondUrl = "https://s3.example/get/reports/second.csv";
+      const events: string[] = [];
+      const http = {
+        get: vi.fn(async (_path: string, params?: Record<string, unknown>) => {
+          if (!params?.includeUrls) {
+            events.push("list");
+            return {
+              files: [
+                { path: "reports/first.csv", size: 5, lastModified: "2026-01-01T00:00:00Z" },
+                { path: "reports/second.csv", size: 6, lastModified: "2026-01-01T00:00:00Z" },
+              ],
+              nextCursor: null,
+              hasMore: false,
+            };
+          }
+          const path = String(params.prefix);
+          events.push(`refresh:${path}`);
+          return {
+            files: [
+              {
+                path,
+                size: path.endsWith("first.csv") ? 5 : 6,
+                lastModified: "2026-01-01T00:00:00Z",
+                url: path.endsWith("first.csv") ? firstUrl : secondUrl,
+              },
+            ],
+            nextCursor: null,
+            hasMore: false,
+          };
+        }),
+      };
+      vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+        const url = String(input);
+        const name = url === firstUrl ? "first" : "second";
+        events.push(`fetch:${name}`);
+        return new Response(
+          new ReadableStream({
+            pull(controller) {
+              events.push(`stream:${name}`);
+              controller.enqueue(new TextEncoder().encode(name));
+              controller.close();
+            },
+          }),
+        );
+      });
+      const workspaces = new Workspaces(http as any);
+
+      const result = await workspaces.downloadAll(WORKSPACE_ID, {
+        to: destination,
+        prefix: "reports/",
+      });
+
+      expect(result).toEqual([
+        join(destination, "reports/first.csv"),
+        join(destination, "reports/second.csv"),
+      ]);
+      expect(events).toEqual([
+        "list",
+        "refresh:reports/first.csv",
+        "fetch:first",
+        "stream:first",
+        "refresh:reports/second.csv",
+        "fetch:second",
+        "stream:second",
+      ]);
+    });
+
+    it("rejects traversal before requesting a URL", async () => {
+      const destination = mkdtempSync(join(tmpdir(), "bu-v4-traversal-"));
+      const http = {
+        get: vi.fn(async () => ({
+          files: [
+            { path: "../escape.txt", size: 6, lastModified: "2026-01-01T00:00:00Z" },
+          ],
+          nextCursor: null,
+          hasMore: false,
+        })),
+      };
+      const fetchMock = vi.spyOn(globalThis, "fetch");
+      const workspaces = new Workspaces(http as any);
+
+      await expect(
+        workspaces.downloadAll(WORKSPACE_ID, { to: destination }),
+      ).rejects.toThrow(/Path traversal detected/);
+
+      expect(http.get).toHaveBeenCalledTimes(1);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects a symlinked parent before requesting a URL", async () => {
+      const destination = mkdtempSync(join(tmpdir(), "bu-v4-symlink-root-"));
+      const outside = mkdtempSync(join(tmpdir(), "bu-v4-symlink-outside-"));
+      symlinkSync(
+        outside,
+        join(destination, "linked"),
+        process.platform === "win32" ? "junction" : "dir",
+      );
+      const http = {
+        get: vi.fn(async () => ({
+          files: [
+            { path: "linked/escape.txt", size: 6, lastModified: "2026-01-01T00:00:00Z" },
+          ],
+          nextCursor: null,
+          hasMore: false,
+        })),
+      };
+      const fetchMock = vi.spyOn(globalThis, "fetch");
+      const workspaces = new Workspaces(http as any);
+
+      await expect(
+        workspaces.downloadAll(WORKSPACE_ID, { to: destination }),
+      ).rejects.toThrow(/Path traversal detected/);
+
+      expect(http.get).toHaveBeenCalledTimes(1);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(readdirSync(outside)).toEqual([]);
+    });
+
+    it("keeps the old destination and removes temp files after a stream error", async () => {
+      const directory = mkdtempSync(join(tmpdir(), "bu-v4-download-error-"));
+      const destination = join(directory, "result.csv");
+      writeFileSync(destination, "previous");
+      const url = "https://s3.example/get/reports/result.csv";
+      const http = {
+        get: vi.fn(async () => ({
+          files: [
+            {
+              path: "reports/result.csv",
+              size: 7,
+              lastModified: "2026-01-01T00:00:00Z",
+              url,
+            },
+          ],
+          nextCursor: null,
+          hasMore: false,
+        })),
+      };
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("partial"));
+              controller.error(new Error("connection dropped"));
+            },
+          }),
+        ),
+      );
+      const workspaces = new Workspaces(http as any);
+
+      await expect(
+        workspaces.download(WORKSPACE_ID, "reports/result.csv", { to: destination }),
+      ).rejects.toThrow(/connection dropped/);
+
+      expect(readFileSync(destination, "utf8")).toBe("previous");
+      expect(readdirSync(directory).filter((name) => name.endsWith(".tmp"))).toEqual([]);
     });
   });
 });

--- a/browser-use-node/tests/v4.test.ts
+++ b/browser-use-node/tests/v4.test.ts
@@ -523,6 +523,50 @@ describe("v4 workspaces", () => {
       });
     });
 
+    it("bounds downloads and cancels non-success response bodies", async () => {
+      const directory = mkdtempSync(join(tmpdir(), "bu-v4-download-status-"));
+      const destination = join(directory, "result.csv");
+      writeFileSync(destination, "previous");
+      const url = "https://s3.example/get/reports/result.csv";
+      const signal = new AbortController().signal;
+      const timeout = vi.spyOn(AbortSignal, "timeout").mockReturnValue(signal);
+      let cancelled = false;
+      const response = new Response(
+        new ReadableStream({
+          cancel() {
+            cancelled = true;
+          },
+        }),
+        { status: 503, statusText: "Service Unavailable" },
+      );
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+      const http = {
+        get: vi.fn(async () => ({
+          files: [
+            {
+              path: "reports/result.csv",
+              size: 6,
+              lastModified: "2026-01-01T00:00:00Z",
+              url,
+            },
+          ],
+          nextCursor: null,
+          hasMore: false,
+        })),
+      };
+      const workspaces = new Workspaces(http as any);
+
+      await expect(
+        workspaces.download(WORKSPACE_ID, "reports/result.csv", { to: destination }),
+      ).rejects.toThrow(/Download failed: 503 Service Unavailable/);
+
+      expect(timeout).toHaveBeenCalledWith(60_000);
+      expect(fetchMock).toHaveBeenCalledWith(url, { signal });
+      expect(cancelled).toBe(true);
+      expect(readFileSync(destination, "utf8")).toBe("previous");
+      expect(readdirSync(directory).filter((name) => name.endsWith(".tmp"))).toEqual([]);
+    });
+
     it("retries partial file writes until the whole response chunk is saved", async () => {
       const directory = mkdtempSync(join(tmpdir(), "bu-v4-short-write-"));
       const destination = join(directory, "result.csv");

--- a/browser-use-python/src/browser_use_sdk/v4/resources/workspaces.py
+++ b/browser-use-python/src/browser_use_sdk/v4/resources/workspaces.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import mimetypes
+import os
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -25,6 +27,60 @@ if TYPE_CHECKING:
 def _guess_content_type(path: str) -> str:
     ct, _ = mimetypes.guess_type(path)
     return ct or "application/octet-stream"
+
+
+def _safe_join(base: Path, untrusted: str) -> Path:
+    """Join a workspace path below ``base`` without allowing traversal."""
+    base_resolved = base.resolve()
+    resolved = (base / untrusted).resolve()
+    if base_resolved != resolved and base_resolved not in resolved.parents:
+        raise ValueError(f"Path traversal detected: {untrusted}")
+    return resolved
+
+
+def _new_temp_file(destination: Path):
+    """Open a sibling temp file so the final replace stays on one filesystem."""
+    return tempfile.NamedTemporaryFile(
+        mode="wb",
+        delete=False,
+        dir=destination.parent,
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+    )
+
+
+def _stream_to_path(response: httpx.Response, destination: Path) -> None:
+    """Stream a response to a temp file, then atomically replace destination."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temp_file = _new_temp_file(destination)
+    temp_path = Path(temp_file.name)
+    try:
+        with temp_file:
+            for chunk in response.iter_bytes():
+                temp_file.write(chunk)
+        os.replace(temp_path, destination)
+    except BaseException:
+        temp_file.close()
+        temp_path.unlink(missing_ok=True)
+        raise
+
+
+async def _stream_to_path_async(
+    response: httpx.Response, destination: Path
+) -> None:
+    """Async response streaming with blocking file writes moved off-loop."""
+    await asyncio.to_thread(destination.parent.mkdir, parents=True, exist_ok=True)
+    temp_file = await asyncio.to_thread(_new_temp_file, destination)
+    temp_path = Path(temp_file.name)
+    try:
+        async for chunk in response.aiter_bytes():
+            await asyncio.to_thread(temp_file.write, chunk)
+        await asyncio.to_thread(temp_file.close)
+        await asyncio.to_thread(os.replace, temp_path, destination)
+    except BaseException:
+        await asyncio.to_thread(temp_file.close)
+        await asyncio.to_thread(temp_path.unlink, missing_ok=True)
+        raise
 
 
 def _presign_items(resolved: list[Path]) -> list[WorkspaceFileUploadItem]:
@@ -192,7 +248,7 @@ class Workspaces:
 
             uploaded = client.workspaces.upload(ws_id, "data.csv")
             client.runs.create("...", workspace_id=ws_id, attached_file_ids=[f.id for f in uploaded])
-        
+
 
         Each file is read at PUT time and its byte length checked against the
         presigned size; a size change raises. Don't modify a file while it is
@@ -214,6 +270,86 @@ class Workspaces:
                     headers={"Content-Type": item.content_type or "application/octet-stream"},
                 ).raise_for_status()
         return list(resp.files)
+
+    def download(
+        self,
+        workspace_id: str | UUID,
+        path: str,
+        *,
+        to: str | Path | None = None,
+    ) -> Path:
+        """Download one exact workspace file and return its local path.
+
+        Usage::
+
+            local = client.workspaces.download(ws_id, "reports/result.csv", to="./result.csv")
+        """
+        cursor: str | None = None
+        while True:
+            file_list = self.files(
+                workspace_id,
+                prefix=path,
+                include_urls=True,
+                cursor=cursor,
+            )
+            match = next((f for f in file_list.files if f.path == path), None)
+            if match is not None:
+                break
+            if not file_list.has_more:
+                raise FileNotFoundError(f"File not found in workspace: {path}")
+            if file_list.next_cursor is None:
+                raise RuntimeError(
+                    "Workspace file response has_more=True but no next_cursor"
+                )
+            cursor = file_list.next_cursor
+
+        if match.url is None:
+            raise ValueError(f"No download URL for {path!r}; ensure include_urls=True")
+
+        dest = Path(to) if to is not None else Path(os.path.basename(match.path))
+        with httpx.Client(timeout=60) as http:
+            with http.stream("GET", match.url) as response:
+                response.raise_for_status()
+                _stream_to_path(response, dest)
+        return dest
+
+    def download_all(
+        self,
+        workspace_id: str | UUID,
+        *,
+        to: str | Path = ".",
+        prefix: str | None = None,
+    ) -> list[Path]:
+        """Download matching workspace files below ``to`` and return their paths.
+
+        Usage::
+
+            paths = client.workspaces.download_all(ws_id, to="./output", prefix="reports/")
+        """
+        dest_dir = Path(to)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        results: list[Path] = []
+        cursor: str | None = None
+
+        while True:
+            # List metadata without URLs. Each file is re-read with include_urls
+            # immediately before its GET so a 60-second URL cannot expire while
+            # earlier files are still downloading.
+            file_list = self.files(
+                workspace_id,
+                prefix=prefix,
+                cursor=cursor,
+            )
+            for file in file_list.files:
+                local = _safe_join(dest_dir, file.path)
+                results.append(self.download(workspace_id, file.path, to=local))
+            if not file_list.has_more:
+                return results
+            if file_list.next_cursor is None:
+                raise RuntimeError(
+                    "Workspace file response has_more=True but no next_cursor"
+                )
+            cursor = file_list.next_cursor
 
 
 class AsyncWorkspaces:
@@ -337,7 +473,7 @@ class AsyncWorkspaces:
         Usage::
 
             uploaded = await client.workspaces.upload(ws_id, "data.csv")
-        
+
 
         Each file is read at PUT time and its byte length checked against the
         presigned size; a size change raises. Don't modify a file while it is
@@ -363,3 +499,88 @@ class AsyncWorkspaces:
                 )
                 r.raise_for_status()
         return list(resp.files)
+
+    async def download(
+        self,
+        workspace_id: str | UUID,
+        path: str,
+        *,
+        to: str | Path | None = None,
+    ) -> Path:
+        """Download one exact workspace file and return its local path.
+
+        Usage::
+
+            local = await client.workspaces.download(
+                ws_id, "reports/result.csv", to="./result.csv"
+            )
+        """
+        cursor: str | None = None
+        while True:
+            file_list = await self.files(
+                workspace_id,
+                prefix=path,
+                include_urls=True,
+                cursor=cursor,
+            )
+            match = next((f for f in file_list.files if f.path == path), None)
+            if match is not None:
+                break
+            if not file_list.has_more:
+                raise FileNotFoundError(f"File not found in workspace: {path}")
+            if file_list.next_cursor is None:
+                raise RuntimeError(
+                    "Workspace file response has_more=True but no next_cursor"
+                )
+            cursor = file_list.next_cursor
+
+        if match.url is None:
+            raise ValueError(f"No download URL for {path!r}; ensure include_urls=True")
+
+        dest = Path(to) if to is not None else Path(os.path.basename(match.path))
+        async with httpx.AsyncClient(timeout=60) as http:
+            async with http.stream("GET", match.url) as response:
+                response.raise_for_status()
+                await _stream_to_path_async(response, dest)
+        return dest
+
+    async def download_all(
+        self,
+        workspace_id: str | UUID,
+        *,
+        to: str | Path = ".",
+        prefix: str | None = None,
+    ) -> list[Path]:
+        """Download matching workspace files below ``to`` and return their paths.
+
+        Usage::
+
+            paths = await client.workspaces.download_all(
+                ws_id, to="./output", prefix="reports/"
+            )
+        """
+        dest_dir = Path(to)
+        await asyncio.to_thread(dest_dir.mkdir, parents=True, exist_ok=True)
+        results: list[Path] = []
+        cursor: str | None = None
+
+        while True:
+            # Do not request a page of short-lived URLs. Refresh one exact file
+            # immediately before streaming it, after the previous file finished.
+            file_list = await self.files(
+                workspace_id,
+                prefix=prefix,
+                cursor=cursor,
+            )
+            for file in file_list.files:
+                local = await asyncio.to_thread(_safe_join, dest_dir, file.path)
+                results.append(
+                    await self.download(workspace_id, file.path, to=local)
+                )
+            if not file_list.has_more:
+                return results
+            if file_list.next_cursor is None:
+                raise RuntimeError(
+                    "Workspace file response has_more=True but no next_cursor"
+                )
+            cursor = file_list.next_cursor

--- a/browser-use-python/tests/test_v4.py
+++ b/browser-use-python/tests/test_v4.py
@@ -916,9 +916,11 @@ def test_async_workspaces_upload_short_presign_raises(tmp_path: Path) -> None:
 
 
 def test_async_workspaces_download_all(tmp_path: Path, monkeypatch: Any) -> None:
-    url = "https://s3.example/get/reports/result.csv"
+    first_url = "https://s3.example/get/reports/first.csv"
+    second_url = "https://s3.example/get/reports/nested/second.csv"
     _FakeAsyncDownloadClient.responses = {
-        url: _FakeDownloadResponse(b"res", b"ult")
+        first_url: _FakeDownloadResponse(b"first"),
+        second_url: _FakeDownloadResponse(b"second"),
     }
     _FakeAsyncDownloadClient.calls = []
     monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncDownloadClient)
@@ -936,15 +938,31 @@ def test_async_workspaces_download_all(tmp_path: Path, monkeypatch: Any) -> None
         http = FakeAsyncHttp(
             [
                 {
-                    "files": [_workspace_file("reports/result.csv", None)],
+                    "files": [_workspace_file("reports/first.csv", None)],
+                    "nextCursor": "page-2",
+                    "hasMore": True,
+                },
+                {
+                    "files": [_workspace_file("reports/first.csv", first_url)],
                     "nextCursor": None,
                     "hasMore": False,
                 },
                 {
-                    "files": [_workspace_file("reports/result.csv", url)],
+                    "files": [
+                        _workspace_file("reports/nested/second.csv", None)
+                    ],
                     "nextCursor": None,
                     "hasMore": False,
-                }
+                },
+                {
+                    "files": [
+                        _workspace_file(
+                            "reports/nested/second.csv", second_url
+                        )
+                    ],
+                    "nextCursor": None,
+                    "hasMore": False,
+                },
             ]
         )
         workspaces = AsyncWorkspaces(http)  # type: ignore[arg-type]
@@ -954,11 +972,45 @@ def test_async_workspaces_download_all(tmp_path: Path, monkeypatch: Any) -> None
             WORKSPACE_ID, to=destination, prefix="reports/"
         )
 
-        assert result == [(destination / "reports/result.csv").resolve()]
-        assert result[0].read_bytes() == b"result"
-        assert _FakeAsyncDownloadClient.calls == [url]
+        assert result == [
+            (destination / "reports/first.csv").resolve(),
+            (destination / "reports/nested/second.csv").resolve(),
+        ]
+        assert result[0].read_bytes() == b"first"
+        assert result[1].read_bytes() == b"second"
+        assert _FakeAsyncDownloadClient.calls == [first_url, second_url]
         assert path_resolution_threads
         assert event_loop_thread not in path_resolution_threads
+        assert [call[3] for call in http.calls] == [
+            {
+                "prefix": "reports/",
+                "limit": None,
+                "cursor": None,
+                "includeUrls": None,
+                "contentDisposition": None,
+            },
+            {
+                "prefix": "reports/first.csv",
+                "limit": None,
+                "cursor": None,
+                "includeUrls": True,
+                "contentDisposition": None,
+            },
+            {
+                "prefix": "reports/",
+                "limit": None,
+                "cursor": "page-2",
+                "includeUrls": None,
+                "contentDisposition": None,
+            },
+            {
+                "prefix": "reports/nested/second.csv",
+                "limit": None,
+                "cursor": None,
+                "includeUrls": True,
+                "contentDisposition": None,
+            },
+        ]
 
     asyncio.run(run())
 

--- a/browser-use-python/tests/test_v4.py
+++ b/browser-use-python/tests/test_v4.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import httpx
 import pytest
 
+import browser_use_sdk.v4.resources.workspaces as workspaces_module
 from browser_use_sdk.v4 import InlineSecretSource, SecretBinding
 from browser_use_sdk.v4.resources.runs import AsyncRuns, Runs
 from browser_use_sdk.v4.resources.sessions import Sessions
@@ -353,6 +355,15 @@ def _upload_item() -> dict[str, Any]:
     }
 
 
+def _workspace_file(path: str, url: str | None) -> dict[str, Any]:
+    return {
+        "path": path,
+        "size": 7,
+        "lastModified": "2026-01-01T00:00:00Z",
+        "url": url,
+    }
+
+
 def test_workspaces_create() -> None:
     http = FakeSyncHttp([_workspace_info()])
     workspaces = Workspaces(http)  # type: ignore[arg-type]
@@ -520,6 +531,300 @@ def test_workspaces_upload_no_paths_raises() -> None:
     assert http.calls == []
 
 
+class _FakeDownloadResponse:
+    def __init__(
+        self,
+        *chunks: bytes | BaseException,
+        status_code: int = 200,
+        on_enter: Callable[[], None] | None = None,
+    ) -> None:
+        self.chunks = chunks
+        self.status_code = status_code
+        self.on_enter = on_enter
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            request = httpx.Request("GET", "https://s3.example/test")
+            raise httpx.HTTPStatusError(
+                f"{self.status_code}",
+                request=request,
+                response=httpx.Response(self.status_code, request=request),
+            )
+
+    def iter_bytes(self):
+        for chunk in self.chunks:
+            if isinstance(chunk, BaseException):
+                raise chunk
+            yield chunk
+
+    async def aiter_bytes(self):
+        for chunk in self.chunks:
+            if isinstance(chunk, BaseException):
+                raise chunk
+            yield chunk
+
+
+class _FakeSyncStreamContext:
+    def __init__(self, response: _FakeDownloadResponse) -> None:
+        self.response = response
+
+    def __enter__(self) -> _FakeDownloadResponse:
+        if self.response.on_enter is not None:
+            self.response.on_enter()
+        return self.response
+
+    def __exit__(self, *_args: Any) -> None:
+        pass
+
+
+class _FakeSyncDownloadClient:
+    responses: dict[str, _FakeDownloadResponse] = {}
+    calls: list[str] = []
+
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    def __enter__(self) -> _FakeSyncDownloadClient:
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        pass
+
+    def stream(self, method: str, url: str) -> _FakeSyncStreamContext:
+        assert method == "GET"
+        type(self).calls.append(url)
+        response = type(self).responses.get(
+            url, _FakeDownloadResponse(status_code=404)
+        )
+        return _FakeSyncStreamContext(response)
+
+
+def test_workspaces_download_paginates_for_exact_path(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    url = "https://s3.example/get/reports/result.csv"
+    _FakeSyncDownloadClient.responses = {
+        url: _FakeDownloadResponse(b"id,", b"name\n1,a\n")
+    }
+    _FakeSyncDownloadClient.calls = []
+    monkeypatch.setattr(httpx, "Client", _FakeSyncDownloadClient)
+
+    http = FakeSyncHttp(
+        [
+            {
+                "files": [_workspace_file("reports/result.csv.bak", None)],
+                "nextCursor": "page-2",
+                "hasMore": True,
+            },
+            {
+                "files": [_workspace_file("reports/result.csv", url)],
+                "nextCursor": None,
+                "hasMore": False,
+            },
+        ]
+    )
+    workspaces = Workspaces(http)  # type: ignore[arg-type]
+    destination = tmp_path / "exports" / "result.csv"
+
+    result = workspaces.download(WORKSPACE_ID, "reports/result.csv", to=destination)
+
+    assert result == destination
+    assert destination.read_bytes() == b"id,name\n1,a\n"
+    assert _FakeSyncDownloadClient.calls == [url]
+    assert [call[3] for call in http.calls] == [
+        {
+            "prefix": "reports/result.csv",
+            "limit": None,
+            "cursor": None,
+            "includeUrls": True,
+            "contentDisposition": None,
+        },
+        {
+            "prefix": "reports/result.csv",
+            "limit": None,
+            "cursor": "page-2",
+            "includeUrls": True,
+            "contentDisposition": None,
+        },
+    ]
+
+
+def test_workspaces_download_missing_file_raises() -> None:
+    http = FakeSyncHttp([{"files": [], "nextCursor": None, "hasMore": False}])
+    workspaces = Workspaces(http)  # type: ignore[arg-type]
+
+    with pytest.raises(FileNotFoundError, match="reports/missing.csv"):
+        workspaces.download(WORKSPACE_ID, "reports/missing.csv")
+
+
+def test_workspaces_download_all_preserves_paths_across_pages(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    first_url = "https://s3.example/get/reports/first.csv"
+    second_url = "https://s3.example/get/reports/nested/second.csv"
+    events: list[str] = []
+    _FakeSyncDownloadClient.responses = {
+        first_url: _FakeDownloadResponse(
+            b"first", on_enter=lambda: events.append("stream:first")
+        ),
+        second_url: _FakeDownloadResponse(
+            b"second", on_enter=lambda: events.append("stream:second")
+        ),
+    }
+    _FakeSyncDownloadClient.calls = []
+    monkeypatch.setattr(httpx, "Client", _FakeSyncDownloadClient)
+
+    class OrderedFakeSyncHttp(FakeSyncHttp):
+        def request(
+            self,
+            method: str,
+            path: str,
+            *,
+            json: dict[str, Any] | None = None,
+            params: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            if params is not None:
+                if params["includeUrls"]:
+                    events.append(f"refresh:{params['prefix']}")
+                else:
+                    events.append(f"list:{params['cursor']}")
+            return super().request(method, path, json=json, params=params)
+
+    http = OrderedFakeSyncHttp(
+        [
+            {
+                "files": [_workspace_file("reports/first.csv", None)],
+                "nextCursor": "page-2",
+                "hasMore": True,
+            },
+            {
+                "files": [_workspace_file("reports/first.csv", first_url)],
+                "nextCursor": None,
+                "hasMore": False,
+            },
+            {
+                "files": [_workspace_file("reports/nested/second.csv", None)],
+                "nextCursor": None,
+                "hasMore": False,
+            },
+            {
+                "files": [_workspace_file("reports/nested/second.csv", second_url)],
+                "nextCursor": None,
+                "hasMore": False,
+            },
+        ]
+    )
+    workspaces = Workspaces(http)  # type: ignore[arg-type]
+    destination = tmp_path / "exports"
+
+    result = workspaces.download_all(WORKSPACE_ID, to=destination, prefix="reports/")
+
+    assert result == [
+        (destination / "reports/first.csv").resolve(),
+        (destination / "reports/nested/second.csv").resolve(),
+    ]
+    assert result[0].read_bytes() == b"first"
+    assert result[1].read_bytes() == b"second"
+    assert _FakeSyncDownloadClient.calls == [first_url, second_url]
+    assert events == [
+        "list:None",
+        "refresh:reports/first.csv",
+        "stream:first",
+        "list:page-2",
+        "refresh:reports/nested/second.csv",
+        "stream:second",
+    ]
+    assert [call[3] for call in http.calls] == [
+        {
+            "prefix": "reports/",
+            "limit": None,
+            "cursor": None,
+            "includeUrls": None,
+            "contentDisposition": None,
+        },
+        {
+            "prefix": "reports/first.csv",
+            "limit": None,
+            "cursor": None,
+            "includeUrls": True,
+            "contentDisposition": None,
+        },
+        {
+            "prefix": "reports/",
+            "limit": None,
+            "cursor": "page-2",
+            "includeUrls": None,
+            "contentDisposition": None,
+        },
+        {
+            "prefix": "reports/nested/second.csv",
+            "limit": None,
+            "cursor": None,
+            "includeUrls": True,
+            "contentDisposition": None,
+        },
+    ]
+
+
+def test_workspaces_download_all_rejects_path_traversal(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    _FakeSyncDownloadClient.responses = {
+        "https://s3.example/get/escape": _FakeDownloadResponse(b"escape")
+    }
+    _FakeSyncDownloadClient.calls = []
+    monkeypatch.setattr(httpx, "Client", _FakeSyncDownloadClient)
+
+    http = FakeSyncHttp(
+        [
+            {
+                "files": [_workspace_file("../escape.txt", None)],
+                "nextCursor": None,
+                "hasMore": False,
+            }
+        ]
+    )
+    workspaces = Workspaces(http)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="Path traversal detected"):
+        workspaces.download_all(WORKSPACE_ID, to=tmp_path / "exports")
+    assert _FakeSyncDownloadClient.calls == []
+
+
+def test_workspaces_download_failure_keeps_destination_and_removes_temp(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    url = "https://s3.example/get/reports/result.csv"
+    _FakeSyncDownloadClient.responses = {
+        url: _FakeDownloadResponse(
+            b"partial", RuntimeError("connection dropped")
+        )
+    }
+    _FakeSyncDownloadClient.calls = []
+    monkeypatch.setattr(httpx, "Client", _FakeSyncDownloadClient)
+    http = FakeSyncHttp(
+        [
+            {
+                "files": [_workspace_file("reports/result.csv", url)],
+                "nextCursor": None,
+                "hasMore": False,
+            }
+        ]
+    )
+    workspaces = Workspaces(http)  # type: ignore[arg-type]
+    destination = tmp_path / "exports" / "result.csv"
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes(b"previous")
+
+    with pytest.raises(RuntimeError, match="connection dropped"):
+        workspaces.download(
+            WORKSPACE_ID, "reports/result.csv", to=destination
+        )
+
+    assert destination.read_bytes() == b"previous"
+    assert list(destination.parent.glob(".result.csv.*.tmp")) == []
+
+
 class _FakeAsyncPutClient:
     calls: list[tuple[str, bytes, dict[str, str]]] = []
     status_code = 200
@@ -536,6 +841,41 @@ class _FakeAsyncPutClient:
     async def put(self, url: str, *, content: bytes, headers: dict[str, str]) -> _FakePutResponse:
         type(self).calls.append((url, content, headers))
         return _FakePutResponse(type(self).status_code)
+
+
+class _FakeAsyncStreamContext:
+    def __init__(self, response: _FakeDownloadResponse) -> None:
+        self.response = response
+
+    async def __aenter__(self) -> _FakeDownloadResponse:
+        if self.response.on_enter is not None:
+            self.response.on_enter()
+        return self.response
+
+    async def __aexit__(self, *_args: Any) -> None:
+        pass
+
+
+class _FakeAsyncDownloadClient:
+    responses: dict[str, _FakeDownloadResponse] = {}
+    calls: list[str] = []
+
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> _FakeAsyncDownloadClient:
+        return self
+
+    async def __aexit__(self, *_args: Any) -> None:
+        pass
+
+    def stream(self, method: str, url: str) -> _FakeAsyncStreamContext:
+        assert method == "GET"
+        type(self).calls.append(url)
+        response = type(self).responses.get(
+            url, _FakeDownloadResponse(status_code=404)
+        )
+        return _FakeAsyncStreamContext(response)
 
 
 def test_async_workspaces_upload(tmp_path: Path, monkeypatch: Any) -> None:
@@ -571,5 +911,173 @@ def test_async_workspaces_upload_short_presign_raises(tmp_path: Path) -> None:
 
         with pytest.raises(ValueError, match=r"data\.csv \(position 0\)"):
             await workspaces.upload(WORKSPACE_ID, f)
+
+    asyncio.run(run())
+
+
+def test_async_workspaces_download_all(tmp_path: Path, monkeypatch: Any) -> None:
+    url = "https://s3.example/get/reports/result.csv"
+    _FakeAsyncDownloadClient.responses = {
+        url: _FakeDownloadResponse(b"res", b"ult")
+    }
+    _FakeAsyncDownloadClient.calls = []
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncDownloadClient)
+    event_loop_thread = threading.get_ident()
+    path_resolution_threads: list[int] = []
+    original_safe_join = workspaces_module._safe_join
+
+    def recording_safe_join(base: Path, untrusted: str) -> Path:
+        path_resolution_threads.append(threading.get_ident())
+        return original_safe_join(base, untrusted)
+
+    monkeypatch.setattr(workspaces_module, "_safe_join", recording_safe_join)
+
+    async def run() -> None:
+        http = FakeAsyncHttp(
+            [
+                {
+                    "files": [_workspace_file("reports/result.csv", None)],
+                    "nextCursor": None,
+                    "hasMore": False,
+                },
+                {
+                    "files": [_workspace_file("reports/result.csv", url)],
+                    "nextCursor": None,
+                    "hasMore": False,
+                }
+            ]
+        )
+        workspaces = AsyncWorkspaces(http)  # type: ignore[arg-type]
+        destination = tmp_path / "exports"
+
+        result = await workspaces.download_all(
+            WORKSPACE_ID, to=destination, prefix="reports/"
+        )
+
+        assert result == [(destination / "reports/result.csv").resolve()]
+        assert result[0].read_bytes() == b"result"
+        assert _FakeAsyncDownloadClient.calls == [url]
+        assert path_resolution_threads
+        assert event_loop_thread not in path_resolution_threads
+
+    asyncio.run(run())
+
+
+def test_async_workspaces_download_paginates_for_exact_path(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    url = "https://s3.example/get/reports/result.csv"
+    _FakeAsyncDownloadClient.responses = {
+        url: _FakeDownloadResponse(b"result")
+    }
+    _FakeAsyncDownloadClient.calls = []
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncDownloadClient)
+
+    async def run() -> None:
+        http = FakeAsyncHttp(
+            [
+                {
+                    "files": [_workspace_file("reports/result.csv.bak", None)],
+                    "nextCursor": "page-2",
+                    "hasMore": True,
+                },
+                {
+                    "files": [_workspace_file("reports/result.csv", url)],
+                    "nextCursor": None,
+                    "hasMore": False,
+                },
+            ]
+        )
+        workspaces = AsyncWorkspaces(http)  # type: ignore[arg-type]
+        destination = tmp_path / "result.csv"
+
+        result = await workspaces.download(
+            WORKSPACE_ID, "reports/result.csv", to=destination
+        )
+
+        assert result == destination
+        assert destination.read_bytes() == b"result"
+        assert [call[3] for call in http.calls] == [
+            {
+                "prefix": "reports/result.csv",
+                "limit": None,
+                "cursor": None,
+                "includeUrls": True,
+                "contentDisposition": None,
+            },
+            {
+                "prefix": "reports/result.csv",
+                "limit": None,
+                "cursor": "page-2",
+                "includeUrls": True,
+                "contentDisposition": None,
+            },
+        ]
+
+    asyncio.run(run())
+
+
+def test_async_workspaces_download_all_rejects_path_traversal(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    _FakeAsyncDownloadClient.responses = {}
+    _FakeAsyncDownloadClient.calls = []
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncDownloadClient)
+
+    async def run() -> None:
+        http = FakeAsyncHttp(
+            [
+                {
+                    "files": [_workspace_file("../escape.txt", None)],
+                    "nextCursor": None,
+                    "hasMore": False,
+                }
+            ]
+        )
+        workspaces = AsyncWorkspaces(http)  # type: ignore[arg-type]
+
+        with pytest.raises(ValueError, match="Path traversal detected"):
+            await workspaces.download_all(
+                WORKSPACE_ID, to=tmp_path / "exports"
+            )
+        assert _FakeAsyncDownloadClient.calls == []
+
+    asyncio.run(run())
+
+
+def test_async_workspaces_download_failure_cleans_temp(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    url = "https://s3.example/get/reports/result.csv"
+    _FakeAsyncDownloadClient.responses = {
+        url: _FakeDownloadResponse(
+            b"partial", RuntimeError("connection dropped")
+        )
+    }
+    _FakeAsyncDownloadClient.calls = []
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncDownloadClient)
+
+    async def run() -> None:
+        http = FakeAsyncHttp(
+            [
+                {
+                    "files": [_workspace_file("reports/result.csv", url)],
+                    "nextCursor": None,
+                    "hasMore": False,
+                }
+            ]
+        )
+        workspaces = AsyncWorkspaces(http)  # type: ignore[arg-type]
+        destination = tmp_path / "exports" / "result.csv"
+        destination.parent.mkdir(parents=True)
+        destination.write_bytes(b"previous")
+
+        with pytest.raises(RuntimeError, match="connection dropped"):
+            await workspaces.download(
+                WORKSPACE_ID, "reports/result.csv", to=destination
+            )
+
+        assert destination.read_bytes() == b"previous"
+        assert list(destination.parent.glob(".result.csv.*.tmp")) == []
 
     asyncio.run(run())

--- a/docs/cloud/agent/workspaces.mdx
+++ b/docs/cloud/agent/workspaces.mdx
@@ -61,28 +61,37 @@ Attachments are run-scoped. Reusing a workspace does not reattach every upload.
 
 ## Retrieve created files
 
-Ask the agent to save its output, then list the workspace:
+Ask the agent to save its output, then download one file or a whole prefix:
 
 <CodeGroup>
 ```python Python
-files = client.workspaces.files(
+report = client.workspaces.download(
     workspace.id,
-    include_urls=True,
+    "reports/result.csv",
+    to="./result.csv",
 )
-for file in files.files:
-    print(file.path, file.url)
+all_reports = client.workspaces.download_all(
+    workspace.id,
+    to="./exports",
+    prefix="reports/",
+)
 ```
 ```typescript TypeScript
-const files = await client.workspaces.files(
+const report = await client.workspaces.download(
   workspace.id,
-  { includeUrls: true },
+  "reports/result.csv",
+  { to: "./result.csv" },
 );
-for (const file of files.files) {
-  console.log(file.path, file.url);
-}
+const allReports = await client.workspaces.downloadAll(
+  workspace.id,
+  { to: "./exports", prefix: "reports/" },
+);
 ```
 </CodeGroup>
 
-Download URLs expire after 60 seconds. See the [workspace API
-reference](/cloud/api-v4/workspaces/list-workspace-files) for pagination and
-limits.
+The helpers stream each file to a temporary sibling and replace the destination
+only after the download completes. Bulk downloads request a fresh URL for each
+file immediately before transfer; workspace download URLs expire after 60
+seconds. Use `files(..., include_urls=True)` / `files(..., { includeUrls: true })`
+only when you need to manage the presigned URLs directly. See the [workspace API
+reference](/cloud/api-v4/workspaces/list-workspace-files) for pagination and limits.


### PR DESCRIPTION
## What changed

V4 workspaces could list and upload files, but neither SDK exposed a high-level download helper.

- Python: add sync and async `download()` and `download_all()`.
- TypeScript: add `download()` and `downloadAll()`.
- Add concise Python and TypeScript examples to the workspace guide.

Each transfer requests a fresh presigned URL immediately before downloading, streams to a sibling temporary file, and atomically replaces the destination. Failed transfers remove the temporary file and preserve an existing destination. Bulk downloads preserve nested paths and reject traversal.

## Tests

- TypeScript: 28 focused V4 tests passed; 148 full non-live tests passed; typecheck passed; ESM, CJS, and DTS build passed.
- Python: 61 passed and 22 skipped; source-file Pyright passed; Ruff passed; compileall passed.
- `git diff --check` passed.
- Exact-range TruffleHog scan found 0 verified and 0 unverified secrets.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds high-level download helpers to the Python and TypeScript V4 workspace SDKs, so callers can pull workspace files to disk without managing presigned URLs manually.

**New Features**
- Python adds sync and async `download()` and `download_all()`; TypeScript adds `download()` and `downloadAll()`.
- Each file requests a fresh presigned URL immediately before streaming and is written via a sibling temp file, then atomically replaces the destination.
- Failed transfers delete the temp file and leave an existing destination in place.
- Bulk downloads preserve nested paths and reject path traversal, including symlinked parents.
- Workspace guide examples now show downloading a single file and a prefix.

<sup>Written for commit ea16657d105df94df2b3fa96e7bc037890d391cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

