### PR TITLE
docs: link profile sync from quickstarts

### DIFF
--- a/docs/cloud/agent/quickstart.mdx
+++ b/docs/cloud/agent/quickstart.mdx
@@ -40,6 +40,10 @@ curl https://api.browser-use.com/api/v4/runs \
 Install the SDK with `pip install browser-use-sdk` or
 `npm install browser-use-sdk`. Curl needs no installation.
 
+To keep cookies and local storage between runs, [sync a browser
+profile](/cloud/guides/profile-sync) and pass its ID as
+`browserSettings.profileId`.
+
 Every new run implicitly creates a [session](/cloud/agent/sessions) for its
 conversation and live browser, plus a [workspace](/cloud/agent/workspaces) for
 persistent files.

--- a/docs/cloud/browser/quickstart.mdx
+++ b/docs/cloud/browser/quickstart.mdx
@@ -92,6 +92,10 @@ curl -X PATCH \
   `PATCH /api/v4/browsers/{id}` with `{"action":"stop"}`.
 </Warning>
 
+To keep cookies and local storage between browsers, [sync a browser
+profile](/cloud/guides/profile-sync) and pass its ID as `profileId` when you
+launch the next browser.
+
 <CardGroup cols={2}>
   <Card
     title="Connect over CDP"

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -235,6 +235,10 @@ curl https://api.browser-use.com/api/v4/runs \
 Install the SDK with `pip install browser-use-sdk` or
 `npm install browser-use-sdk`. Curl needs no installation.
 
+To keep cookies and local storage between runs, [sync a browser
+profile](https://docs.browser-use.com/cloud/guides/profile-sync) and pass its ID as
+`browserSettings.profileId`.
+
 Every new run implicitly creates a [session](https://docs.browser-use.com/cloud/agent/sessions) for its
 conversation and live browser, plus a [workspace](https://docs.browser-use.com/cloud/agent/workspaces) for
 persistent files.
@@ -1077,6 +1081,10 @@ curl -X PATCH \
   `browser.close()`, disconnecting CDP, or `client.close()` does not stop the
   managed browser. Use `client.browsers.stop(browser.id)` or call
   `PATCH /api/v4/browsers/{id}` with `{"action":"stop"}`.
+
+To keep cookies and local storage between browsers, [sync a browser
+profile](https://docs.browser-use.com/cloud/guides/profile-sync) and pass its ID as `profileId` when you
+launch the next browser.
 
   [Connect over CDP](https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium)
 Use the CDP URL with Playwright or Puppeteer.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -235,6 +235,10 @@ curl https://api.browser-use.com/api/v4/runs \
 Install the SDK with `pip install browser-use-sdk` or
 `npm install browser-use-sdk`. Curl needs no installation.
 
+To keep cookies and local storage between runs, [sync a browser
+profile](https://docs.browser-use.com/cloud/guides/profile-sync) and pass its ID as
+`browserSettings.profileId`.
+
 Every new run implicitly creates a [session](https://docs.browser-use.com/cloud/agent/sessions) for its
 conversation and live browser, plus a [workspace](https://docs.browser-use.com/cloud/agent/workspaces) for
 persistent files.
@@ -1077,6 +1081,10 @@ curl -X PATCH \
   `browser.close()`, disconnecting CDP, or `client.close()` does not stop the
   managed browser. Use `client.browsers.stop(browser.id)` or call
   `PATCH /api/v4/browsers/{id}` with `{"action":"stop"}`.
+
+To keep cookies and local storage between browsers, [sync a browser
+profile](https://docs.browser-use.com/cloud/guides/profile-sync) and pass its ID as `profileId` when you
+launch the next browser.
 
   [Connect over CDP](https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium)
 Use the CDP URL with Playwright or Puppeteer.


### PR DESCRIPTION
## What changed

The V4 agent and browser quickstarts now link the existing profile-sync guide at the point where users need persistent cookies and local storage.

- Agent runs name `browserSettings.profileId`.
- Browser sessions name `profileId`.
- The generated full documentation files are refreshed.

## Why

A 2027 profile-persistence run needed 12 documentation fetches before finding the existing guide. The guide was already correct; the two main V4 entry points could not point to it.

## Checks

- Generated the LLM files twice; the result was idempotent.
- Parsed `docs/docs.json` and verified `/cloud/guides/profile-sync` exists.
- Mintlify broken-links passed with no findings.
- `git diff --check` passed.

This is documentation only. It does not change SDK or API behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Links the existing profile-sync guide from the V4 agent and browser quickstarts so users can find how to keep cookies and local storage between runs. The quickstarts now point to `/cloud/guides/profile-sync` and show passing the profile ID as `browserSettings.profileId` for agents and `profileId` for browsers. Also regenerates the full documentation text files.

<sup>Written for commit f59bc9fc026e2caa483ef65e05f5249703b50053. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

