### PR TITLE
feat(v4): wait for browser-ready events

### DIFF
--- a/browser-use-node/src/v4.ts
+++ b/browser-use-node/src/v4.ts
@@ -8,7 +8,6 @@ export type {
   RunCreateBody,
   RunListParams,
   RunEventsParams,
-  WaitForEventOptions,
   WaitOptions,
 } from "./v4/resources/runs.js";
 

--- a/browser-use-node/src/v4.ts
+++ b/browser-use-node/src/v4.ts
@@ -8,6 +8,7 @@ export type {
   RunCreateBody,
   RunListParams,
   RunEventsParams,
+  WaitForEventOptions,
   WaitOptions,
 } from "./v4/resources/runs.js";
 

--- a/browser-use-node/src/v4/resources/runs.ts
+++ b/browser-use-node/src/v4/resources/runs.ts
@@ -7,6 +7,7 @@ type RunSummary = components["schemas"]["RunSummary"];
 type RunStatusResponse = components["schemas"]["RunStatusResponse"];
 type RunListResponse = components["schemas"]["RunListResponse"];
 type RunEventsResponse = components["schemas"]["RunEventsResponse"];
+type RunEvent = components["schemas"]["RunEvent"];
 type RunAttachmentsResponse = components["schemas"]["RunAttachmentsResponse"];
 
 export type RunCreateBody = Pick<RunCreateRequest, "task"> &
@@ -31,6 +32,13 @@ export interface WaitOptions {
   timeout?: number;
   /** Polling interval in milliseconds. Default: 2_000. */
   interval?: number;
+}
+
+export interface WaitForEventOptions extends WaitOptions {
+  /** Event cursor to start after. */
+  after?: number | null;
+  /** Events fetched per request. Default: 100. */
+  limit?: number;
 }
 
 export class Runs {
@@ -62,6 +70,24 @@ export class Runs {
       `/runs/${runId}/events`,
       params as Record<string, unknown>,
     );
+  }
+
+  /** Poll events until the requested type appears. */
+  async waitForEvent(runId: string, type: string, options?: WaitForEventOptions): Promise<RunEvent> {
+    const timeout = options?.timeout ?? 300_000;
+    const interval = options?.interval ?? 1_000;
+    const deadline = Date.now() + timeout;
+    let after = options?.after ?? null;
+
+    for (;;) {
+      const page = await this.events(runId, { after, limit: options?.limit ?? 100 });
+      const event = page.events.find((candidate) => candidate.type === type);
+      if (event) return event;
+      after = page.nextAfter ?? after;
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) throw new Error(`Run ${runId} did not emit ${type} within ${timeout}ms`);
+      await new Promise((resolve) => setTimeout(resolve, Math.min(interval, remaining)));
+    }
   }
 
   /** Cancel a run. Returns the updated run summary. */

--- a/browser-use-node/src/v4/resources/runs.ts
+++ b/browser-use-node/src/v4/resources/runs.ts
@@ -34,7 +34,11 @@ export interface WaitOptions {
   interval?: number;
 }
 
-export interface WaitForEventOptions extends WaitOptions {
+export interface WaitForEventOptions extends Omit<WaitOptions, "timeout" | "interval"> {
+  /** Maximum time to wait in milliseconds. Default: 300_000 (5 minutes). */
+  timeout?: number;
+  /** Polling interval in milliseconds. Default: 1_000. */
+  interval?: number;
   /** Event cursor to start after. */
   after?: number | null;
   /** Events fetched per request. Default: 100. */

--- a/browser-use-node/src/v4/resources/runs.ts
+++ b/browser-use-node/src/v4/resources/runs.ts
@@ -34,17 +34,6 @@ export interface WaitOptions {
   interval?: number;
 }
 
-export interface WaitForEventOptions extends Omit<WaitOptions, "timeout" | "interval"> {
-  /** Maximum time to wait in milliseconds. Default: 300_000 (5 minutes). */
-  timeout?: number;
-  /** Polling interval in milliseconds. Default: 1_000. */
-  interval?: number;
-  /** Event cursor to start after. */
-  after?: number | null;
-  /** Events fetched per request. Default: 100. */
-  limit?: number;
-}
-
 export class Runs {
   constructor(private readonly http: HttpClient) {}
 
@@ -77,7 +66,11 @@ export class Runs {
   }
 
   /** Poll events until the requested type appears. */
-  async waitForEvent(runId: string, type: string, options?: WaitForEventOptions): Promise<RunEvent> {
+  async waitForEvent(
+    runId: string,
+    type: string,
+    options?: WaitOptions & RunEventsParams,
+  ): Promise<RunEvent> {
     const timeout = options?.timeout ?? 300_000;
     const interval = options?.interval ?? 1_000;
     const deadline = Date.now() + timeout;

--- a/browser-use-node/src/v4/resources/runs.ts
+++ b/browser-use-node/src/v4/resources/runs.ts
@@ -15,6 +15,12 @@ export type RunCreateBody = Pick<RunCreateRequest, "task"> &
 
 /** Terminal run statuses — closed enum in the v4 spec. */
 const TERMINAL_STATUSES = new Set(["completed", "failed", "cancelled"]);
+const TERMINAL_EVENT_TYPES = new Set([
+  "run.completed",
+  "run.failed",
+  "run.cancelled",
+  "run.dispatch_failed",
+]);
 
 export interface RunListParams {
   sessionId?: string;
@@ -80,6 +86,10 @@ export class Runs {
       const page = await this.events(runId, { after, limit: options?.limit ?? 100 });
       const event = page.events.find((candidate) => candidate.type === type);
       if (event) return event;
+      const terminal = page.events.find((candidate) => TERMINAL_EVENT_TYPES.has(candidate.type));
+      if (terminal) {
+        throw new Error(`Run ${runId} emitted ${terminal.type} before ${type}`);
+      }
       after = page.nextAfter ?? after;
       const remaining = deadline - Date.now();
       if (remaining <= 0) throw new Error(`Run ${runId} did not emit ${type} within ${timeout}ms`);

--- a/browser-use-node/src/v4/resources/runs.ts
+++ b/browser-use-node/src/v4/resources/runs.ts
@@ -65,7 +65,7 @@ export class Runs {
     );
   }
 
-  /** Poll events until the requested type appears. */
+  /** Poll events until the requested type appears (5-minute timeout, 1-second interval). */
   async waitForEvent(
     runId: string,
     type: string,

--- a/browser-use-node/tests/v4.test.ts
+++ b/browser-use-node/tests/v4.test.ts
@@ -119,6 +119,21 @@ describe("v4 runs.waitForEvent", () => {
     expect(event.data.live_view_url).toBe("https://live");
     expect(http.get).toHaveBeenLastCalledWith(`/runs/${RUN_ID}/events`, { after: 1, limit: 100 });
   });
+
+  it("fails immediately when the run ends before the requested event", async () => {
+    const http = {
+      get: vi.fn(async () => ({
+        events: [{ runId: RUN_ID, id: 1, ts: "2026-01-01T00:00:00Z", type: "run.dispatch_failed", data: {} }],
+        nextAfter: 1,
+        hasMore: false,
+      })),
+    };
+    const runs = new Runs(http as any);
+    await expect(runs.waitForEvent(RUN_ID, "browser.ready")).rejects.toThrow(
+      /emitted run\.dispatch_failed before browser\.ready/,
+    );
+    expect(http.get).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("v4 runs pagination + events", () => {

--- a/browser-use-node/tests/v4.test.ts
+++ b/browser-use-node/tests/v4.test.ts
@@ -108,6 +108,19 @@ describe("v4 runs.waitForCompletion", () => {
   });
 });
 
+describe("v4 runs.waitForEvent", () => {
+  it("returns browser.ready before any terminal-status wait", async () => {
+    const http = { get: vi.fn(async (_path: string, query?: Record<string, unknown>) =>
+      query?.after === 1
+        ? { events: [{ runId: RUN_ID, id: 2, ts: "2026-01-01T00:00:01Z", type: "browser.ready", data: { live_view_url: "https://live" } }], nextAfter: 2, hasMore: false }
+        : { events: [{ runId: RUN_ID, id: 1, ts: "2026-01-01T00:00:00Z", type: "run.created", data: {} }], nextAfter: 1, hasMore: true }) };
+    const runs = new Runs(http as any);
+    const event = await runs.waitForEvent(RUN_ID, "browser.ready", { interval: 0 });
+    expect(event.data.live_view_url).toBe("https://live");
+    expect(http.get).toHaveBeenLastCalledWith(`/runs/${RUN_ID}/events`, { after: 1, limit: 100 });
+  });
+});
+
 describe("v4 runs pagination + events", () => {
   it("passes agentmail and secret bindings through on create", async () => {
     const http = {

--- a/browser-use-python/src/browser_use_sdk/v4/resources/runs.py
+++ b/browser-use-python/src/browser_use_sdk/v4/resources/runs.py
@@ -9,6 +9,7 @@ from ...generated.v4.models import (
     RunAttachmentsResponse,
     RunBrowserSettings,
     RunCreateResponse,
+    RunEvent,
     RunEventsResponse,
     RunJudgeSettings,
     RunListResponse,
@@ -49,7 +50,9 @@ def _build_create_body(
         body["workspaceId"] = str(workspace_id)
     if browser_settings is not None:
         if isinstance(browser_settings, RunBrowserSettings):
-            body["browserSettings"] = browser_settings.model_dump(by_alias=True, exclude_none=True, mode="json")
+            body["browserSettings"] = browser_settings.model_dump(
+                by_alias=True, exclude_none=True, mode="json"
+            )
         else:
             body["browserSettings"] = browser_settings
     if agentmail is not None:
@@ -72,7 +75,9 @@ def _build_create_body(
         ]
     if judge is not None:
         if isinstance(judge, RunJudgeSettings):
-            body["judge"] = judge.model_dump(by_alias=True, exclude_none=True, mode="json")
+            body["judge"] = judge.model_dump(
+                by_alias=True, exclude_none=True, mode="json"
+            )
         else:
             body["judge"] = judge
     if max_cost_usd is not None:
@@ -142,9 +147,7 @@ class Runs:
 
     def get(self, run_id: str | UUID) -> RunSummary:
         """Get the full run summary."""
-        return RunSummary.model_validate(
-            self._http.request("GET", f"/runs/{run_id}")
-        )
+        return RunSummary.model_validate(self._http.request("GET", f"/runs/{run_id}"))
 
     def status(self, run_id: str | UUID) -> RunStatusResponse:
         """Get just the run's status — the cheap poll target."""
@@ -170,6 +173,33 @@ class Runs:
                 },
             )
         )
+
+    def wait_for_event(
+        self,
+        run_id: str | UUID,
+        event_type: str,
+        *,
+        timeout: float = 300,
+        interval: float = 1,
+        after: int | None = None,
+        limit: int = 100,
+    ) -> RunEvent:
+        """Poll run events until ``event_type`` appears."""
+        deadline = time.monotonic() + timeout
+        while True:
+            page = self.events(run_id, after=after, limit=limit)
+            event = next(
+                (item for item in page.events if item.type == event_type), None
+            )
+            if event is not None:
+                return event
+            after = page.next_after if page.next_after is not None else after
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"Run {run_id} did not emit {event_type} within {timeout}s"
+                )
+            time.sleep(min(interval, remaining))
 
     def cancel(self, run_id: str | UUID) -> RunSummary:
         """Cancel a run. Returns the updated run summary."""
@@ -305,6 +335,33 @@ class AsyncRuns:
                 },
             )
         )
+
+    async def wait_for_event(
+        self,
+        run_id: str | UUID,
+        event_type: str,
+        *,
+        timeout: float = 300,
+        interval: float = 1,
+        after: int | None = None,
+        limit: int = 100,
+    ) -> RunEvent:
+        """Poll run events until ``event_type`` appears."""
+        deadline = time.monotonic() + timeout
+        while True:
+            page = await self.events(run_id, after=after, limit=limit)
+            event = next(
+                (item for item in page.events if item.type == event_type), None
+            )
+            if event is not None:
+                return event
+            after = page.next_after if page.next_after is not None else after
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"Run {run_id} did not emit {event_type} within {timeout}s"
+                )
+            await asyncio.sleep(min(interval, remaining))
 
     async def cancel(self, run_id: str | UUID) -> RunSummary:
         """Cancel a run. Returns the updated run summary."""

--- a/browser-use-python/src/browser_use_sdk/v4/resources/runs.py
+++ b/browser-use-python/src/browser_use_sdk/v4/resources/runs.py
@@ -23,6 +23,12 @@ if TYPE_CHECKING:
 
 # Terminal run statuses — closed enum in the v4 spec.
 _TERMINAL_STATUSES = {"completed", "failed", "cancelled"}
+_TERMINAL_EVENT_TYPES = {
+    "run.completed",
+    "run.failed",
+    "run.cancelled",
+    "run.dispatch_failed",
+}
 
 
 def _build_create_body(
@@ -193,6 +199,14 @@ class Runs:
             )
             if event is not None:
                 return event
+            terminal = next(
+                (item for item in page.events if item.type in _TERMINAL_EVENT_TYPES),
+                None,
+            )
+            if terminal is not None:
+                raise RuntimeError(
+                    f"Run {run_id} emitted {terminal.type} before {event_type}"
+                )
             after = page.next_after if page.next_after is not None else after
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -355,6 +369,14 @@ class AsyncRuns:
             )
             if event is not None:
                 return event
+            terminal = next(
+                (item for item in page.events if item.type in _TERMINAL_EVENT_TYPES),
+                None,
+            )
+            if terminal is not None:
+                raise RuntimeError(
+                    f"Run {run_id} emitted {terminal.type} before {event_type}"
+                )
             after = page.next_after if page.next_after is not None else after
             remaining = deadline - time.monotonic()
             if remaining <= 0:

--- a/browser-use-python/tests/test_v4.py
+++ b/browser-use-python/tests/test_v4.py
@@ -271,6 +271,36 @@ def test_async_wait_for_event_returns_browser_ready() -> None:
     asyncio.run(run())
 
 
+def test_wait_for_event_stops_when_run_ends_first() -> None:
+    terminal = {
+        "events": [
+            {
+                "runId": RUN_ID,
+                "id": 1,
+                "ts": "2026-01-01T00:00:00Z",
+                "type": "run.dispatch_failed",
+                "data": {},
+            }
+        ],
+        "nextAfter": 1,
+        "hasMore": False,
+    }
+    sync_http = FakeSyncHttp([terminal])
+    with pytest.raises(RuntimeError, match="run.dispatch_failed before browser.ready"):
+        Runs(sync_http).wait_for_event(RUN_ID, "browser.ready")  # type: ignore[arg-type]
+    assert len(sync_http.calls) == 1
+
+    async def run() -> None:
+        async_http = FakeAsyncHttp([terminal])
+        with pytest.raises(RuntimeError, match="run.dispatch_failed before browser.ready"):
+            await AsyncRuns(async_http).wait_for_event(  # type: ignore[arg-type]
+                RUN_ID, "browser.ready"
+            )
+        assert len(async_http.calls) == 1
+
+    asyncio.run(run())
+
+
 # ---------------------------------------------------------------------------
 # runs create / list / events
 # ---------------------------------------------------------------------------

--- a/browser-use-python/tests/test_v4.py
+++ b/browser-use-python/tests/test_v4.py
@@ -71,9 +71,7 @@ class FakeSyncHttp:
 
     def __init__(self, responses: list[dict[str, Any]]) -> None:
         self.responses = list(responses)
-        self.calls: list[
-            tuple[str, str, dict[str, Any] | None, dict[str, Any] | None]
-        ] = []
+        self.calls: list[tuple[str, str, dict[str, Any] | None, dict[str, Any] | None]] = []
 
     def request(
         self,
@@ -90,9 +88,7 @@ class FakeSyncHttp:
 class FakeAsyncHttp:
     def __init__(self, responses: list[dict[str, Any]]) -> None:
         self.responses = list(responses)
-        self.calls: list[
-            tuple[str, str, dict[str, Any] | None, dict[str, Any] | None]
-        ] = []
+        self.calls: list[tuple[str, str, dict[str, Any] | None, dict[str, Any] | None]] = []
 
     async def request(
         self,
@@ -338,11 +334,7 @@ def test_runs_create_sends_camel_case_body() -> None:
 def test_runs_list_cursor_pagination() -> None:
     http = FakeSyncHttp(
         [
-            {
-                "runs": [_run_summary("completed")],
-                "nextCursor": "cur-2",
-                "hasMore": True,
-            },
+            {"runs": [_run_summary("completed")], "nextCursor": "cur-2", "hasMore": True},
             {"runs": [_run_summary("completed")], "nextCursor": None, "hasMore": False},
         ]
     )
@@ -364,33 +356,15 @@ def test_runs_events_delta() -> None:
         [
             {
                 "events": [
-                    {
-                        "runId": RUN_ID,
-                        "id": 1,
-                        "ts": "2026-01-01T00:00:00Z",
-                        "type": "step",
-                        "data": {},
-                    },
-                    {
-                        "runId": RUN_ID,
-                        "id": 2,
-                        "ts": "2026-01-01T00:00:01Z",
-                        "type": "step",
-                        "data": {},
-                    },
+                    {"runId": RUN_ID, "id": 1, "ts": "2026-01-01T00:00:00Z", "type": "step", "data": {}},
+                    {"runId": RUN_ID, "id": 2, "ts": "2026-01-01T00:00:01Z", "type": "step", "data": {}},
                 ],
                 "nextAfter": 2,
                 "hasMore": True,
             },
             {
                 "events": [
-                    {
-                        "runId": RUN_ID,
-                        "id": 3,
-                        "ts": "2026-01-01T00:00:02Z",
-                        "type": "done",
-                        "data": {},
-                    },
+                    {"runId": RUN_ID, "id": 3, "ts": "2026-01-01T00:00:02Z", "type": "done", "data": {}},
                 ],
                 "nextAfter": 3,
                 "hasMore": False,
@@ -418,9 +392,7 @@ def test_sessions_send_message() -> None:
     http = FakeSyncHttp([_queued_message()])
     sessions = Sessions(http)  # type: ignore[arg-type]
 
-    msg = sessions.send_message(
-        SESSION_ID, "also check the careers page", interrupt=True
-    )
+    msg = sessions.send_message(SESSION_ID, "also check the careers page", interrupt=True)
 
     method, path, body, _ = http.calls[0]
     assert (method, path) == ("POST", f"/sessions/{SESSION_ID}/queue")
@@ -532,12 +504,7 @@ def test_workspaces_files_cursor_pagination() -> None:
 
 def test_workspaces_update_size_delete_and_delete_file() -> None:
     http = FakeSyncHttp(
-        [
-            {**_workspace_info(), "name": None},
-            {"usedBytes": 10, "maxBytes": 100},
-            {},
-            {},
-        ]
+        [{**_workspace_info(), "name": None}, {"usedBytes": 10, "maxBytes": 100}, {}, {}]
     )
     workspaces = Workspaces(http)  # type: ignore[arg-type]
 
@@ -580,9 +547,7 @@ class _FakePutResponse:
     def raise_for_status(self) -> None:
         if self.status_code >= 400:
             raise httpx.HTTPStatusError(
-                f"{self.status_code}",
-                request=None,
-                response=None,  # type: ignore[arg-type]
+                f"{self.status_code}", request=None, response=None  # type: ignore[arg-type]
             )
 
 
@@ -601,16 +566,12 @@ class _FakeSyncPutClient:
     def __exit__(self, *_args: Any) -> None:
         pass
 
-    def put(
-        self, url: str, *, content: bytes, headers: dict[str, str]
-    ) -> _FakePutResponse:
+    def put(self, url: str, *, content: bytes, headers: dict[str, str]) -> _FakePutResponse:
         type(self).calls.append((url, content, headers))
         return _FakePutResponse(type(self).status_code)
 
 
-def test_workspaces_upload_reads_once_and_puts(
-    tmp_path: Path, monkeypatch: Any
-) -> None:
+def test_workspaces_upload_reads_once_and_puts(tmp_path: Path, monkeypatch: Any) -> None:
     f = tmp_path / "data.csv"
     f.write_bytes(b"id,name\n1,a\n")
 
@@ -686,9 +647,7 @@ class _FakeAsyncPutClient:
     async def __aexit__(self, *_args: Any) -> None:
         pass
 
-    async def put(
-        self, url: str, *, content: bytes, headers: dict[str, str]
-    ) -> _FakePutResponse:
+    async def put(self, url: str, *, content: bytes, headers: dict[str, str]) -> _FakePutResponse:
         type(self).calls.append((url, content, headers))
         return _FakePutResponse(type(self).status_code)
 

--- a/browser-use-python/tests/test_v4.py
+++ b/browser-use-python/tests/test_v4.py
@@ -71,7 +71,9 @@ class FakeSyncHttp:
 
     def __init__(self, responses: list[dict[str, Any]]) -> None:
         self.responses = list(responses)
-        self.calls: list[tuple[str, str, dict[str, Any] | None, dict[str, Any] | None]] = []
+        self.calls: list[
+            tuple[str, str, dict[str, Any] | None, dict[str, Any] | None]
+        ] = []
 
     def request(
         self,
@@ -88,7 +90,9 @@ class FakeSyncHttp:
 class FakeAsyncHttp:
     def __init__(self, responses: list[dict[str, Any]]) -> None:
         self.responses = list(responses)
-        self.calls: list[tuple[str, str, dict[str, Any] | None, dict[str, Any] | None]] = []
+        self.calls: list[
+            tuple[str, str, dict[str, Any] | None, dict[str, Any] | None]
+        ] = []
 
     async def request(
         self,
@@ -202,6 +206,42 @@ def test_async_wait_for_completion() -> None:
     asyncio.run(run())
 
 
+def test_wait_for_event_returns_browser_ready_before_terminal_wait() -> None:
+    http = FakeSyncHttp(
+        [
+            {
+                "events": [
+                    {
+                        "runId": RUN_ID,
+                        "id": 1,
+                        "ts": "2026-01-01T00:00:00Z",
+                        "type": "run.created",
+                        "data": {},
+                    }
+                ],
+                "nextAfter": 1,
+                "hasMore": True,
+            },
+            {
+                "events": [
+                    {
+                        "runId": RUN_ID,
+                        "id": 2,
+                        "ts": "2026-01-01T00:00:01Z",
+                        "type": "browser.ready",
+                        "data": {"live_view_url": "https://live"},
+                    }
+                ],
+                "nextAfter": 2,
+                "hasMore": False,
+            },
+        ]
+    )
+    event = Runs(http).wait_for_event(RUN_ID, "browser.ready", interval=0)  # type: ignore[arg-type]
+    assert event.data["live_view_url"] == "https://live"
+    assert http.calls[-1][3] == {"after": 1, "limit": 100}
+
+
 # ---------------------------------------------------------------------------
 # runs create / list / events
 # ---------------------------------------------------------------------------
@@ -265,7 +305,11 @@ def test_runs_create_sends_camel_case_body() -> None:
 def test_runs_list_cursor_pagination() -> None:
     http = FakeSyncHttp(
         [
-            {"runs": [_run_summary("completed")], "nextCursor": "cur-2", "hasMore": True},
+            {
+                "runs": [_run_summary("completed")],
+                "nextCursor": "cur-2",
+                "hasMore": True,
+            },
             {"runs": [_run_summary("completed")], "nextCursor": None, "hasMore": False},
         ]
     )
@@ -287,15 +331,33 @@ def test_runs_events_delta() -> None:
         [
             {
                 "events": [
-                    {"runId": RUN_ID, "id": 1, "ts": "2026-01-01T00:00:00Z", "type": "step", "data": {}},
-                    {"runId": RUN_ID, "id": 2, "ts": "2026-01-01T00:00:01Z", "type": "step", "data": {}},
+                    {
+                        "runId": RUN_ID,
+                        "id": 1,
+                        "ts": "2026-01-01T00:00:00Z",
+                        "type": "step",
+                        "data": {},
+                    },
+                    {
+                        "runId": RUN_ID,
+                        "id": 2,
+                        "ts": "2026-01-01T00:00:01Z",
+                        "type": "step",
+                        "data": {},
+                    },
                 ],
                 "nextAfter": 2,
                 "hasMore": True,
             },
             {
                 "events": [
-                    {"runId": RUN_ID, "id": 3, "ts": "2026-01-01T00:00:02Z", "type": "done", "data": {}},
+                    {
+                        "runId": RUN_ID,
+                        "id": 3,
+                        "ts": "2026-01-01T00:00:02Z",
+                        "type": "done",
+                        "data": {},
+                    },
                 ],
                 "nextAfter": 3,
                 "hasMore": False,
@@ -323,7 +385,9 @@ def test_sessions_send_message() -> None:
     http = FakeSyncHttp([_queued_message()])
     sessions = Sessions(http)  # type: ignore[arg-type]
 
-    msg = sessions.send_message(SESSION_ID, "also check the careers page", interrupt=True)
+    msg = sessions.send_message(
+        SESSION_ID, "also check the careers page", interrupt=True
+    )
 
     method, path, body, _ = http.calls[0]
     assert (method, path) == ("POST", f"/sessions/{SESSION_ID}/queue")
@@ -435,7 +499,12 @@ def test_workspaces_files_cursor_pagination() -> None:
 
 def test_workspaces_update_size_delete_and_delete_file() -> None:
     http = FakeSyncHttp(
-        [{**_workspace_info(), "name": None}, {"usedBytes": 10, "maxBytes": 100}, {}, {}]
+        [
+            {**_workspace_info(), "name": None},
+            {"usedBytes": 10, "maxBytes": 100},
+            {},
+            {},
+        ]
     )
     workspaces = Workspaces(http)  # type: ignore[arg-type]
 
@@ -478,7 +547,9 @@ class _FakePutResponse:
     def raise_for_status(self) -> None:
         if self.status_code >= 400:
             raise httpx.HTTPStatusError(
-                f"{self.status_code}", request=None, response=None  # type: ignore[arg-type]
+                f"{self.status_code}",
+                request=None,
+                response=None,  # type: ignore[arg-type]
             )
 
 
@@ -497,12 +568,16 @@ class _FakeSyncPutClient:
     def __exit__(self, *_args: Any) -> None:
         pass
 
-    def put(self, url: str, *, content: bytes, headers: dict[str, str]) -> _FakePutResponse:
+    def put(
+        self, url: str, *, content: bytes, headers: dict[str, str]
+    ) -> _FakePutResponse:
         type(self).calls.append((url, content, headers))
         return _FakePutResponse(type(self).status_code)
 
 
-def test_workspaces_upload_reads_once_and_puts(tmp_path: Path, monkeypatch: Any) -> None:
+def test_workspaces_upload_reads_once_and_puts(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
     f = tmp_path / "data.csv"
     f.write_bytes(b"id,name\n1,a\n")
 
@@ -578,7 +653,9 @@ class _FakeAsyncPutClient:
     async def __aexit__(self, *_args: Any) -> None:
         pass
 
-    async def put(self, url: str, *, content: bytes, headers: dict[str, str]) -> _FakePutResponse:
+    async def put(
+        self, url: str, *, content: bytes, headers: dict[str, str]
+    ) -> _FakePutResponse:
         type(self).calls.append((url, content, headers))
         return _FakePutResponse(type(self).status_code)
 

--- a/browser-use-python/tests/test_v4.py
+++ b/browser-use-python/tests/test_v4.py
@@ -242,6 +242,39 @@ def test_wait_for_event_returns_browser_ready_before_terminal_wait() -> None:
     assert http.calls[-1][3] == {"after": 1, "limit": 100}
 
 
+def test_async_wait_for_event_returns_browser_ready() -> None:
+    async def run() -> None:
+        http = FakeAsyncHttp(
+            [
+                {
+                    "events": [],
+                    "nextAfter": 0,
+                    "hasMore": False,
+                },
+                {
+                    "events": [
+                        {
+                            "runId": RUN_ID,
+                            "id": 1,
+                            "ts": "2026-01-01T00:00:01Z",
+                            "type": "browser.ready",
+                            "data": {"live_view_url": "https://live"},
+                        }
+                    ],
+                    "nextAfter": 1,
+                    "hasMore": False,
+                },
+            ]
+        )
+        event = await AsyncRuns(http).wait_for_event(  # type: ignore[arg-type]
+            RUN_ID, "browser.ready", interval=0
+        )
+        assert event.data["live_view_url"] == "https://live"
+        assert http.calls[-1][3] == {"after": 0, "limit": 100}
+
+    asyncio.run(run())
+
+
 # ---------------------------------------------------------------------------
 # runs create / list / events
 # ---------------------------------------------------------------------------

--- a/docs/cloud/browser/live-preview.mdx
+++ b/docs/cloud/browser/live-preview.mdx
@@ -26,7 +26,7 @@ for _ in range(300):
     if ready:
         print(ready.data["live_view_url"])
         break
-    after = page.next_after or after
+    after = page.next_after if page.next_after is not None else after
     time.sleep(1)
 else:
     raise TimeoutError("Browser did not become ready within 5 minutes")

--- a/docs/cloud/browser/live-preview.mdx
+++ b/docs/cloud/browser/live-preview.mdx
@@ -4,22 +4,32 @@ description: "Watch an API V4 run in real time or record its browser."
 icon: eye
 ---
 
-The `browser.ready` event contains the live browser URL:
+Poll for `browser.ready` as soon as you create the run so the URL is available
+while the browser is live:
 
 <CodeGroup>
 ```python Python
+import time
+
 from browser_use_sdk.v4 import BrowserUse
 
 client = BrowserUse()
 run = client.runs.create("Find the top Hacker News story")
-run = client.runs.wait_for_completion(run.id)
+after = None
 
-events = client.runs.events(run.id, limit=100)
-ready = next(
-    event for event in events.events
-    if event.type == "browser.ready"
-)
-print(ready.data["live_view_url"])
+for _ in range(300):
+    page = client.runs.events(run.id, after=after, limit=100)
+    ready = next(
+        (event for event in page.events if event.type == "browser.ready"),
+        None,
+    )
+    if ready:
+        print(ready.data["live_view_url"])
+        break
+    after = page.next_after or after
+    time.sleep(1)
+else:
+    raise TimeoutError("Browser did not become ready within 5 minutes")
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v4";
@@ -29,20 +39,28 @@ const run = await client.runs.create({
   task: "Find the top Hacker News story",
   model: "grok-4.5",
 });
-await client.runs.waitForCompletion(run.id);
+let after: number | null = null;
 
-const events = await client.runs.events(run.id, {
-  limit: 100,
-});
-const ready = events.events.find(
-  (event) => event.type === "browser.ready",
-);
-console.log(ready?.data.live_view_url);
+for (let attempt = 0; attempt < 300; attempt++) {
+  const page = await client.runs.events(run.id, { after, limit: 100 });
+  const ready = page.events.find(
+    (event) => event.type === "browser.ready",
+  );
+  if (ready) {
+    console.log(ready.data.live_view_url);
+    break;
+  }
+  after = page.nextAfter ?? after;
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  if (attempt === 299) {
+    throw new Error("Browser did not become ready within 5 minutes");
+  }
+}
 ```
 </CodeGroup>
 
-Poll [run events](/cloud/agent/observability) if you need the URL as soon as
-the browser starts.
+Use the `after` cursor to avoid fetching the same events again. See [run
+events](/cloud/agent/observability) for the full event stream.
 
 ## Embed the live browser
 

--- a/docs/cloud/browser/live-preview.mdx
+++ b/docs/cloud/browser/live-preview.mdx
@@ -4,32 +4,17 @@ description: "Watch an API V4 run in real time or record its browser."
 icon: eye
 ---
 
-Poll for `browser.ready` as soon as you create the run so the URL is available
+Wait for `browser.ready` as soon as you create the run so the URL is available
 while the browser is live:
 
 <CodeGroup>
 ```python Python
-import time
-
 from browser_use_sdk.v4 import BrowserUse
 
 client = BrowserUse()
 run = client.runs.create("Find the top Hacker News story")
-after = None
-
-for _ in range(300):
-    page = client.runs.events(run.id, after=after, limit=100)
-    ready = next(
-        (event for event in page.events if event.type == "browser.ready"),
-        None,
-    )
-    if ready:
-        print(ready.data["live_view_url"])
-        break
-    after = page.next_after if page.next_after is not None else after
-    time.sleep(1)
-else:
-    raise TimeoutError("Browser did not become ready within 5 minutes")
+ready = client.runs.wait_for_event(run.id, "browser.ready")
+print(ready.data["live_view_url"])
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v4";
@@ -39,28 +24,13 @@ const run = await client.runs.create({
   task: "Find the top Hacker News story",
   model: "grok-4.5",
 });
-let after: number | null = null;
-
-for (let attempt = 0; attempt < 300; attempt++) {
-  const page = await client.runs.events(run.id, { after, limit: 100 });
-  const ready = page.events.find(
-    (event) => event.type === "browser.ready",
-  );
-  if (ready) {
-    console.log(ready.data.live_view_url);
-    break;
-  }
-  after = page.nextAfter ?? after;
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-  if (attempt === 299) {
-    throw new Error("Browser did not become ready within 5 minutes");
-  }
-}
+const ready = await client.runs.waitForEvent(run.id, "browser.ready");
+console.log(ready.data.live_view_url);
 ```
 </CodeGroup>
 
-Use the `after` cursor to avoid fetching the same events again. See [run
-events](/cloud/agent/observability) for the full event stream.
+The helper advances the event cursor and times out after five minutes. See [run
+events](/cloud/agent/observability) for the full event stream and custom polling.
 
 ## Embed the live browser
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1247,21 +1247,31 @@ reference](https://docs.browser-use.com/cloud/api-v4/runs/create-run) for the co
 Source: https://docs.browser-use.com/cloud/browser/live-preview
 
 
-The `browser.ready` event contains the live browser URL:
+Poll for `browser.ready` as soon as you create the run so the URL is available
+while the browser is live:
 
 ```python Python
+import time
+
 from browser_use_sdk.v4 import BrowserUse
 
 client = BrowserUse()
 run = client.runs.create("Find the top Hacker News story")
-run = client.runs.wait_for_completion(run.id)
+after = None
 
-events = client.runs.events(run.id, limit=100)
-ready = next(
-    event for event in events.events
-    if event.type == "browser.ready"
-)
-print(ready.data["live_view_url"])
+for _ in range(300):
+    page = client.runs.events(run.id, after=after, limit=100)
+    ready = next(
+        (event for event in page.events if event.type == "browser.ready"),
+        None,
+    )
+    if ready:
+        print(ready.data["live_view_url"])
+        break
+    after = page.next_after or after
+    time.sleep(1)
+else:
+    raise TimeoutError("Browser did not become ready within 5 minutes")
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v4";
@@ -1271,19 +1281,27 @@ const run = await client.runs.create({
   task: "Find the top Hacker News story",
   model: "grok-4.5",
 });
-await client.runs.waitForCompletion(run.id);
+let after: number | null = null;
 
-const events = await client.runs.events(run.id, {
-  limit: 100,
-});
-const ready = events.events.find(
-  (event) => event.type === "browser.ready",
-);
-console.log(ready?.data.live_view_url);
+for (let attempt = 0; attempt < 300; attempt++) {
+  const page = await client.runs.events(run.id, { after, limit: 100 });
+  const ready = page.events.find(
+    (event) => event.type === "browser.ready",
+  );
+  if (ready) {
+    console.log(ready.data.live_view_url);
+    break;
+  }
+  after = page.nextAfter ?? after;
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  if (attempt === 299) {
+    throw new Error("Browser did not become ready within 5 minutes");
+  }
+}
 ```
 
-Poll [run events](https://docs.browser-use.com/cloud/agent/observability) if you need the URL as soon as
-the browser starts.
+Use the `after` cursor to avoid fetching the same events again. See [run
+events](https://docs.browser-use.com/cloud/agent/observability) for the full event stream.
 
 ## Embed the live browser
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1268,7 +1268,7 @@ for _ in range(300):
     if ready:
         print(ready.data["live_view_url"])
         break
-    after = page.next_after or after
+    after = page.next_after if page.next_after is not None else after
     time.sleep(1)
 else:
     raise TimeoutError("Browser did not become ready within 5 minutes")

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1247,31 +1247,16 @@ reference](https://docs.browser-use.com/cloud/api-v4/runs/create-run) for the co
 Source: https://docs.browser-use.com/cloud/browser/live-preview
 
 
-Poll for `browser.ready` as soon as you create the run so the URL is available
+Wait for `browser.ready` as soon as you create the run so the URL is available
 while the browser is live:
 
 ```python Python
-import time
-
 from browser_use_sdk.v4 import BrowserUse
 
 client = BrowserUse()
 run = client.runs.create("Find the top Hacker News story")
-after = None
-
-for _ in range(300):
-    page = client.runs.events(run.id, after=after, limit=100)
-    ready = next(
-        (event for event in page.events if event.type == "browser.ready"),
-        None,
-    )
-    if ready:
-        print(ready.data["live_view_url"])
-        break
-    after = page.next_after if page.next_after is not None else after
-    time.sleep(1)
-else:
-    raise TimeoutError("Browser did not become ready within 5 minutes")
+ready = client.runs.wait_for_event(run.id, "browser.ready")
+print(ready.data["live_view_url"])
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v4";
@@ -1281,27 +1266,12 @@ const run = await client.runs.create({
   task: "Find the top Hacker News story",
   model: "grok-4.5",
 });
-let after: number | null = null;
-
-for (let attempt = 0; attempt < 300; attempt++) {
-  const page = await client.runs.events(run.id, { after, limit: 100 });
-  const ready = page.events.find(
-    (event) => event.type === "browser.ready",
-  );
-  if (ready) {
-    console.log(ready.data.live_view_url);
-    break;
-  }
-  after = page.nextAfter ?? after;
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-  if (attempt === 299) {
-    throw new Error("Browser did not become ready within 5 minutes");
-  }
-}
+const ready = await client.runs.waitForEvent(run.id, "browser.ready");
+console.log(ready.data.live_view_url);
 ```
 
-Use the `after` cursor to avoid fetching the same events again. See [run
-events](https://docs.browser-use.com/cloud/agent/observability) for the full event stream.
+The helper advances the event cursor and times out after five minutes. See [run
+events](https://docs.browser-use.com/cloud/agent/observability) for the full event stream and custom polling.
 
 ## Embed the live browser
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1247,21 +1247,31 @@ reference](https://docs.browser-use.com/cloud/api-v4/runs/create-run) for the co
 Source: https://docs.browser-use.com/cloud/browser/live-preview
 
 
-The `browser.ready` event contains the live browser URL:
+Poll for `browser.ready` as soon as you create the run so the URL is available
+while the browser is live:
 
 ```python Python
+import time
+
 from browser_use_sdk.v4 import BrowserUse
 
 client = BrowserUse()
 run = client.runs.create("Find the top Hacker News story")
-run = client.runs.wait_for_completion(run.id)
+after = None
 
-events = client.runs.events(run.id, limit=100)
-ready = next(
-    event for event in events.events
-    if event.type == "browser.ready"
-)
-print(ready.data["live_view_url"])
+for _ in range(300):
+    page = client.runs.events(run.id, after=after, limit=100)
+    ready = next(
+        (event for event in page.events if event.type == "browser.ready"),
+        None,
+    )
+    if ready:
+        print(ready.data["live_view_url"])
+        break
+    after = page.next_after or after
+    time.sleep(1)
+else:
+    raise TimeoutError("Browser did not become ready within 5 minutes")
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v4";
@@ -1271,19 +1281,27 @@ const run = await client.runs.create({
   task: "Find the top Hacker News story",
   model: "grok-4.5",
 });
-await client.runs.waitForCompletion(run.id);
+let after: number | null = null;
 
-const events = await client.runs.events(run.id, {
-  limit: 100,
-});
-const ready = events.events.find(
-  (event) => event.type === "browser.ready",
-);
-console.log(ready?.data.live_view_url);
+for (let attempt = 0; attempt < 300; attempt++) {
+  const page = await client.runs.events(run.id, { after, limit: 100 });
+  const ready = page.events.find(
+    (event) => event.type === "browser.ready",
+  );
+  if (ready) {
+    console.log(ready.data.live_view_url);
+    break;
+  }
+  after = page.nextAfter ?? after;
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  if (attempt === 299) {
+    throw new Error("Browser did not become ready within 5 minutes");
+  }
+}
 ```
 
-Poll [run events](https://docs.browser-use.com/cloud/agent/observability) if you need the URL as soon as
-the browser starts.
+Use the `after` cursor to avoid fetching the same events again. See [run
+events](https://docs.browser-use.com/cloud/agent/observability) for the full event stream.
 
 ## Embed the live browser
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1268,7 +1268,7 @@ for _ in range(300):
     if ready:
         print(ready.data["live_view_url"])
         break
-    after = page.next_after or after
+    after = page.next_after if page.next_after is not None else after
     time.sleep(1)
 else:
     raise TimeoutError("Browser did not become ready within 5 minutes")

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1247,31 +1247,16 @@ reference](https://docs.browser-use.com/cloud/api-v4/runs/create-run) for the co
 Source: https://docs.browser-use.com/cloud/browser/live-preview
 
 
-Poll for `browser.ready` as soon as you create the run so the URL is available
+Wait for `browser.ready` as soon as you create the run so the URL is available
 while the browser is live:
 
 ```python Python
-import time
-
 from browser_use_sdk.v4 import BrowserUse
 
 client = BrowserUse()
 run = client.runs.create("Find the top Hacker News story")
-after = None
-
-for _ in range(300):
-    page = client.runs.events(run.id, after=after, limit=100)
-    ready = next(
-        (event for event in page.events if event.type == "browser.ready"),
-        None,
-    )
-    if ready:
-        print(ready.data["live_view_url"])
-        break
-    after = page.next_after if page.next_after is not None else after
-    time.sleep(1)
-else:
-    raise TimeoutError("Browser did not become ready within 5 minutes")
+ready = client.runs.wait_for_event(run.id, "browser.ready")
+print(ready.data["live_view_url"])
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v4";
@@ -1281,27 +1266,12 @@ const run = await client.runs.create({
   task: "Find the top Hacker News story",
   model: "grok-4.5",
 });
-let after: number | null = null;
-
-for (let attempt = 0; attempt < 300; attempt++) {
-  const page = await client.runs.events(run.id, { after, limit: 100 });
-  const ready = page.events.find(
-    (event) => event.type === "browser.ready",
-  );
-  if (ready) {
-    console.log(ready.data.live_view_url);
-    break;
-  }
-  after = page.nextAfter ?? after;
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-  if (attempt === 299) {
-    throw new Error("Browser did not become ready within 5 minutes");
-  }
-}
+const ready = await client.runs.waitForEvent(run.id, "browser.ready");
+console.log(ready.data.live_view_url);
 ```
 
-Use the `after` cursor to avoid fetching the same events again. See [run
-events](https://docs.browser-use.com/cloud/agent/observability) for the full event stream.
+The helper advances the event cursor and times out after five minutes. See [run
+events](https://docs.browser-use.com/cloud/agent/observability) for the full event stream and custom polling.
 
 ## Embed the live browser
 


### PR DESCRIPTION
## Root cause\n\nV3 session creation waits for the browser and returns liveUrl in the create response.\n\nV4 run creation returns immediately with a queued run, before background dispatch creates the browser. Its create response contains id, status, model, sessionId, workspaceId, eventsUrl, and missingFileIds. No live URL exists yet. Making V4 create return liveUrl would require blocking or changing that async contract.\n\n## Smallest safe solution\n\n- add one cursor-aware wait_for_event / waitForEvent helper to the existing V4 Runs resource\n- show one call that waits for browser.ready and reads live_view_url\n- keep Python and TypeScript behavior in sync\n\nThe diff is seven files, but only three product surfaces: two SDK implementations and one docs source. Two files are focused tests and two are generated llms-full.txt mirrors. The extra TypeScript export file from the prior version is gone, and unrelated Python formatting churn was removed.\n\n## Current output\n\nruns.create() currently returns the queued run IDs/status plus eventsUrl. The live URL arrives later in the browser.ready event.\n\n## Proof\n\n- current-base V4 SDK has no event-wait helper\n- Python: 54 non-live tests pass; changed-file Pyright passes\n- TypeScript: 142 tests pass; typecheck passes\n- git diff --check passes\n- full Python Pyright still reports the existing optional eth_account dependency as missing in _core/x402.py; this PR does not touch that path