### PR TITLE
docs: keep V4 quickstarts on latest SDK

### DIFF
--- a/docs/cloud/agent/quickstart.mdx
+++ b/docs/cloud/agent/quickstart.mdx
@@ -37,8 +37,8 @@ curl https://api.browser-use.com/api/v4/runs \
 ```
 </CodeGroup>
 
-Install the SDK with `pip install browser-use-sdk` or
-`npm install browser-use-sdk`. Curl needs no installation.
+Install the latest SDK with `pip install --upgrade browser-use-sdk` or
+`npm install browser-use-sdk@latest`. Curl needs no installation.
 
 Every new run implicitly creates a [session](/cloud/agent/sessions) for its
 conversation and live browser, plus a [workspace](/cloud/agent/workspaces) for

--- a/docs/cloud/browser/quickstart.mdx
+++ b/docs/cloud/browser/quickstart.mdx
@@ -34,10 +34,10 @@ Skip this step if you use curl.
 
 <CodeGroup>
 ```bash Python
-pip install browser-use-sdk
+pip install --upgrade browser-use-sdk
 ```
 ```bash TypeScript
-npm install browser-use-sdk
+npm install browser-use-sdk@latest
 ```
 </CodeGroup>
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -22,10 +22,10 @@ export BROWSER_USE_API_KEY=your_key
 Skip this step if you use curl.
 
 ```bash Python
-pip install browser-use-sdk
+pip install --upgrade browser-use-sdk
 ```
 ```bash TypeScript
-npm install browser-use-sdk
+npm install browser-use-sdk@latest
 ```
 
 ## Run Browser Use Agents
@@ -232,8 +232,8 @@ curl https://api.browser-use.com/api/v4/runs \
   -d '{"task":"Find the top Hacker News story"}'
 ```
 
-Install the SDK with `pip install browser-use-sdk` or
-`npm install browser-use-sdk`. Curl needs no installation.
+Install the latest SDK with `pip install --upgrade browser-use-sdk` or
+`npm install browser-use-sdk@latest`. Curl needs no installation.
 
 Every new run implicitly creates a [session](https://docs.browser-use.com/cloud/agent/sessions) for its
 conversation and live browser, plus a [workspace](https://docs.browser-use.com/cloud/agent/workspaces) for
@@ -1025,10 +1025,10 @@ export BROWSER_USE_API_KEY=your_key
 Skip this step if you use curl.
 
 ```bash Python
-pip install browser-use-sdk
+pip install --upgrade browser-use-sdk
 ```
 ```bash TypeScript
-npm install browser-use-sdk
+npm install browser-use-sdk@latest
 ```
 
 ## Launch a browser

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -26,10 +26,10 @@ Skip this step if you use curl.
 
 <CodeGroup>
 ```bash Python
-pip install browser-use-sdk
+pip install --upgrade browser-use-sdk
 ```
 ```bash TypeScript
-npm install browser-use-sdk
+npm install browser-use-sdk@latest
 ```
 </CodeGroup>
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -22,10 +22,10 @@ export BROWSER_USE_API_KEY=your_key
 Skip this step if you use curl.
 
 ```bash Python
-pip install browser-use-sdk
+pip install --upgrade browser-use-sdk
 ```
 ```bash TypeScript
-npm install browser-use-sdk
+npm install browser-use-sdk@latest
 ```
 
 ## Run Browser Use Agents
@@ -232,8 +232,8 @@ curl https://api.browser-use.com/api/v4/runs \
   -d '{"task":"Find the top Hacker News story"}'
 ```
 
-Install the SDK with `pip install browser-use-sdk` or
-`npm install browser-use-sdk`. Curl needs no installation.
+Install the latest SDK with `pip install --upgrade browser-use-sdk` or
+`npm install browser-use-sdk@latest`. Curl needs no installation.
 
 Every new run implicitly creates a [session](https://docs.browser-use.com/cloud/agent/sessions) for its
 conversation and live browser, plus a [workspace](https://docs.browser-use.com/cloud/agent/workspaces) for
@@ -1025,10 +1025,10 @@ export BROWSER_USE_API_KEY=your_key
 Skip this step if you use curl.
 
 ```bash Python
-pip install browser-use-sdk
+pip install --upgrade browser-use-sdk
 ```
 ```bash TypeScript
-npm install browser-use-sdk
+npm install browser-use-sdk@latest
 ```
 
 ## Launch a browser


### PR DESCRIPTION
The V4 quickstarts imported `browser_use_sdk.v4` after a plain `pip install browser-use-sdk`. For anyone with 3.8.4 already installed, pip kept that version and the import failed because V4 arrived in 3.9.0.

This switches the three V4 entry points to explicit upgrade/latest installs and regenerates the checked-in LLM docs.

Checks:
- reproduced 3.8.4 staying installed and failing `browser_use_sdk.v4`
- verified `pip install --upgrade browser-use-sdk` moves 3.8.4 to 3.11.1 and imports V4
- `mintlify broken-links`
- generator idempotence
- `git diff --check`
- TruffleHog exact range: no findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the V4 quickstarts so a plain `pip install browser-use-sdk` no longer leaves an older SDK installed that fails to import `browser_use_sdk.v4`. The three quickstarts now use `pip install --upgrade browser-use-sdk` and `npm install browser-use-sdk@latest`, and the checked-in LLM docs are regenerated to match.

<sup>Written for commit 7c3858bb24e50145853b06c4262db695be970034. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

