### PR TITLE
docs: migrate session examples to API v4

### DIFF
--- a/browser-use-node/examples/sessions.ts
+++ b/browser-use-node/examples/sessions.ts
@@ -9,23 +9,29 @@ import { BrowserUse } from "browser-use-sdk/v4";
 
 async function main() {
   const client = new BrowserUse();
+  let sessionId: string | undefined;
 
-  // A new run creates its session implicitly.
-  const first = await client.runs.create({
-    task: "Go to google.co.uk and search for 'browser automation'",
-    browserSettings: { proxyCountryCode: "uk" },
-  });
-  const firstResult = await client.runs.waitForCompletion(first.id);
-  console.log(`Session: ${first.sessionId}`);
-  console.log("Task 1:", firstResult.result);
+  try {
+    // A new run creates its session implicitly.
+    const first = await client.runs.create({
+      task: "Go to google.co.uk and search for 'browser automation'",
+      browserSettings: { proxyCountryCode: "uk" },
+    });
+    sessionId = first.sessionId;
+    const firstResult = await client.runs.waitForCompletion(first.id);
+    console.log(`Session: ${sessionId}`);
+    console.log("Task 1:", firstResult.result);
 
-  // Pass the session ID to continue with the same state.
-  const followUp = await client.runs.create({
-    task: "Click the first search result and summarize the page",
-    sessionId: first.sessionId,
-  });
-  const followUpResult = await client.runs.waitForCompletion(followUp.id);
-  console.log("Task 2:", followUpResult.result);
+    // Pass the session ID to continue with the same state.
+    const followUp = await client.runs.create({
+      task: "Click the first search result and summarize the page",
+      sessionId,
+    });
+    const followUpResult = await client.runs.waitForCompletion(followUp.id);
+    console.log("Task 2:", followUpResult.result);
+  } finally {
+    if (sessionId) await client.browsers.stop(sessionId);
+  }
 }
 
 await main();

--- a/browser-use-node/examples/sessions.ts
+++ b/browser-use-node/examples/sessions.ts
@@ -1,38 +1,31 @@
 /**
  * Sessions — run multiple tasks in the same browser session.
  *
- * Sessions let you chain tasks that share browser state (cookies, tabs, etc).
+ * Pass a session ID to continue the conversation and workspace. A live browser
+ * is reused when available.
  */
 import "dotenv/config";
-import { BrowserUse } from "browser-use-sdk";
+import { BrowserUse } from "browser-use-sdk/v4";
 
 async function main() {
   const client = new BrowserUse();
 
-  // Create a session with a UK proxy
-  const session = await client.sessions.create({
-    proxyCountryCode: "uk",
+  // A new run creates its session implicitly.
+  const first = await client.runs.create({
+    task: "Go to google.co.uk and search for 'browser automation'",
+    browserSettings: { proxyCountryCode: "uk" },
   });
-  console.log(`Session: ${session.id}`);
-  console.log(`Watch live: ${session.liveUrl}`);
+  const firstResult = await client.runs.waitForCompletion(first.id);
+  console.log(`Session: ${first.sessionId}`);
+  console.log("Task 1:", firstResult.result);
 
-  // Run a task in this session
-  const output1 = await client.run(
-    "Go to google.co.uk and search for 'browser automation'",
-    { sessionId: session.id },
-  );
-  console.log("Task 1:", output1);
-
-  // Run another task in the same session (browser state is preserved)
-  const output2 = await client.run(
-    "Click on the first search result and summarize the page",
-    { sessionId: session.id },
-  );
-  console.log("Task 2:", output2);
-
-  // Clean up
-  await client.sessions.stop(session.id);
-  await client.sessions.delete(session.id);
+  // Pass the session ID to continue with the same state.
+  const followUp = await client.runs.create({
+    task: "Click the first search result and summarize the page",
+    sessionId: first.sessionId,
+  });
+  const followUpResult = await client.runs.waitForCompletion(followUp.id);
+  console.log("Task 2:", followUpResult.result);
 }
 
-main();
+await main();

--- a/browser-use-node/src/v4/client.ts
+++ b/browser-use-node/src/v4/client.ts
@@ -1,4 +1,5 @@
 import { HttpClient } from "../core/http.js";
+import { Browsers } from "./resources/browsers.js";
 import { Runs } from "./resources/runs.js";
 import { Sessions } from "./resources/sessions.js";
 import { Workspaces } from "./resources/workspaces.js";
@@ -13,6 +14,7 @@ export interface BrowserUseOptions {
 }
 
 export class BrowserUse {
+  readonly browsers: Browsers;
   readonly runs: Runs;
   readonly sessions: Sessions;
   readonly workspaces: Workspaces;
@@ -33,6 +35,7 @@ export class BrowserUse {
       timeout: options.timeout,
     });
 
+    this.browsers = new Browsers(this.http);
     this.runs = new Runs(this.http);
     this.sessions = new Sessions(this.http);
     this.workspaces = new Workspaces(this.http);

--- a/browser-use-node/src/v4/resources/browsers.ts
+++ b/browser-use-node/src/v4/resources/browsers.ts
@@ -1,0 +1,15 @@
+import type { HttpClient } from "../../core/http.js";
+import type { components } from "../../generated/v4/types.js";
+
+type BrowserSessionView = components["schemas"]["BrowserSessionView"];
+
+export class Browsers {
+  constructor(private readonly http: HttpClient) {}
+
+  /** Stop a browser session and refund its unused time. */
+  stop(sessionId: string): Promise<BrowserSessionView> {
+    return this.http.patch<BrowserSessionView>(`/browsers/${sessionId}`, {
+      action: "stop",
+    });
+  }
+}

--- a/browser-use-node/tests/v4.test.ts
+++ b/browser-use-node/tests/v4.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { Browsers } from "../src/v4/resources/browsers.js";
 import { Runs } from "../src/v4/resources/runs.js";
 import { Sessions } from "../src/v4/resources/sessions.js";
 import { Workspaces } from "../src/v4/resources/workspaces.js";
@@ -30,6 +31,30 @@ function runSummary(status: string) {
     updatedAt: "2026-01-01T00:00:00Z",
   };
 }
+
+describe("v4 browsers", () => {
+  it("stops a browser session", async () => {
+    const stopped = {
+      id: SESSION_ID,
+      status: "stopped",
+      timeoutAt: "2026-01-01T01:00:00Z",
+      startedAt: "2026-01-01T00:00:00Z",
+      proxyUsedMb: "0",
+      proxyCost: "0",
+      browserCost: "0.01",
+      metadata: {},
+    };
+    const http = { patch: vi.fn(async () => stopped) };
+    const browsers = new Browsers(http as any);
+
+    const browser = await browsers.stop(SESSION_ID);
+
+    expect(http.patch).toHaveBeenCalledWith(`/browsers/${SESSION_ID}`, {
+      action: "stop",
+    });
+    expect(browser.status).toBe("stopped");
+  });
+});
 
 describe("v4 runs.waitForCompletion", () => {
   it("polls status until terminal, then fetches the full run once", async () => {

--- a/browser-use-python/examples/sessions.py
+++ b/browser-use-python/examples/sessions.py
@@ -1,41 +1,35 @@
 """
 Sessions -- run multiple tasks in the same browser session.
 
-Sessions let you chain tasks that share browser state (cookies, tabs, etc).
+Pass a session ID to continue the conversation and workspace. A live browser
+is reused when available.
 """
 import asyncio
 
 from dotenv import load_dotenv
-from browser_use_sdk import AsyncBrowserUse
+from browser_use_sdk.v4 import AsyncBrowserUse
 
 load_dotenv()
 
 
 async def main():
-    client = AsyncBrowserUse()
+    async with AsyncBrowserUse() as client:
+        # A new run creates its session implicitly.
+        first = await client.runs.create(
+            "Go to google.co.uk and search for 'browser automation'",
+            browser_settings={"proxyCountryCode": "uk"},
+        )
+        first_result = await client.runs.wait_for_completion(first.id)
+        print(f"Session: {first.session_id}")
+        print(f"Task 1: {first_result.result}")
 
-    # Create a session with a UK proxy
-    session = await client.sessions.create(proxy_country_code="uk")
-    print(f"Session: {session.id}")
-    print(f"Watch live: {session.live_url}")
-
-    # Run a task in this session
-    output1 = await client.run(
-        "Go to google.co.uk and search for 'browser automation'",
-        session_id=str(session.id),
-    )
-    print(f"Task 1: {output1}")
-
-    # Run another task in the same session (browser state is preserved)
-    output2 = await client.run(
-        "Click on the first search result and summarize the page",
-        session_id=str(session.id),
-    )
-    print(f"Task 2: {output2}")
-
-    # Clean up
-    await client.sessions.stop(str(session.id))
-    await client.sessions.delete(str(session.id))
+        # Pass the session ID to continue with the same state.
+        follow_up = await client.runs.create(
+            "Click the first search result and summarize the page",
+            session_id=first.session_id,
+        )
+        follow_up_result = await client.runs.wait_for_completion(follow_up.id)
+        print(f"Task 2: {follow_up_result.result}")
 
 
 asyncio.run(main())

--- a/browser-use-python/examples/sessions.py
+++ b/browser-use-python/examples/sessions.py
@@ -14,22 +14,28 @@ load_dotenv()
 
 async def main():
     async with AsyncBrowserUse() as client:
-        # A new run creates its session implicitly.
-        first = await client.runs.create(
-            "Go to google.co.uk and search for 'browser automation'",
-            browser_settings={"proxyCountryCode": "uk"},
-        )
-        first_result = await client.runs.wait_for_completion(first.id)
-        print(f"Session: {first.session_id}")
-        print(f"Task 1: {first_result.result}")
+        session_id = None
+        try:
+            # A new run creates its session implicitly.
+            first = await client.runs.create(
+                "Go to google.co.uk and search for 'browser automation'",
+                browser_settings={"proxyCountryCode": "uk"},
+            )
+            session_id = first.session_id
+            first_result = await client.runs.wait_for_completion(first.id)
+            print(f"Session: {session_id}")
+            print(f"Task 1: {first_result.result}")
 
-        # Pass the session ID to continue with the same state.
-        follow_up = await client.runs.create(
-            "Click the first search result and summarize the page",
-            session_id=first.session_id,
-        )
-        follow_up_result = await client.runs.wait_for_completion(follow_up.id)
-        print(f"Task 2: {follow_up_result.result}")
+            # Pass the session ID to continue with the same state.
+            follow_up = await client.runs.create(
+                "Click the first search result and summarize the page",
+                session_id=session_id,
+            )
+            follow_up_result = await client.runs.wait_for_completion(follow_up.id)
+            print(f"Task 2: {follow_up_result.result}")
+        finally:
+            if session_id:
+                await client.browsers.stop(session_id)
 
 
 asyncio.run(main())

--- a/browser-use-python/src/browser_use_sdk/v4/__init__.py
+++ b/browser-use-python/src/browser_use_sdk/v4/__init__.py
@@ -2,6 +2,8 @@ from .client import AsyncBrowserUse, BrowserUse
 from .._core.errors import BrowserUseError
 
 from ..generated.v4.models import (
+    BrowserSessionStatus,
+    BrowserSessionView,
     CustomProxy,
     InlineSecretSource,
     Model as RunModel,
@@ -60,6 +62,7 @@ __all__ = [
     "SecretBinding",
     "SecretBindings",
     # Session models
+    "BrowserSessionView",
     "SessionInfo",
     "SessionListResponse",
     "QueueMessageRequest",
@@ -81,6 +84,7 @@ __all__ = [
     "RunModel",
     "QueuedMessageStatus",
     "RunAttachmentStatus",
+    "BrowserSessionStatus",
     "ProxyCountryCode",
     "CustomProxy",
 ]

--- a/browser-use-python/src/browser_use_sdk/v4/client.py
+++ b/browser-use-python/src/browser_use_sdk/v4/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 
 from .._core.http import AsyncHttpClient, SyncHttpClient
+from .resources.browsers import AsyncBrowsers, Browsers
 from .resources.runs import AsyncRuns, Runs
 from .resources.sessions import AsyncSessions, Sessions
 from .resources.workspaces import AsyncWorkspaces, Workspaces
@@ -35,6 +36,7 @@ class BrowserUse:
             api_key=resolved_key,
             timeout=timeout,
         )
+        self.browsers = Browsers(self._http)
         self.runs = Runs(self._http)
         self.sessions = Sessions(self._http)
         self.workspaces = Workspaces(self._http)
@@ -75,6 +77,7 @@ class AsyncBrowserUse:
             api_key=resolved_key,
             timeout=timeout,
         )
+        self.browsers = AsyncBrowsers(self._http)
         self.runs = AsyncRuns(self._http)
         self.sessions = AsyncSessions(self._http)
         self.workspaces = AsyncWorkspaces(self._http)

--- a/browser-use-python/src/browser_use_sdk/v4/resources/__init__.py
+++ b/browser-use-python/src/browser_use_sdk/v4/resources/__init__.py
@@ -1,5 +1,15 @@
+from .browsers import AsyncBrowsers, Browsers
 from .runs import AsyncRuns, Runs
 from .sessions import AsyncSessions, Sessions
 from .workspaces import AsyncWorkspaces, Workspaces
 
-__all__ = ["Runs", "AsyncRuns", "Sessions", "AsyncSessions", "Workspaces", "AsyncWorkspaces"]
+__all__ = [
+    "Browsers",
+    "AsyncBrowsers",
+    "Runs",
+    "AsyncRuns",
+    "Sessions",
+    "AsyncSessions",
+    "Workspaces",
+    "AsyncWorkspaces",
+]

--- a/browser-use-python/src/browser_use_sdk/v4/resources/browsers.py
+++ b/browser-use-python/src/browser_use_sdk/v4/resources/browsers.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..._core.http import AsyncHttpClient, SyncHttpClient
+from ...generated.v4.models import BrowserSessionView
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+
+class Browsers:
+    def __init__(self, http: SyncHttpClient) -> None:
+        self._http = http
+
+    def stop(self, session_id: str | UUID) -> BrowserSessionView:
+        """Stop a browser session and refund its unused time."""
+        return BrowserSessionView.model_validate(
+            self._http.request(
+                "PATCH", f"/browsers/{session_id}", json={"action": "stop"}
+            )
+        )
+
+
+class AsyncBrowsers:
+    def __init__(self, http: AsyncHttpClient) -> None:
+        self._http = http
+
+    async def stop(self, session_id: str | UUID) -> BrowserSessionView:
+        """Stop a browser session and refund its unused time."""
+        return BrowserSessionView.model_validate(
+            await self._http.request(
+                "PATCH", f"/browsers/{session_id}", json={"action": "stop"}
+            )
+        )

--- a/browser-use-python/tests/test_v4.py
+++ b/browser-use-python/tests/test_v4.py
@@ -10,6 +10,7 @@ import httpx
 import pytest
 
 from browser_use_sdk.v4 import InlineSecretSource, SecretBinding
+from browser_use_sdk.v4.resources.browsers import AsyncBrowsers, Browsers
 from browser_use_sdk.v4.resources.runs import AsyncRuns, Runs
 from browser_use_sdk.v4.resources.sessions import Sessions
 from browser_use_sdk.v4.resources.workspaces import AsyncWorkspaces, Workspaces
@@ -52,6 +53,19 @@ def _queued_message(status: str = "pending") -> dict[str, Any]:
     }
 
 
+def _stopped_browser() -> dict[str, Any]:
+    return {
+        "id": SESSION_ID,
+        "status": "stopped",
+        "timeoutAt": "2026-01-01T01:00:00Z",
+        "startedAt": "2026-01-01T00:00:00Z",
+        "proxyUsedMb": "0",
+        "proxyCost": "0",
+        "browserCost": "0.01",
+        "metadata": {},
+    }
+
+
 class FakeSyncHttp:
     """Fake SyncHttpClient — returns queued responses, records every call."""
 
@@ -86,6 +100,37 @@ class FakeAsyncHttp:
     ) -> dict[str, Any]:
         self.calls.append((method, path, json, params))
         return self.responses.pop(0)
+
+
+def test_browsers_stop() -> None:
+    http = FakeSyncHttp([_stopped_browser()])
+    browsers = Browsers(http)  # type: ignore[arg-type]
+
+    browser = browsers.stop(SESSION_ID)
+
+    assert http.calls[0][:3] == (
+        "PATCH",
+        f"/browsers/{SESSION_ID}",
+        {"action": "stop"},
+    )
+    assert browser.status.value == "stopped"
+
+
+def test_async_browsers_stop() -> None:
+    async def run() -> None:
+        http = FakeAsyncHttp([_stopped_browser()])
+        browsers = AsyncBrowsers(http)  # type: ignore[arg-type]
+
+        browser = await browsers.stop(SESSION_ID)
+
+        assert http.calls[0][:3] == (
+            "PATCH",
+            f"/browsers/{SESSION_ID}",
+            {"action": "stop"},
+        )
+        assert browser.status.value == "stopped"
+
+    asyncio.run(run())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- migrate the Python and TypeScript session examples to API v4
- add `browsers.stop(...)` to both public V4 clients
- stop the browser in `finally` so failed runs cannot leave billable sessions active

## Verification
- 142 TypeScript offline tests passed
- 54 Python offline tests passed (22 live/prod tests deselected)
- TypeScript and focused Python type checks passed
- TypeScript and Python packages built
- V4 TypeScript types regenerate byte-for-byte from the checked-in OpenAPI snapshot
- `git diff --check` and focused secret scan passed

Broad Pyright still reports one pre-existing warning in `examples/streaming.py`; the changed V4 SDK and session example typecheck cleanly.