### PR TITLE
docs: explain automatic CAPTCHA handling

### DIFF
--- a/docs/cloud/browser/captcha-handling.mdx
+++ b/docs/cloud/browser/captcha-handling.mdx
@@ -1,0 +1,28 @@
+---
+title: CAPTCHA handling
+description: "Cloud browsers solve reCAPTCHA and hCaptcha automatically."
+icon: shield-check
+---
+
+Every Browser Use Cloud browser enables automatic CAPTCHA solving. This applies
+to API V4 Agent runs and standalone Cloud Browser sessions. There is no request
+field to turn on.
+
+## Supported challenges
+
+- reCAPTCHA
+- hCaptcha
+
+Other anti-bot pages may still be passed by the browser's stealth protections
+or residential proxy. That is separate from automatic CAPTCHA solver coverage.
+
+## When a CAPTCHA appears
+
+Stop driving the page, wait about 10 seconds, then inspect it again. Do not
+refresh, click the challenge, or replace the browser while the solver is
+working.
+
+CAPTCHA solving is not guaranteed. If the challenge remains, open the
+[live preview](/cloud/browser/live-preview) for human control. If the whole
+site is blocking the browser rather than showing a challenge, try a different
+[proxy country](/cloud/browser/proxies).

--- a/docs/cloud/browser/captcha-handling.mdx
+++ b/docs/cloud/browser/captcha-handling.mdx
@@ -1,6 +1,6 @@
 ---
 title: CAPTCHA handling
-description: "Cloud browsers solve reCAPTCHA and hCaptcha automatically."
+description: "Cloud browsers solve supported CAPTCHA challenges automatically."
 icon: shield-check
 ---
 
@@ -8,10 +8,7 @@ Every Browser Use Cloud browser enables automatic CAPTCHA solving. This applies
 to API V4 Agent runs and standalone Cloud Browser sessions. There is no request
 field to turn on.
 
-## Supported challenges
-
-- reCAPTCHA
-- hCaptcha
+The automatic solver handles reCAPTCHA and other supported challenges.
 
 Other anti-bot pages may still be passed by the browser's stealth protections
 or residential proxy. That is separate from automatic CAPTCHA solver coverage.
@@ -26,3 +23,5 @@ CAPTCHA solving is not guaranteed. If the challenge remains, open the
 [live preview](/cloud/browser/live-preview) for human control. If the whole
 site is blocking the browser rather than showing a challenge, try a different
 [proxy country](/cloud/browser/proxies).
+
+For a specific CAPTCHA or anti-bot issue, email [contact@browser-use.com](mailto:contact@browser-use.com).

--- a/docs/cloud/browser/stealth.mdx
+++ b/docs/cloud/browser/stealth.mdx
@@ -14,6 +14,10 @@ Every cloud browser session runs in a hardened Chromium fork with stealth enable
 - **Ad and cookie banner blocking** — Banners are dismissed automatically so the agent sees clean pages and executes faster.
 - **Cloudflare / anti-bot bypass** — Works on sites protected by Cloudflare, PerimeterX, and other bot detection services.
 
+Cloud browsers also solve reCAPTCHA and hCaptcha automatically. See
+[CAPTCHA handling](/cloud/browser/captcha-handling) for the supported challenges
+and what to do when a solver is still working.
+
 ## Residential proxies
 
 Residential proxies are enabled by default across 195+ countries. This makes browser sessions appear as real users from the target geography. See [Proxies](/cloud/browser/proxies) for details on geo-targeting and custom proxy configuration.

--- a/docs/cloud/browser/stealth.mdx
+++ b/docs/cloud/browser/stealth.mdx
@@ -14,9 +14,9 @@ Every cloud browser session runs in a hardened Chromium fork with stealth enable
 - **Ad and cookie banner blocking** — Banners are dismissed automatically so the agent sees clean pages and executes faster.
 - **Cloudflare / anti-bot bypass** — Works on sites protected by Cloudflare, PerimeterX, and other bot detection services.
 
-Cloud browsers also solve reCAPTCHA and hCaptcha automatically. See
-[CAPTCHA handling](/cloud/browser/captcha-handling) for the supported challenges
-and what to do when a solver is still working.
+Cloud browsers also solve reCAPTCHA and other supported challenges automatically.
+See [CAPTCHA handling](/cloud/browser/captcha-handling) for what to do when a
+solver is still working or a site has a specific anti-bot issue.
 
 ## Residential proxies
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1097,9 +1097,40 @@ Every cloud browser session runs in a hardened Chromium fork with stealth enable
 - **Ad and cookie banner blocking** — Banners are dismissed automatically so the agent sees clean pages and executes faster.
 - **Cloudflare / anti-bot bypass** — Works on sites protected by Cloudflare, PerimeterX, and other bot detection services.
 
+Cloud browsers also solve reCAPTCHA and hCaptcha automatically. See
+[CAPTCHA handling](https://docs.browser-use.com/cloud/browser/captcha-handling) for the supported challenges
+and what to do when a solver is still working.
+
 ## Residential proxies
 
 Residential proxies are enabled by default across 195+ countries. This makes browser sessions appear as real users from the target geography. See [Proxies](https://docs.browser-use.com/cloud/browser/proxies) for details on geo-targeting and custom proxy configuration.
+
+# CAPTCHA handling
+Source: https://docs.browser-use.com/cloud/browser/captcha-handling
+
+
+Every Browser Use Cloud browser enables automatic CAPTCHA solving. This applies
+to API V4 Agent runs and standalone Cloud Browser sessions. There is no request
+field to turn on.
+
+## Supported challenges
+
+- reCAPTCHA
+- hCaptcha
+
+Other anti-bot pages may still be passed by the browser's stealth protections
+or residential proxy. That is separate from automatic CAPTCHA solver coverage.
+
+## When a CAPTCHA appears
+
+Stop driving the page, wait about 10 seconds, then inspect it again. Do not
+refresh, click the challenge, or replace the browser while the solver is
+working.
+
+CAPTCHA solving is not guaranteed. If the challenge remains, open the
+[live preview](https://docs.browser-use.com/cloud/browser/live-preview) for human control. If the whole
+site is blocking the browser rather than showing a challenge, try a different
+[proxy country](https://docs.browser-use.com/cloud/browser/proxies).
 
 # Proxies
 Source: https://docs.browser-use.com/cloud/browser/proxies

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1097,9 +1097,9 @@ Every cloud browser session runs in a hardened Chromium fork with stealth enable
 - **Ad and cookie banner blocking** — Banners are dismissed automatically so the agent sees clean pages and executes faster.
 - **Cloudflare / anti-bot bypass** — Works on sites protected by Cloudflare, PerimeterX, and other bot detection services.
 
-Cloud browsers also solve reCAPTCHA and hCaptcha automatically. See
-[CAPTCHA handling](https://docs.browser-use.com/cloud/browser/captcha-handling) for the supported challenges
-and what to do when a solver is still working.
+Cloud browsers also solve reCAPTCHA and other supported challenges automatically.
+See [CAPTCHA handling](https://docs.browser-use.com/cloud/browser/captcha-handling) for what to do when a
+solver is still working or a site has a specific anti-bot issue.
 
 ## Residential proxies
 
@@ -1113,10 +1113,7 @@ Every Browser Use Cloud browser enables automatic CAPTCHA solving. This applies
 to API V4 Agent runs and standalone Cloud Browser sessions. There is no request
 field to turn on.
 
-## Supported challenges
-
-- reCAPTCHA
-- hCaptcha
+The automatic solver handles reCAPTCHA and other supported challenges.
 
 Other anti-bot pages may still be passed by the browser's stealth protections
 or residential proxy. That is separate from automatic CAPTCHA solver coverage.
@@ -1131,6 +1128,8 @@ CAPTCHA solving is not guaranteed. If the challenge remains, open the
 [live preview](https://docs.browser-use.com/cloud/browser/live-preview) for human control. If the whole
 site is blocking the browser rather than showing a challenge, try a different
 [proxy country](https://docs.browser-use.com/cloud/browser/proxies).
+
+For a specific CAPTCHA or anti-bot issue, email [contact@browser-use.com](mailto:contact@browser-use.com).
 
 # Proxies
 Source: https://docs.browser-use.com/cloud/browser/proxies

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -65,7 +65,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 ## Browser
 - [Browser Infrastructure quickstart](https://docs.browser-use.com/cloud/browser/quickstart): Launch a cloud browser and connect to it from your code.
 - [Stealth](https://docs.browser-use.com/cloud/browser/stealth): Best stealth on the planet. We fork Chromium to give agents access to all websites.
-- [CAPTCHA handling](https://docs.browser-use.com/cloud/browser/captcha-handling): Cloud browsers solve reCAPTCHA and hCaptcha automatically.
+- [CAPTCHA handling](https://docs.browser-use.com/cloud/browser/captcha-handling): Cloud browsers solve supported CAPTCHA challenges automatically.
 - [Proxies](https://docs.browser-use.com/cloud/browser/proxies): Route API V4 agent runs through residential or custom proxies.
 - [Live preview & recording](https://docs.browser-use.com/cloud/browser/live-preview): Watch an API V4 run in real time or record its browser.
 - [Playwright, Puppeteer, Selenium](https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium): Control a Browser Use cloud browser directly over CDP.

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -65,6 +65,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 ## Browser
 - [Browser Infrastructure quickstart](https://docs.browser-use.com/cloud/browser/quickstart): Launch a cloud browser and connect to it from your code.
 - [Stealth](https://docs.browser-use.com/cloud/browser/stealth): Best stealth on the planet. We fork Chromium to give agents access to all websites.
+- [CAPTCHA handling](https://docs.browser-use.com/cloud/browser/captcha-handling): Cloud browsers solve reCAPTCHA and hCaptcha automatically.
 - [Proxies](https://docs.browser-use.com/cloud/browser/proxies): Route API V4 agent runs through residential or custom proxies.
 - [Live preview & recording](https://docs.browser-use.com/cloud/browser/live-preview): Watch an API V4 run in real time or record its browser.
 - [Playwright, Puppeteer, Selenium](https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium): Control a Browser Use cloud browser directly over CDP.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -95,6 +95,7 @@
                     "pages": [
                       "cloud/browser/quickstart",
                       "cloud/browser/stealth",
+                      "cloud/browser/captcha-handling",
                       "cloud/browser/proxies",
                       "cloud/browser/live-preview",
                       "cloud/browser/playwright-puppeteer-selenium",

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1097,9 +1097,40 @@ Every cloud browser session runs in a hardened Chromium fork with stealth enable
 - **Ad and cookie banner blocking** — Banners are dismissed automatically so the agent sees clean pages and executes faster.
 - **Cloudflare / anti-bot bypass** — Works on sites protected by Cloudflare, PerimeterX, and other bot detection services.
 
+Cloud browsers also solve reCAPTCHA and hCaptcha automatically. See
+[CAPTCHA handling](https://docs.browser-use.com/cloud/browser/captcha-handling) for the supported challenges
+and what to do when a solver is still working.
+
 ## Residential proxies
 
 Residential proxies are enabled by default across 195+ countries. This makes browser sessions appear as real users from the target geography. See [Proxies](https://docs.browser-use.com/cloud/browser/proxies) for details on geo-targeting and custom proxy configuration.
+
+# CAPTCHA handling
+Source: https://docs.browser-use.com/cloud/browser/captcha-handling
+
+
+Every Browser Use Cloud browser enables automatic CAPTCHA solving. This applies
+to API V4 Agent runs and standalone Cloud Browser sessions. There is no request
+field to turn on.
+
+## Supported challenges
+
+- reCAPTCHA
+- hCaptcha
+
+Other anti-bot pages may still be passed by the browser's stealth protections
+or residential proxy. That is separate from automatic CAPTCHA solver coverage.
+
+## When a CAPTCHA appears
+
+Stop driving the page, wait about 10 seconds, then inspect it again. Do not
+refresh, click the challenge, or replace the browser while the solver is
+working.
+
+CAPTCHA solving is not guaranteed. If the challenge remains, open the
+[live preview](https://docs.browser-use.com/cloud/browser/live-preview) for human control. If the whole
+site is blocking the browser rather than showing a challenge, try a different
+[proxy country](https://docs.browser-use.com/cloud/browser/proxies).
 
 # Proxies
 Source: https://docs.browser-use.com/cloud/browser/proxies

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1097,9 +1097,9 @@ Every cloud browser session runs in a hardened Chromium fork with stealth enable
 - **Ad and cookie banner blocking** — Banners are dismissed automatically so the agent sees clean pages and executes faster.
 - **Cloudflare / anti-bot bypass** — Works on sites protected by Cloudflare, PerimeterX, and other bot detection services.
 
-Cloud browsers also solve reCAPTCHA and hCaptcha automatically. See
-[CAPTCHA handling](https://docs.browser-use.com/cloud/browser/captcha-handling) for the supported challenges
-and what to do when a solver is still working.
+Cloud browsers also solve reCAPTCHA and other supported challenges automatically.
+See [CAPTCHA handling](https://docs.browser-use.com/cloud/browser/captcha-handling) for what to do when a
+solver is still working or a site has a specific anti-bot issue.
 
 ## Residential proxies
 
@@ -1113,10 +1113,7 @@ Every Browser Use Cloud browser enables automatic CAPTCHA solving. This applies
 to API V4 Agent runs and standalone Cloud Browser sessions. There is no request
 field to turn on.
 
-## Supported challenges
-
-- reCAPTCHA
-- hCaptcha
+The automatic solver handles reCAPTCHA and other supported challenges.
 
 Other anti-bot pages may still be passed by the browser's stealth protections
 or residential proxy. That is separate from automatic CAPTCHA solver coverage.
@@ -1131,6 +1128,8 @@ CAPTCHA solving is not guaranteed. If the challenge remains, open the
 [live preview](https://docs.browser-use.com/cloud/browser/live-preview) for human control. If the whole
 site is blocking the browser rather than showing a challenge, try a different
 [proxy country](https://docs.browser-use.com/cloud/browser/proxies).
+
+For a specific CAPTCHA or anti-bot issue, email [contact@browser-use.com](mailto:contact@browser-use.com).
 
 # Proxies
 Source: https://docs.browser-use.com/cloud/browser/proxies

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -65,7 +65,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 ## Browser
 - [Browser Infrastructure quickstart](https://docs.browser-use.com/cloud/browser/quickstart): Launch a cloud browser and connect to it from your code.
 - [Stealth](https://docs.browser-use.com/cloud/browser/stealth): Best stealth on the planet. We fork Chromium to give agents access to all websites.
-- [CAPTCHA handling](https://docs.browser-use.com/cloud/browser/captcha-handling): Cloud browsers solve reCAPTCHA and hCaptcha automatically.
+- [CAPTCHA handling](https://docs.browser-use.com/cloud/browser/captcha-handling): Cloud browsers solve supported CAPTCHA challenges automatically.
 - [Proxies](https://docs.browser-use.com/cloud/browser/proxies): Route API V4 agent runs through residential or custom proxies.
 - [Live preview & recording](https://docs.browser-use.com/cloud/browser/live-preview): Watch an API V4 run in real time or record its browser.
 - [Playwright, Puppeteer, Selenium](https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium): Control a Browser Use cloud browser directly over CDP.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -65,6 +65,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 ## Browser
 - [Browser Infrastructure quickstart](https://docs.browser-use.com/cloud/browser/quickstart): Launch a cloud browser and connect to it from your code.
 - [Stealth](https://docs.browser-use.com/cloud/browser/stealth): Best stealth on the planet. We fork Chromium to give agents access to all websites.
+- [CAPTCHA handling](https://docs.browser-use.com/cloud/browser/captcha-handling): Cloud browsers solve reCAPTCHA and hCaptcha automatically.
 - [Proxies](https://docs.browser-use.com/cloud/browser/proxies): Route API V4 agent runs through residential or custom proxies.
 - [Live preview & recording](https://docs.browser-use.com/cloud/browser/live-preview): Watch an API V4 run in real time or record its browser.
 - [Playwright, Puppeteer, Selenium](https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium): Control a Browser Use cloud browser directly over CDP.


### PR DESCRIPTION
## Why

2027.dev repeatedly found agents searching many Browser Use pages without one direct CAPTCHA answer. This adds that answer.

## What changed

- document automatic reCAPTCHA and hCaptcha handling for V4 Agent and Cloud Browser
- tell agents to stop driving, wait about 10 seconds, then inspect again
- explain the live-preview human-control fallback
- separate CAPTCHA solver coverage from other anti-bot blocks
- link the page from Stealth, the sidebar, and llms.txt

## Checks

- llms generator ran twice with byte-identical output
- `docs/docs.json` parses with `jq`
- new internal links resolve
- `git diff --check` passes
- verified secret scan: 0 findings
- `mintlify broken-links`: no broken links found

Earlier local validation had stopped at a pre-existing `RUNBOOK.md:99` parse error on unchanged main. The current Mintlify release now completes cleanly; `RUNBOOK.md` remains untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds documentation explaining automatic CAPTCHA handling for Cloud browsers, giving agents a direct answer that reCAPTCHA and other supported challenges are solved automatically. The new page describes what to do when a CAPTCHA appears (stop driving, wait ~10 seconds, then inspect again) and fallback to live preview for human control. Also links the page from Stealth, the sidebar, and `llms.txt`.

<sup>Written for commit 9ecd6020e65f5689ee3896dc345f36d2994201ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

