### PR TITLE
docs: replace cloud browser diagram with ASCII

### DIFF
--- a/docs/cloud/browser/quickstart.mdx
+++ b/docs/cloud/browser/quickstart.mdx
@@ -8,18 +8,27 @@ icon: rocket
 Every browser includes stealth, proxies, live preview, and recording. Its
 **CDP URL** is a WebSocket endpoint for remotely controlling Chrome.
 
-<img
-  src="/cloud/images/browser-cdp-light.svg"
-  alt="Your code using a CDP URL to connect to and control a cloud browser that accesses the web"
-  noZoom
-  className="block dark:hidden"
-/>
-<img
-  src="/cloud/images/browser-cdp-dark.svg"
-  alt="Your code using a CDP URL to connect to and control a cloud browser that accesses the web"
-  noZoom
-  className="hidden dark:block"
-/>
+```text
++-------------------+
+| Your code         |
++-------------------+
+          |
+          | CDP URL
+          v
++-------------------+
+| Cloud browser     |
+|                   |
+| - Stealth         |
+| - Proxy           |
+| - Live preview    |
+| - Recording       |
++-------------------+
+          |
+          v
++-------------------+
+| Web               |
++-------------------+
+```
 
 Get an [API key](https://cloud.browser-use.com/settings?tab=api-keys&new=1) and
 export it:

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1016,18 +1016,27 @@ Source: https://docs.browser-use.com/cloud/browser/quickstart
 Every browser includes stealth, proxies, live preview, and recording. Its
 **CDP URL** is a WebSocket endpoint for remotely controlling Chrome.
 
-<img
-  src="/cloud/images/browser-cdp-light.svg"
-  alt="Your code using a CDP URL to connect to and control a cloud browser that accesses the web"
-  noZoom
-  className="block dark:hidden"
-/>
-<img
-  src="/cloud/images/browser-cdp-dark.svg"
-  alt="Your code using a CDP URL to connect to and control a cloud browser that accesses the web"
-  noZoom
-  className="hidden dark:block"
-/>
+```text
++-------------------+
+| Your code         |
++-------------------+
+          |
+          | CDP URL
+          v
++-------------------+
+| Cloud browser     |
+|                   |
+| - Stealth         |
+| - Proxy           |
+| - Live preview    |
+| - Recording       |
++-------------------+
+          |
+          v
++-------------------+
+| Web               |
++-------------------+
+```
 
 Get an [API key](https://cloud.browser-use.com/settings?tab=api-keys&new=1) and
 export it:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1016,18 +1016,27 @@ Source: https://docs.browser-use.com/cloud/browser/quickstart
 Every browser includes stealth, proxies, live preview, and recording. Its
 **CDP URL** is a WebSocket endpoint for remotely controlling Chrome.
 
-<img
-  src="/cloud/images/browser-cdp-light.svg"
-  alt="Your code using a CDP URL to connect to and control a cloud browser that accesses the web"
-  noZoom
-  className="block dark:hidden"
-/>
-<img
-  src="/cloud/images/browser-cdp-dark.svg"
-  alt="Your code using a CDP URL to connect to and control a cloud browser that accesses the web"
-  noZoom
-  className="hidden dark:block"
-/>
+```text
++-------------------+
+| Your code         |
++-------------------+
+          |
+          | CDP URL
+          v
++-------------------+
+| Cloud browser     |
+|                   |
+| - Stealth         |
+| - Proxy           |
+| - Live preview    |
+| - Recording       |
++-------------------+
+          |
+          v
++-------------------+
+| Web               |
++-------------------+
+```
 
 Get an [API key](https://cloud.browser-use.com/settings?tab=api-keys&new=1) and
 export it:


### PR DESCRIPTION
## Summary

- replace the Cloud browser quickstart image with an ASCII flow diagram
- keep generated LLM documentation in sync
- preserve responsive rendering without horizontal page overflow

## Verification

- verified at 1440×900 and 390×844
- confirmed no page or code-block overflow
- ran `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the cloud browser quickstart image with an ASCII flow diagram so the flow renders consistently in light/dark mode and in the LLM-generated docs.

- Removes the light/dark SVG image pair from `docs/cloud/browser/quickstart.mdx`.
- Adds the same ASCII flow diagram to `docs/cloud/llms-full.txt` and `docs/llms-full.txt` to keep generated LLM docs in sync.
- Verified at desktop and mobile viewport widths with no horizontal or code-block overflow.

<sup>Written for commit a56a76832de7a21af3a2bc61116d2be5e9a573cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

