### PR TITLE
docs: replace stale free-task quota

### DIFF
--- a/docs/open-source/customize/skills/basics.mdx
+++ b/docs/open-source/customize/skills/basics.mdx
@@ -37,7 +37,7 @@ BROWSER_USE_API_KEY=your-api-key
 ```
 
 <Note>
-Get your API key on [cloud](https://cloud.browser-use.com/new-api-key) — new users get 5 free tasks.
+Get your API key on [cloud](https://cloud.browser-use.com/new-api-key) — eligible new accounts receive $15 in one-time credits.
 </Note>
 
 ## Cookie Handling

--- a/docs/open-source/legacy/sandbox/quickstart.mdx
+++ b/docs/open-source/legacy/sandbox/quickstart.mdx
@@ -7,7 +7,7 @@ icon: "rocket"
 Sandboxes are the **easiest way to run Browser-Use in production**. We handle agents, browsers, persistence, auth, cookies, and LLMs. It is also the **fastest way to deploy** - the agent runs right next to the browser, so latency is minimal.
 
 <Note>
-Get your API key at [cloud.browser-use.com/new-api-key](https://cloud.browser-use.com/new-api-key) — new users get 5 free tasks.
+Get your API key at [cloud.browser-use.com/new-api-key](https://cloud.browser-use.com/new-api-key) — eligible new accounts receive $15 in one-time credits.
 </Note>
 
 ## Basic Example

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -21,7 +21,7 @@ Source: https://docs.browser-use.com/open-source/quickstart
 
 To get started with Browser Use you need to install the package and create an `.env` file with your API key.
 
-`ChatBrowserUse` offers the [fastest and most cost-effective models](https://browser-use.com/posts/speed-matters/), completing tasks 3-5x faster. New users get 5 free tasks. Get your API key [here](https://cloud.browser-use.com/new-api-key).
+`ChatBrowserUse` offers the [fastest and most cost-effective models](https://browser-use.com/posts/speed-matters/), completing tasks 3-5x faster. Eligible new accounts receive $15 in one-time credits. Get your API key [here](https://cloud.browser-use.com/new-api-key).
 
 ## 1. Installing Browser-Use
 
@@ -44,7 +44,7 @@ uvx browser-use install
 Create a `.env` file and add your API key. 
 
 <Callout icon="key" iconType="regular">
-We recommend using ChatBrowserUse which is optimized for browser automation tasks (highest accuracy + fastest speed + lowest token cost). Get your API key [here](https://cloud.browser-use.com/new-api-key) — new users get 5 free tasks.
+We recommend using ChatBrowserUse which is optimized for browser automation tasks (highest accuracy + fastest speed + lowest token cost). Get your API key [here](https://cloud.browser-use.com/new-api-key) — eligible new accounts receive $15 in one-time credits.
 </Callout>
 
 ```bash .env
@@ -57,7 +57,7 @@ Then add your API key to the file.
 ```bash Browser Use
 # add your key to .env file
 BROWSER_USE_API_KEY=
-# Get your API key at https://cloud.browser-use.com/new-api-key - new users get 5 free tasks
+# Get your API key at https://cloud.browser-use.com/new-api-key - eligible new accounts receive $15 in one-time credits
 ```
 ```bash Google
 # add your key to .env file
@@ -212,7 +212,7 @@ Required environment variables:
 BROWSER_USE_API_KEY=
 ```
 
-Get your API key from the [Browser Use Cloud](https://cloud.browser-use.com/new-api-key). New users get 5 free tasks.
+Get your API key from the [Browser Use Cloud](https://cloud.browser-use.com/new-api-key). Eligible new accounts receive $15 in one-time credits.
 
 #### Pricing
 
@@ -3322,7 +3322,7 @@ Source: https://docs.browser-use.com/open-source/legacy/sandbox/quickstart
 
 Sandboxes are the **easiest way to run Browser-Use in production**. We handle agents, browsers, persistence, auth, cookies, and LLMs. It is also the **fastest way to deploy** - the agent runs right next to the browser, so latency is minimal.
 
-Get your API key at [cloud.browser-use.com/new-api-key](https://cloud.browser-use.com/new-api-key) — new users get 5 free tasks.
+Get your API key at [cloud.browser-use.com/new-api-key](https://cloud.browser-use.com/new-api-key) — eligible new accounts receive $15 in one-time credits.
 
 ## Basic Example
 

--- a/docs/open-source/quickstart.mdx
+++ b/docs/open-source/quickstart.mdx
@@ -7,7 +7,7 @@ icon: "rocket"
 To get started with Browser Use you need to install the package and create an `.env` file with your API key.
 
 <Note icon="key" color="#FFC107" iconType="regular">
-`ChatBrowserUse` offers the [fastest and most cost-effective models](https://browser-use.com/posts/speed-matters/), completing tasks 3-5x faster. New users get 5 free tasks. Get your API key [here](https://cloud.browser-use.com/new-api-key).
+`ChatBrowserUse` offers the [fastest and most cost-effective models](https://browser-use.com/posts/speed-matters/), completing tasks 3-5x faster. Eligible new accounts receive $15 in one-time credits. Get your API key [here](https://cloud.browser-use.com/new-api-key).
 </Note>
 
 ## 1. Installing Browser-Use
@@ -31,7 +31,7 @@ uvx browser-use install
 Create a `.env` file and add your API key. 
 
 <Callout icon="key" iconType="regular">
-We recommend using ChatBrowserUse which is optimized for browser automation tasks (highest accuracy + fastest speed + lowest token cost). Get your API key [here](https://cloud.browser-use.com/new-api-key) — new users get 5 free tasks.
+We recommend using ChatBrowserUse which is optimized for browser automation tasks (highest accuracy + fastest speed + lowest token cost). Get your API key [here](https://cloud.browser-use.com/new-api-key) — eligible new accounts receive $15 in one-time credits.
 </Callout>
 
 ```bash .env
@@ -46,7 +46,7 @@ Then add your API key to the file.
 ```bash Browser Use
 # add your key to .env file
 BROWSER_USE_API_KEY=
-# Get your API key at https://cloud.browser-use.com/new-api-key - new users get 5 free tasks
+# Get your API key at https://cloud.browser-use.com/new-api-key - eligible new accounts receive $15 in one-time credits
 ```
 ```bash Google
 # add your key to .env file

--- a/docs/open-source/supported-models.mdx
+++ b/docs/open-source/supported-models.mdx
@@ -35,7 +35,7 @@ Required environment variables:
 BROWSER_USE_API_KEY=
 ```
 
-Get your API key from the [Browser Use Cloud](https://cloud.browser-use.com/new-api-key). New users get 5 free tasks.
+Get your API key from the [Browser Use Cloud](https://cloud.browser-use.com/new-api-key). Eligible new accounts receive $15 in one-time credits.
 
 #### Pricing
 


### PR DESCRIPTION
## What changed
- replace every “5 free tasks” promise with the current $15 one-time credit
- keep the eligibility caveat in every API-key callout
- regenerate the open-source LLM docs

## Checks
- `bash docs/generate-llms-txt.sh` (idempotent)
- `npx --yes mintlify@4.2.850 validate --telemetry false`
- `npx --yes mintlify@4.2.850 broken-links --telemetry false`
- `git diff --check`
- exact-file secret scan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the open-source docs so the API-key callouts no longer promise "5 free tasks" and instead state the current offer: $15 in one-time credits for eligible new accounts.

- Regenerates `docs/open-source/llms-full.txt` to match the updated pages.

<sup>Written for commit d3e4f101ab660fd0150141060904e31753ee369a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

