### PR TITLE
feat(v4): make the Cloud quickstart V4-only

### DIFF
--- a/browser-use-node/package.json
+++ b/browser-use-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-use-sdk",
-  "version": "3.11.1",
+  "version": "3.11.2",
   "description": "Official TypeScript SDK for the Browser Use API",
   "repository": {
     "type": "git",

--- a/browser-use-node/src/v4.ts
+++ b/browser-use-node/src/v4.ts
@@ -1,6 +1,9 @@
 export { BrowserUse } from "./v4/client.js";
 export type { BrowserUseOptions } from "./v4/client.js";
 
+export { Browsers } from "./v4/resources/browsers.js";
+export type { CreateBrowserBody } from "./v4/resources/browsers.js";
+
 export { BrowserUseError } from "./core/errors.js";
 
 export { Runs } from "./v4/resources/runs.js";
@@ -39,6 +42,8 @@ export type InlineSecretSource = S["InlineSecretSource"];
 export type SecretBinding = S["SecretBinding"];
 
 // Session models
+export type BrowserSessionItemView = S["BrowserSessionItemView"];
+export type BrowserSessionView = S["BrowserSessionView"];
 export type SessionInfo = S["SessionInfo"];
 export type SessionListResponse = S["SessionListResponse"];
 export type QueueMessageRequest = S["QueueMessageRequest"];

--- a/browser-use-node/src/v4/resources/browsers.ts
+++ b/browser-use-node/src/v4/resources/browsers.ts
@@ -2,9 +2,19 @@ import type { HttpClient } from "../../core/http.js";
 import type { components } from "../../generated/v4/types.js";
 
 type BrowserSessionView = components["schemas"]["BrowserSessionView"];
+type BrowserSessionItemView = components["schemas"]["BrowserSessionItemView"];
+export type CreateBrowserBody = Partial<components["schemas"]["CreateBrowserSessionRequest"]>;
 
 export class Browsers {
   constructor(private readonly http: HttpClient) {}
+
+  /** Create a new standalone browser session. */
+  create(body: CreateBrowserBody = {}): Promise<BrowserSessionItemView> {
+    if (body.metadata && Object.keys(body.metadata).length > 10) {
+      throw new RangeError("metadata supports at most 10 key-value pairs");
+    }
+    return this.http.post<BrowserSessionItemView>("/browsers", body);
+  }
 
   /** Stop a browser session and refund its unused time. */
   stop(sessionId: string): Promise<BrowserSessionView> {

--- a/browser-use-node/tests/v4.test.ts
+++ b/browser-use-node/tests/v4.test.ts
@@ -33,6 +33,29 @@ function runSummary(status: string) {
 }
 
 describe("v4 browsers", () => {
+  it("creates a browser session", async () => {
+    const active = {
+      id: SESSION_ID,
+      status: "active",
+      cdpUrl: "wss://connect.browser-use.com/devtools/browser/test",
+      timeoutAt: "2026-01-01T01:00:00Z",
+      startedAt: "2026-01-01T00:00:00Z",
+      proxyUsedMb: "0",
+      proxyCost: "0",
+      browserCost: "0.01",
+      metadata: {},
+    };
+    const http = { post: vi.fn(async () => active) };
+    const browsers = new Browsers(http as any);
+
+    const browser = await browsers.create({ proxyCountryCode: "us" });
+
+    expect(http.post).toHaveBeenCalledWith("/browsers", {
+      proxyCountryCode: "us",
+    });
+    expect(browser.cdpUrl).toContain("devtools/browser/test");
+  });
+
   it("stops a browser session", async () => {
     const stopped = {
       id: SESSION_ID,

--- a/browser-use-python/pyproject.toml
+++ b/browser-use-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "browser-use-sdk"
-version = "3.11.1"
+version = "3.11.2"
 description = "Python SDK for the Browser Use cloud API"
 readme = "README.md"
 license = "MIT"

--- a/browser-use-python/src/browser_use_sdk/v4/__init__.py
+++ b/browser-use-python/src/browser_use_sdk/v4/__init__.py
@@ -2,6 +2,7 @@ from .client import AsyncBrowserUse, BrowserUse
 from .._core.errors import BrowserUseError
 
 from ..generated.v4.models import (
+    BrowserSessionItemView,
     BrowserSessionStatus,
     BrowserSessionView,
     CustomProxy,
@@ -62,6 +63,7 @@ __all__ = [
     "SecretBinding",
     "SecretBindings",
     # Session models
+    "BrowserSessionItemView",
     "BrowserSessionView",
     "SessionInfo",
     "SessionListResponse",

--- a/browser-use-python/src/browser_use_sdk/v4/resources/browsers.py
+++ b/browser-use-python/src/browser_use_sdk/v4/resources/browsers.py
@@ -1,17 +1,96 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
+from ..._core import _UNSET
 from ..._core.http import AsyncHttpClient, SyncHttpClient
-from ...generated.v4.models import BrowserSessionView
+from ...generated.v4.models import (
+    BrowserSessionItemView,
+    BrowserSessionView,
+    CustomProxy,
+)
 
 if TYPE_CHECKING:
     from uuid import UUID
 
 
+def _build_create_body(
+    *,
+    profile_id: str | None = None,
+    proxy_country_code: str | None = _UNSET,  # type: ignore[assignment]
+    metadata: dict[str, str] | None = None,
+    timeout: int | None = None,
+    browser_screen_width: int | None = None,
+    browser_screen_height: int | None = None,
+    allow_resizing: bool | None = None,
+    custom_proxy: CustomProxy | None = None,
+    enable_recording: bool | None = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    if metadata is not None and len(metadata) > 10:
+        raise ValueError("metadata supports at most 10 key-value pairs")
+
+    body: dict[str, Any] = {}
+    if profile_id is not None:
+        body["profileId"] = profile_id
+    if proxy_country_code is not _UNSET:
+        body["proxyCountryCode"] = (
+            proxy_country_code.lower()
+            if isinstance(proxy_country_code, str)
+            else proxy_country_code
+        )
+    if metadata is not None:
+        body["metadata"] = metadata
+    if timeout is not None:
+        body["timeout"] = timeout
+    if browser_screen_width is not None:
+        body["browserScreenWidth"] = browser_screen_width
+    if browser_screen_height is not None:
+        body["browserScreenHeight"] = browser_screen_height
+    if allow_resizing is not None:
+        body["allowResizing"] = allow_resizing
+    if custom_proxy is not None:
+        body["customProxy"] = custom_proxy.model_dump(by_alias=True, exclude_none=True)
+    if enable_recording is not None:
+        body["enableRecording"] = enable_recording
+    body.update(extra)
+    return body
+
+
 class Browsers:
     def __init__(self, http: SyncHttpClient) -> None:
         self._http = http
+
+    def create(
+        self,
+        *,
+        profile_id: str | None = None,
+        proxy_country_code: str | None = _UNSET,  # type: ignore[assignment]
+        metadata: dict[str, str] | None = None,
+        timeout: int | None = None,
+        browser_screen_width: int | None = None,
+        browser_screen_height: int | None = None,
+        allow_resizing: bool | None = None,
+        custom_proxy: CustomProxy | None = None,
+        enable_recording: bool | None = None,
+        **extra: Any,
+    ) -> BrowserSessionItemView:
+        """Create a new standalone browser session."""
+        body = _build_create_body(
+            profile_id=profile_id,
+            proxy_country_code=proxy_country_code,
+            metadata=metadata,
+            timeout=timeout,
+            browser_screen_width=browser_screen_width,
+            browser_screen_height=browser_screen_height,
+            allow_resizing=allow_resizing,
+            custom_proxy=custom_proxy,
+            enable_recording=enable_recording,
+            **extra,
+        )
+        return BrowserSessionItemView.model_validate(
+            self._http.request("POST", "/browsers", json=body)
+        )
 
     def stop(self, session_id: str | UUID) -> BrowserSessionView:
         """Stop a browser session and refund its unused time."""
@@ -25,6 +104,37 @@ class Browsers:
 class AsyncBrowsers:
     def __init__(self, http: AsyncHttpClient) -> None:
         self._http = http
+
+    async def create(
+        self,
+        *,
+        profile_id: str | None = None,
+        proxy_country_code: str | None = _UNSET,  # type: ignore[assignment]
+        metadata: dict[str, str] | None = None,
+        timeout: int | None = None,
+        browser_screen_width: int | None = None,
+        browser_screen_height: int | None = None,
+        allow_resizing: bool | None = None,
+        custom_proxy: CustomProxy | None = None,
+        enable_recording: bool | None = None,
+        **extra: Any,
+    ) -> BrowserSessionItemView:
+        """Create a new standalone browser session."""
+        body = _build_create_body(
+            profile_id=profile_id,
+            proxy_country_code=proxy_country_code,
+            metadata=metadata,
+            timeout=timeout,
+            browser_screen_width=browser_screen_width,
+            browser_screen_height=browser_screen_height,
+            allow_resizing=allow_resizing,
+            custom_proxy=custom_proxy,
+            enable_recording=enable_recording,
+            **extra,
+        )
+        return BrowserSessionItemView.model_validate(
+            await self._http.request("POST", "/browsers", json=body)
+        )
 
     async def stop(self, session_id: str | UUID) -> BrowserSessionView:
         """Stop a browser session and refund its unused time."""

--- a/browser-use-python/tests/test_v4.py
+++ b/browser-use-python/tests/test_v4.py
@@ -66,6 +66,14 @@ def _stopped_browser() -> dict[str, Any]:
     }
 
 
+def _active_browser() -> dict[str, Any]:
+    return {
+        **_stopped_browser(),
+        "status": "active",
+        "cdpUrl": "wss://connect.browser-use.com/devtools/browser/test",
+    }
+
+
 class FakeSyncHttp:
     """Fake SyncHttpClient — returns queued responses, records every call."""
 
@@ -116,6 +124,20 @@ def test_browsers_stop() -> None:
     assert browser.status.value == "stopped"
 
 
+def test_browsers_create() -> None:
+    http = FakeSyncHttp([_active_browser()])
+    browsers = Browsers(http)  # type: ignore[arg-type]
+
+    browser = browsers.create(proxy_country_code="DE", metadata={"flow": "quickstart"})
+
+    assert http.calls[0][:3] == (
+        "POST",
+        "/browsers",
+        {"proxyCountryCode": "de", "metadata": {"flow": "quickstart"}},
+    )
+    assert browser.cdp_url == "wss://connect.browser-use.com/devtools/browser/test"
+
+
 def test_async_browsers_stop() -> None:
     async def run() -> None:
         http = FakeAsyncHttp([_stopped_browser()])
@@ -129,6 +151,19 @@ def test_async_browsers_stop() -> None:
             {"action": "stop"},
         )
         assert browser.status.value == "stopped"
+
+    asyncio.run(run())
+
+
+def test_async_browsers_create() -> None:
+    async def run() -> None:
+        http = FakeAsyncHttp([_active_browser()])
+        browsers = AsyncBrowsers(http)  # type: ignore[arg-type]
+
+        browser = await browsers.create(proxy_country_code="us")
+
+        assert http.calls[0][:3] == ("POST", "/browsers", {"proxyCountryCode": "us"})
+        assert browser.status.value == "active"
 
     asyncio.run(run())
 

--- a/browser-use-python/uv.lock
+++ b/browser-use-python/uv.lock
@@ -342,7 +342,7 @@ wheels = [
 
 [[package]]
 name = "browser-use-sdk"
-version = "3.11.1"
+version = "3.11.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -26,10 +26,10 @@ export BROWSER_USE_API_KEY=your_key
 Skip this step if you use curl.
 
 ```bash Python
-pip install --upgrade browser-use-sdk
+pip install --upgrade browser-use-sdk playwright
 ```
 ```bash TypeScript
-npm install browser-use-sdk@latest
+npm install browser-use-sdk@latest puppeteer-core
 ```
 
 ## Run Browser Use Agents
@@ -76,7 +76,7 @@ print(browser.cdp_url)
 
 with sync_playwright() as p:
     chrome = p.chromium.connect_over_cdp(browser.cdp_url)
-    page = chrome.contexts[0].pages[0]
+    page = chrome.new_page()
     page.goto("https://example.com")
     print(page.title())
 
@@ -94,7 +94,7 @@ console.log(browser.cdpUrl);
 const chrome = await puppeteer.connect({
   browserWSEndpoint: browser.cdpUrl,
 });
-const [page] = await chrome.pages();
+const page = await chrome.newPage();
 await page.goto("https://example.com");
 console.log(await page.title());
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -10,9 +10,9 @@ Give an agent a task and get the result.
   [Browser Infrastructure](https://docs.browser-use.com/cloud/browser/quickstart)
 Launch a cloud browser and connect to it from your code.
 
-Use `browser_use_sdk.v4` when Browser Use should do the browsing for you. Use
-`browser_use_sdk.v3` when your code needs a raw cloud browser over CDP. For a
-local agent, use the [open-source library](/open-source/quickstart).
+Both Cloud paths use API V4. Choose whether Browser Use drives the browser or
+your Playwright/Puppeteer code connects directly over CDP. For a local agent,
+use the [open-source library](/open-source/quickstart).
 
 Get an [API key](https://cloud.browser-use.com/settings?tab=api-keys&new=1) and
 export it:
@@ -63,11 +63,8 @@ curl https://api.browser-use.com/api/v4/runs \
 
 Launch a browser, connect to its CDP URL, then stop it:
 
-The browser-management resource currently uses the explicit V3 SDK namespace.
-The equivalent REST endpoint is API V4.
-
 ```python Python
-from browser_use_sdk.v3 import BrowserUse
+from browser_use_sdk.v4 import BrowserUse
 from playwright.sync_api import sync_playwright
 
 client = BrowserUse()
@@ -84,7 +81,7 @@ with sync_playwright() as p:
 client.browsers.stop(browser.id)
 ```
 ```typescript TypeScript
-import { BrowserUse } from "browser-use-sdk/v3";
+import { BrowserUse } from "browser-use-sdk/v4";
 import puppeteer from "puppeteer-core";
 
 const client = new BrowserUse();

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -10,6 +10,10 @@ Give an agent a task and get the result.
   [Browser Infrastructure](https://docs.browser-use.com/cloud/browser/quickstart)
 Launch a cloud browser and connect to it from your code.
 
+Use `browser_use_sdk.v4` when Browser Use should do the browsing for you. Use
+`browser_use_sdk.v3` when your code needs a raw cloud browser over CDP. For a
+local agent, use the [open-source library](/open-source/quickstart).
+
 Get an [API key](https://cloud.browser-use.com/settings?tab=api-keys&new=1) and
 export it:
 
@@ -64,20 +68,35 @@ The equivalent REST endpoint is API V4.
 
 ```python Python
 from browser_use_sdk.v3 import BrowserUse
+from playwright.sync_api import sync_playwright
 
 client = BrowserUse()
 browser = client.browsers.create(proxy_country_code="us")
 print(browser.cdp_url)
+
+with sync_playwright() as p:
+    chrome = p.chromium.connect_over_cdp(browser.cdp_url)
+    page = chrome.contexts[0].pages[0]
+    page.goto("https://example.com")
+    print(page.title())
 
 # When finished:
 client.browsers.stop(browser.id)
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
+import puppeteer from "puppeteer-core";
 
 const client = new BrowserUse();
 const browser = await client.browsers.create({ proxyCountryCode: "us" });
 console.log(browser.cdpUrl);
+
+const chrome = await puppeteer.connect({
+  browserWSEndpoint: browser.cdpUrl,
+});
+const [page] = await chrome.pages();
+await page.goto("https://example.com");
+console.log(await page.title());
 
 // When finished:
 await client.browsers.stop(browser.id);

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -13,6 +13,10 @@ icon: rocket
   </Card>
 </CardGroup>
 
+Use `browser_use_sdk.v4` when Browser Use should do the browsing for you. Use
+`browser_use_sdk.v3` when your code needs a raw cloud browser over CDP. For a
+local agent, use the [open-source library](/open-source/quickstart).
+
 Get an [API key](https://cloud.browser-use.com/settings?tab=api-keys&new=1) and
 export it:
 
@@ -72,20 +76,35 @@ The equivalent REST endpoint is API V4.
 <CodeGroup>
 ```python Python
 from browser_use_sdk.v3 import BrowserUse
+from playwright.sync_api import sync_playwright
 
 client = BrowserUse()
 browser = client.browsers.create(proxy_country_code="us")
 print(browser.cdp_url)
+
+with sync_playwright() as p:
+    chrome = p.chromium.connect_over_cdp(browser.cdp_url)
+    page = chrome.contexts[0].pages[0]
+    page.goto("https://example.com")
+    print(page.title())
 
 # When finished:
 client.browsers.stop(browser.id)
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
+import puppeteer from "puppeteer-core";
 
 const client = new BrowserUse();
 const browser = await client.browsers.create({ proxyCountryCode: "us" });
 console.log(browser.cdpUrl);
+
+const chrome = await puppeteer.connect({
+  browserWSEndpoint: browser.cdpUrl,
+});
+const [page] = await chrome.pages();
+await page.goto("https://example.com");
+console.log(await page.title());
 
 // When finished:
 await client.browsers.stop(browser.id);

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -13,9 +13,9 @@ icon: rocket
   </Card>
 </CardGroup>
 
-Use `browser_use_sdk.v4` when Browser Use should do the browsing for you. Use
-`browser_use_sdk.v3` when your code needs a raw cloud browser over CDP. For a
-local agent, use the [open-source library](/open-source/quickstart).
+Both Cloud paths use API V4. Choose whether Browser Use drives the browser or
+your Playwright/Puppeteer code connects directly over CDP. For a local agent,
+use the [open-source library](/open-source/quickstart).
 
 Get an [API key](https://cloud.browser-use.com/settings?tab=api-keys&new=1) and
 export it:
@@ -70,12 +70,9 @@ curl https://api.browser-use.com/api/v4/runs \
 
 Launch a browser, connect to its CDP URL, then stop it:
 
-The browser-management resource currently uses the explicit V3 SDK namespace.
-The equivalent REST endpoint is API V4.
-
 <CodeGroup>
 ```python Python
-from browser_use_sdk.v3 import BrowserUse
+from browser_use_sdk.v4 import BrowserUse
 from playwright.sync_api import sync_playwright
 
 client = BrowserUse()
@@ -92,7 +89,7 @@ with sync_playwright() as p:
 client.browsers.stop(browser.id)
 ```
 ```typescript TypeScript
-import { BrowserUse } from "browser-use-sdk/v3";
+import { BrowserUse } from "browser-use-sdk/v4";
 import puppeteer from "puppeteer-core";
 
 const client = new BrowserUse();

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -30,10 +30,10 @@ Skip this step if you use curl.
 
 <CodeGroup>
 ```bash Python
-pip install --upgrade browser-use-sdk
+pip install --upgrade browser-use-sdk playwright
 ```
 ```bash TypeScript
-npm install browser-use-sdk@latest
+npm install browser-use-sdk@latest puppeteer-core
 ```
 </CodeGroup>
 
@@ -84,7 +84,7 @@ print(browser.cdp_url)
 
 with sync_playwright() as p:
     chrome = p.chromium.connect_over_cdp(browser.cdp_url)
-    page = chrome.contexts[0].pages[0]
+    page = chrome.new_page()
     page.goto("https://example.com")
     print(page.title())
 
@@ -102,7 +102,7 @@ console.log(browser.cdpUrl);
 const chrome = await puppeteer.connect({
   browserWSEndpoint: browser.cdpUrl,
 });
-const [page] = await chrome.pages();
+const page = await chrome.newPage();
 await page.goto("https://example.com");
 console.log(await page.title());
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -26,10 +26,10 @@ export BROWSER_USE_API_KEY=your_key
 Skip this step if you use curl.
 
 ```bash Python
-pip install --upgrade browser-use-sdk
+pip install --upgrade browser-use-sdk playwright
 ```
 ```bash TypeScript
-npm install browser-use-sdk@latest
+npm install browser-use-sdk@latest puppeteer-core
 ```
 
 ## Run Browser Use Agents
@@ -76,7 +76,7 @@ print(browser.cdp_url)
 
 with sync_playwright() as p:
     chrome = p.chromium.connect_over_cdp(browser.cdp_url)
-    page = chrome.contexts[0].pages[0]
+    page = chrome.new_page()
     page.goto("https://example.com")
     print(page.title())
 
@@ -94,7 +94,7 @@ console.log(browser.cdpUrl);
 const chrome = await puppeteer.connect({
   browserWSEndpoint: browser.cdpUrl,
 });
-const [page] = await chrome.pages();
+const page = await chrome.newPage();
 await page.goto("https://example.com");
 console.log(await page.title());
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -10,9 +10,9 @@ Give an agent a task and get the result.
   [Browser Infrastructure](https://docs.browser-use.com/cloud/browser/quickstart)
 Launch a cloud browser and connect to it from your code.
 
-Use `browser_use_sdk.v4` when Browser Use should do the browsing for you. Use
-`browser_use_sdk.v3` when your code needs a raw cloud browser over CDP. For a
-local agent, use the [open-source library](/open-source/quickstart).
+Both Cloud paths use API V4. Choose whether Browser Use drives the browser or
+your Playwright/Puppeteer code connects directly over CDP. For a local agent,
+use the [open-source library](/open-source/quickstart).
 
 Get an [API key](https://cloud.browser-use.com/settings?tab=api-keys&new=1) and
 export it:
@@ -63,11 +63,8 @@ curl https://api.browser-use.com/api/v4/runs \
 
 Launch a browser, connect to its CDP URL, then stop it:
 
-The browser-management resource currently uses the explicit V3 SDK namespace.
-The equivalent REST endpoint is API V4.
-
 ```python Python
-from browser_use_sdk.v3 import BrowserUse
+from browser_use_sdk.v4 import BrowserUse
 from playwright.sync_api import sync_playwright
 
 client = BrowserUse()
@@ -84,7 +81,7 @@ with sync_playwright() as p:
 client.browsers.stop(browser.id)
 ```
 ```typescript TypeScript
-import { BrowserUse } from "browser-use-sdk/v3";
+import { BrowserUse } from "browser-use-sdk/v4";
 import puppeteer from "puppeteer-core";
 
 const client = new BrowserUse();

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -10,6 +10,10 @@ Give an agent a task and get the result.
   [Browser Infrastructure](https://docs.browser-use.com/cloud/browser/quickstart)
 Launch a cloud browser and connect to it from your code.
 
+Use `browser_use_sdk.v4` when Browser Use should do the browsing for you. Use
+`browser_use_sdk.v3` when your code needs a raw cloud browser over CDP. For a
+local agent, use the [open-source library](/open-source/quickstart).
+
 Get an [API key](https://cloud.browser-use.com/settings?tab=api-keys&new=1) and
 export it:
 
@@ -64,20 +68,35 @@ The equivalent REST endpoint is API V4.
 
 ```python Python
 from browser_use_sdk.v3 import BrowserUse
+from playwright.sync_api import sync_playwright
 
 client = BrowserUse()
 browser = client.browsers.create(proxy_country_code="us")
 print(browser.cdp_url)
+
+with sync_playwright() as p:
+    chrome = p.chromium.connect_over_cdp(browser.cdp_url)
+    page = chrome.contexts[0].pages[0]
+    page.goto("https://example.com")
+    print(page.title())
 
 # When finished:
 client.browsers.stop(browser.id)
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v3";
+import puppeteer from "puppeteer-core";
 
 const client = new BrowserUse();
 const browser = await client.browsers.create({ proxyCountryCode: "us" });
 console.log(browser.cdpUrl);
+
+const chrome = await puppeteer.connect({
+  browserWSEndpoint: browser.cdpUrl,
+});
+const [page] = await chrome.pages();
+await page.goto("https://example.com");
+console.log(await page.title());
 
 // When finished:
 await client.browsers.stop(browser.id);


### PR DESCRIPTION
## Why

The Cloud quickstart mixed a V4 hosted-agent example with a V3 raw-browser example. The backend browser endpoint was already V4, but the V4 SDK could only stop a browser—not create one.

## What changed

- add `browsers.create()` to the Python and TypeScript V4 clients
- keep sync/async Python and TypeScript request behavior aligned
- run both hosted agents and direct CDP browsers through V4 in the quickstart
- include the Playwright and Puppeteer connection calls instead of sending readers elsewhere
- bump both packages to 3.11.2 so the docs and SDK ship together
- regenerate both full LLM-doc mirrors

## Proof

- Python: 59/59 non-live tests; focused V4 suite 29/29; Pyright 0 errors
- TypeScript: 145/145 tests; focused V4 suite 25/25; typecheck and package build pass
- Python source and wheel build pass
- Mintlify validation passes
- docs generation run twice with byte-identical output
- `uv lock --check`, `jq empty docs/docs.json`, and `git diff --check` pass

Merging this PR bumps the SDK to 3.11.2. The repository's release workflow creates that release; package publication remains behind its release-environment approval gate.
