### PR TITLE
Add a 'Which Browser Use do I need?' page

### DIFF
--- a/docs/cloud/images/which-product-dark-mobile.svg
+++ b/docs/cloud/images/which-product-dark-mobile.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="360" height="704" viewBox="0 0 360 704" role="img" aria-labelledby="title desc">
+<title id="title">Choose your agent, CLI and browser</title>
+<desc id="desc">Both columns share three aligned rows: agent, CLI, browser. On your computer, choose Claude Code, Codex, OpenCode or Hermes Agent, then Playwright CLI or Browser Use CLI. Both CLIs can use real Chrome or the single Cloud Browser in our cloud. Hosted V4 runs OpenCode, Browser Use CLI and that Cloud Browser. Profile Sync copies selected cookies from real Chrome to a cloud profile; it is a separate, explicit step. Send a prompt through the V4 API and get a result back.</desc>
+<defs><marker id="gray-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto"><path d="M0 0L7 3.5L0 7Z" fill="#A1A1AA"/></marker><marker id="orange-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto"><path d="M0 0L7 3.5L0 7Z" fill="#FFAA66"/></marker></defs>
+<rect width="360" height="704" fill="#18181B"/><g font-family="Inter, ui-sans-serif, system-ui, sans-serif">
+<rect x="196" y="10" width="156" height="686" rx="12" fill="#29211B" stroke="#835733" stroke-width="1.7"/>
+<text x="90" y="39" fill="#FAFAFA" font-size="16" font-weight="750" text-anchor="middle">YOUR COMPUTER</text>
+<text x="90" y="63" fill="#C0C0C8" font-size="16" font-weight="450" text-anchor="middle">Choose each part</text>
+<text x="274" y="39" fill="#FAFAFA" font-size="16" font-weight="750" text-anchor="middle">OUR CLOUD</text>
+<text x="274" y="63" fill="#FFAA66" font-size="16" font-weight="600" text-anchor="middle">Send a prompt.</text>
+<text x="274" y="84" fill="#C0C0C8" font-size="16" font-weight="450" text-anchor="middle">Get a result.</text>
+<rect x="8" y="95" width="166" height="128" rx="12" fill="#27272A" stroke="#A1A1AA" stroke-width="1.7"/>
+<text x="91" y="119" fill="#C0C0C8" font-size="16" font-weight="700" text-anchor="middle">YOUR AGENT</text>
+<text x="91" y="143" fill="#FAFAFA" font-size="16" font-weight="600" text-anchor="middle">Claude Code</text>
+<text x="91" y="165" fill="#FAFAFA" font-size="16" font-weight="600" text-anchor="middle">Codex · OpenCode</text>
+<text x="91" y="187" fill="#FAFAFA" font-size="16" font-weight="600" text-anchor="middle">Hermes Agent</text>
+<rect x="208" y="95" width="132" height="128" rx="12" fill="#27272A" stroke="#A1A1AA" stroke-width="1.7"/>
+<text x="274" y="166" fill="#FAFAFA" font-size="18" font-weight="750" text-anchor="middle">OpenCode</text>
+<path d="M91 223V253" fill="none" stroke="#A1A1AA" stroke-width="2" stroke-linejoin="round" marker-end="url(#gray-arrow)"/>
+<path d="M274 223V253" fill="none" stroke="#A1A1AA" stroke-width="2" stroke-linejoin="round" marker-end="url(#gray-arrow)"/>
+<rect x="8" y="263" width="166" height="92" rx="12" fill="#3A281A" stroke="#FFAA66" stroke-width="1.7"/>
+<text x="91" y="292" fill="#FAFAFA" font-size="16" font-weight="750" text-anchor="middle">Playwright CLI</text>
+<text x="91" y="316" fill="#C0C0C8" font-size="16" font-weight="450" text-anchor="middle">or</text>
+<text x="91" y="340" fill="#FAFAFA" font-size="16" font-weight="600" text-anchor="middle">Browser Use CLI</text>
+<rect x="208" y="263" width="132" height="92" rx="12" fill="#3A281A" stroke="#FFAA66" stroke-width="1.7"/>
+<text x="274" y="303" fill="#FAFAFA" font-size="16" font-weight="750" text-anchor="middle">Browser Use</text>
+<text x="274" y="326" fill="#FAFAFA" font-size="16" font-weight="750" text-anchor="middle">CLI</text>
+<path d="M50 355V379H132V355" fill="none" stroke="#A1A1AA" stroke-width="2" stroke-linejoin="round"/>
+<path d="M50 379V406H87V425" fill="none" stroke="#A1A1AA" stroke-width="2" stroke-linejoin="round" marker-end="url(#gray-arrow)"/>
+<path d="M132 379H183V489H202" fill="none" stroke="#FFAA66" stroke-width="2" stroke-linejoin="round" marker-end="url(#orange-arrow)"/>
+<path d="M274 355V425" fill="none" stroke="#FFAA66" stroke-width="2" marker-end="url(#orange-arrow)"/>
+<circle cx="50" cy="379" r="3" fill="#A1A1AA"/>
+<circle cx="132" cy="379" r="3" fill="#FFAA66"/>
+<rect x="18" y="435" width="138" height="108" rx="12" fill="#18181B" stroke="#A1A1AA" stroke-width="1.7"/>
+<path d="M18 462H156" fill="none" stroke="#A1A1AA" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="32" cy="449" r="2.6" fill="#A1A1AA"/>
+<circle cx="42" cy="449" r="2.6" fill="#A1A1AA"/>
+<circle cx="52" cy="449" r="2.6" fill="#A1A1AA"/>
+<text x="87" y="491" fill="#FAFAFA" font-size="16" font-weight="750" text-anchor="middle">Real Chrome</text>
+<text x="87" y="514" fill="#C0C0C8" font-size="16" font-weight="450" text-anchor="middle">your tabs,</text>
+<text x="87" y="532" fill="#C0C0C8" font-size="16" font-weight="450" text-anchor="middle">cookies, logins</text>
+<rect x="208" y="435" width="132" height="108" rx="12" fill="#3A281A" stroke="#FFAA66" stroke-width="1.7"/>
+<path d="M208 462H340" fill="none" stroke="#FFAA66" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="222" cy="449" r="2.6" fill="#FFAA66"/>
+<circle cx="232" cy="449" r="2.6" fill="#FFAA66"/>
+<circle cx="242" cy="449" r="2.6" fill="#FFAA66"/>
+<text x="274" y="491" fill="#FAFAFA" font-size="16" font-weight="750" text-anchor="middle">Cloud Browser</text>
+<text x="274" y="514" fill="#C0C0C8" font-size="16" font-weight="450" text-anchor="middle">profiles, stealth,</text>
+<text x="274" y="532" fill="#C0C0C8" font-size="16" font-weight="450" text-anchor="middle">proxies</text>
+<path d="M87 543V573H274V553" fill="none" stroke="#A1A1AA" stroke-width="2" stroke-dasharray="6 5" stroke-linejoin="round" marker-end="url(#gray-arrow)"/>
+<text x="182" y="599" fill="#C0C0C8" font-size="16" font-weight="600" text-anchor="middle">Profile Sync · cookies</text>
+<text x="89" y="651" fill="#C0C0C8" font-size="16" font-weight="600" text-anchor="middle">Both CLIs.</text>
+<text x="89" y="673" fill="#C0C0C8" font-size="16" font-weight="600" text-anchor="middle">Either browser.</text>
+<text x="274" y="651" fill="#FFAA66" font-size="16" font-weight="600" text-anchor="middle">Hosted V4 API</text>
+</g></svg>

--- a/docs/cloud/images/which-product-dark-mobile.svg
+++ b/docs/cloud/images/which-product-dark-mobile.svg
@@ -48,6 +48,7 @@
 <text x="274" y="514" fill="#C0C0C8" font-size="16" font-weight="450" text-anchor="middle">profiles, stealth,</text>
 <text x="274" y="532" fill="#C0C0C8" font-size="16" font-weight="450" text-anchor="middle">proxies</text>
 <path d="M87 543V573H274V553" fill="none" stroke="#A1A1AA" stroke-width="2" stroke-dasharray="6 5" stroke-linejoin="round" marker-end="url(#gray-arrow)"/>
+<rect x="80" y="580" width="204" height="26" rx="4" fill="#18181B"/>
 <text x="182" y="599" fill="#C0C0C8" font-size="16" font-weight="600" text-anchor="middle">Profile Sync · cookies</text>
 <text x="89" y="651" fill="#C0C0C8" font-size="16" font-weight="600" text-anchor="middle">Both CLIs.</text>
 <text x="89" y="673" fill="#C0C0C8" font-size="16" font-weight="600" text-anchor="middle">Either browser.</text>

--- a/docs/cloud/images/which-product-dark.svg
+++ b/docs/cloud/images/which-product-dark.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="460" viewBox="0 0 1200 460" role="img" aria-labelledby="title desc">
+  <title id="title">Three parts of Browser Use</title>
+  <desc id="desc">Your agent, the Browser Use CLI, and a browser. Take all three hosted as Cloud v4, bring your own agent with our CLI, or take only the browser.</desc>
+  <defs>
+    <filter id="rough">
+      <feTurbulence type="fractalNoise" baseFrequency=".01" numOctaves="2" seed="7" result="noise"/>
+      <feDisplacementMap in="SourceGraphic" in2="noise" scale="1.4"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="460" fill="#09090B"/>
+  <rect x="20" y="20" width="1160" height="420" fill="none" stroke="#27272A" stroke-width="2"/>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round" filter="url(#rough)">
+    <rect x="60" y="90" width="300" height="150" rx="30" fill="#111113" stroke="#A1A1AA" stroke-width="4" stroke-dasharray="16 12"/>
+    <path d="M365 165 C402 157 418 173 445 165" stroke="#A1A1AA" stroke-width="4"/>
+    <path d="M423 150 L445 165 L423 182" stroke="#A1A1AA" stroke-width="4"/>
+    <rect x="450" y="90" width="300" height="150" rx="30" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
+    <path d="M755 165 C792 157 808 173 835 165" stroke="#A1A1AA" stroke-width="4"/>
+    <path d="M813 150 L835 165 L813 182" stroke="#A1A1AA" stroke-width="4"/>
+    <rect x="840" y="90" width="300" height="150" rx="30" fill="#111113" stroke="#A1A1AA" stroke-width="4" stroke-dasharray="16 12"/>
+    <path d="M70 290 L70 320 L1130 320 L1130 290" stroke="#FE750E" stroke-width="4"/>
+    <path d="M70 360 L70 390 L750 390 L750 360" stroke="#A1A1AA" stroke-width="4"/>
+    <path d="M850 360 L850 390 L1130 390 L1130 360" stroke="#A1A1AA" stroke-width="4"/>
+  </g>
+  <g font-family="Virgil, Comic Sans MS, cursive">
+    <text x="210" y="150" font-size="40" fill="#F4F4F5" text-anchor="middle">YOUR AGENT</text>
+    <text x="210" y="200" font-size="22" fill="#A1A1AA" text-anchor="middle">codex · claude code · hermes</text>
+    <text x="600" y="150" font-size="40" fill="#F4F4F5" text-anchor="middle">BROWSER USE CLI</text>
+    <text x="600" y="200" font-size="22" fill="#A1A1AA" text-anchor="middle">the harness your agent runs</text>
+    <text x="990" y="150" font-size="40" fill="#F4F4F5" text-anchor="middle">BROWSER</text>
+    <text x="990" y="200" font-size="22" fill="#A1A1AA" text-anchor="middle">your chrome · our cloud browser</text>
+    <text x="600" y="350" font-size="30" fill="#FE750E" text-anchor="middle">ALL THREE, HOSTED = CLOUD V4 (one API call)</text>
+    <text x="410" y="425" font-size="26" fill="#A1A1AA" text-anchor="middle">YOUR AGENT + OUR CLI + ANY BROWSER = CLI</text>
+    <text x="990" y="425" font-size="26" fill="#A1A1AA" text-anchor="middle">ONLY THE BROWSER = BROWSER API</text>
+  </g>
+</svg>

--- a/docs/cloud/images/which-product-dark.svg
+++ b/docs/cloud/images/which-product-dark.svg
@@ -1,44 +1,48 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="500" viewBox="0 0 1200 500" role="img" aria-labelledby="title desc">
-  <title id="title">Which Browser Use do I need</title>
-  <desc id="desc">On your machine: Claude Code or Codex run the Browser Use CLI against your own Chrome or one of our cloud browsers. In our cloud: the fully hosted agent you send a prompt to, or just a browser for your own agent.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="620" viewBox="0 0 1200 620" role="img" aria-labelledby="title desc">
+  <title id="title">Where each Browser Use part runs</title>
+  <desc id="desc">Claude Code or Codex use Browser Use CLI on your machine. The CLI drives real Chrome locally or connects to the single Cloud Browser in our cloud. OpenCode and Browser Use CLI also run beside Cloud Browser as the fully hosted stack. Your own agent can connect directly through the Browser API.</desc>
   <defs>
-    <filter id="rough">
-      <feTurbulence type="fractalNoise" baseFrequency=".01" numOctaves="2" seed="7" result="noise"/>
-      <feDisplacementMap in="SourceGraphic" in2="noise" scale="1.4"/>
-    </filter>
+    <filter id="rough"><feTurbulence type="fractalNoise" baseFrequency=".012" numOctaves="2" seed="7" result="noise"/><feDisplacementMap in="SourceGraphic" in2="noise" scale="1.2"/></filter>
+    <marker id="arrow-orange" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#FE750E"/></marker>
+    <marker id="arrow-gray" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#A1A1AA"/></marker>
   </defs>
-  <rect width="1200" height="500" fill="#09090B"/>
-  <rect x="20" y="20" width="1160" height="460" fill="none" stroke="#27272A" stroke-width="2"/>
-  <g fill="none" stroke-linecap="round" stroke-linejoin="round" filter="url(#rough)">
-    <rect x="40" y="70" width="560" height="300" rx="22" fill="#111113" stroke="#A1A1AA" stroke-width="4"/>
-    <path d="M20 370 L620 370 L600 405 L40 405 Z" fill="#111113" stroke="#A1A1AA" stroke-width="4"/>
-    <rect x="70" y="130" width="200" height="90" rx="30" fill="#111113" stroke="#A1A1AA" stroke-width="4" stroke-dasharray="16 12"/>
-    <path d="M275 175 C300 167 292 183 315 175" stroke="#A1A1AA" stroke-width="4"/>
-    <path d="M293 160 L315 175 L293 192" stroke="#A1A1AA" stroke-width="4"/>
-    <rect x="320" y="130" width="260" height="90" rx="30" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
-    <rect x="70" y="255" width="200" height="80" rx="30" fill="#111113" stroke="#A1A1AA" stroke-width="4" stroke-dasharray="16 12"/>
-    <rect x="320" y="255" width="260" height="80" rx="30" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
-    <path d="M680 240 C640 240 630 180 690 175 C690 120 790 100 815 150 C850 110 940 120 935 180 C1000 175 1010 240 960 250 L700 250 Z" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
-    <rect x="700" y="285" width="460" height="88" rx="30" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
-    <rect x="700" y="390" width="185" height="80" rx="30" fill="#111113" stroke="#A1A1AA" stroke-width="4" stroke-dasharray="16 12"/>
-    <path d="M890 430 C905 423 905 437 920 430" stroke="#A1A1AA" stroke-width="4"/>
-    <path d="M905 416 L920 430 L905 444" stroke="#A1A1AA" stroke-width="4"/>
-    <rect x="925" y="390" width="235" height="80" rx="30" fill="#23170F" stroke="#FE750E" stroke-width="4"/>
-  </g>
-  <g font-family="Virgil, Comic Sans MS, cursive">
-    <text x="320" y="110" font-size="30" fill="#A1A1AA" text-anchor="middle">YOUR MACHINE</text>
-    <text x="170" y="172" font-size="25" fill="#F4F4F5" text-anchor="middle">YOUR AGENT</text>
-    <text x="170" y="200" font-size="18" fill="#A1A1AA" text-anchor="middle">claude code · codex</text>
-    <text x="450" y="185" font-size="24" fill="#F4F4F5" text-anchor="middle">BROWSER USE CLI</text>
-    <text x="170" y="303" font-size="24" fill="#F4F4F5" text-anchor="middle">YOUR CHROME</text>
-    <text x="450" y="303" font-size="22" fill="#F4F4F5" text-anchor="middle">OUR CLOUD BROWSER</text>
-    <text x="320" y="358" font-size="20" fill="#A1A1AA" text-anchor="middle">pick either browser</text>
-    <text x="815" y="205" font-size="34" fill="#F4F4F5" text-anchor="middle">OUR CLOUD</text>
-    <text x="930" y="322" font-size="24" fill="#F4F4F5" text-anchor="middle">FULLY HOSTED AGENT = V4</text>
-    <text x="930" y="352" font-size="19" fill="#A1A1AA" text-anchor="middle">send a prompt, get the result back</text>
-    <text x="792" y="424" font-size="21" fill="#F4F4F5" text-anchor="middle">YOUR AGENT</text>
-    <text x="792" y="451" font-size="16" fill="#A1A1AA" text-anchor="middle">anywhere</text>
-    <text x="1042" y="424" font-size="21" fill="#F4F4F5" text-anchor="middle">BROWSER API</text>
-    <text x="1042" y="451" font-size="16" fill="#A1A1AA" text-anchor="middle">only our browser</text>
+  <rect width="1200" height="620" fill="#09090B"/>
+  <g filter="url(#rough)" font-family="Virgil, Comic Sans MS, cursive">
+    <rect x="28" y="28" width="556" height="564" rx="30" fill="#111113" stroke="#52525B" stroke-width="3"/>
+    <rect x="616" y="28" width="556" height="564" rx="30" fill="#17100B" stroke="#FE750E" stroke-width="3"/>
+    <text x="306" y="77" font-size="30" fill="#F4F4F5" text-anchor="middle">YOUR MACHINE</text>
+    <text x="894" y="77" font-size="30" fill="#F4F4F5" text-anchor="middle">OUR CLOUD</text>
+    <rect x="66" y="112" width="214" height="78" rx="24" fill="#17171A" stroke="#A1A1AA" stroke-width="3" stroke-dasharray="13 10"/>
+    <text x="173" y="145" font-size="22" fill="#F4F4F5" text-anchor="middle">YOUR AGENT</text>
+    <text x="173" y="173" font-size="16" fill="#A1A1AA" text-anchor="middle">Claude Code · Codex</text>
+    <rect x="330" y="112" width="216" height="78" rx="24" fill="#24140B" stroke="#FE750E" stroke-width="3"/>
+    <text x="438" y="160" font-size="21" fill="#F4F4F5" text-anchor="middle">BROWSER USE CLI</text>
+    <path d="M280 151H324" fill="none" stroke="#A1A1AA" stroke-width="4" marker-end="url(#arrow-gray)"/>
+    <rect x="126" y="274" width="360" height="136" rx="26" fill="#17171A" stroke="#A1A1AA" stroke-width="3"/>
+    <circle cx="156" cy="302" r="6" fill="#FF5F57"/><circle cx="177" cy="302" r="6" fill="#FEBC2E"/><circle cx="198" cy="302" r="6" fill="#28C840"/>
+    <text x="306" y="348" font-size="24" fill="#F4F4F5" text-anchor="middle">REAL CHROME</text>
+    <text x="306" y="382" font-size="17" fill="#A1A1AA" text-anchor="middle">tabs · cookies · logins</text>
+    <path d="M438 190V236H306V268" fill="none" stroke="#A1A1AA" stroke-width="4" marker-end="url(#arrow-gray)"/>
+    <rect x="672" y="112" width="174" height="76" rx="24" fill="#17171A" stroke="#A1A1AA" stroke-width="3" stroke-dasharray="13 10"/>
+    <text x="759" y="159" font-size="22" fill="#F4F4F5" text-anchor="middle">OPENCODE</text>
+    <rect x="896" y="112" width="222" height="76" rx="24" fill="#24140B" stroke="#FE750E" stroke-width="3"/>
+    <text x="1007" y="159" font-size="20" fill="#F4F4F5" text-anchor="middle">BROWSER USE CLI</text>
+    <path d="M846 150H890" fill="none" stroke="#FE750E" stroke-width="4" marker-end="url(#arrow-orange)"/>
+    <rect x="760" y="274" width="268" height="136" rx="28" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
+    <circle cx="790" cy="302" r="6" fill="#FF5F57"/><circle cx="811" cy="302" r="6" fill="#FEBC2E"/><circle cx="832" cy="302" r="6" fill="#28C840"/>
+    <text x="894" y="348" font-size="25" fill="#F4F4F5" text-anchor="middle">CLOUD BROWSER</text>
+    <text x="894" y="382" font-size="17" fill="#FEA35F" text-anchor="middle">stealth · profiles · proxies</text>
+    <path d="M1007 188V232H894V268" fill="none" stroke="#FE750E" stroke-width="4" marker-end="url(#arrow-orange)"/>
+    <path d="M438 190V224H650V342H754" fill="none" stroke="#FE750E" stroke-width="4" marker-end="url(#arrow-orange)"/>
+    <text x="608" y="214" font-size="16" fill="#FEA35F" text-anchor="middle">or connect to our cloud</text>
+    <rect x="672" y="474" width="174" height="72" rx="22" fill="#17171A" stroke="#A1A1AA" stroke-width="3" stroke-dasharray="13 10"/>
+    <text x="759" y="505" font-size="19" fill="#F4F4F5" text-anchor="middle">YOUR AGENT</text>
+    <text x="759" y="530" font-size="15" fill="#A1A1AA" text-anchor="middle">anywhere</text>
+    <rect x="896" y="474" width="222" height="72" rx="22" fill="#17100B" stroke="#FE750E" stroke-width="3"/>
+    <text x="1007" y="518" font-size="20" fill="#F4F4F5" text-anchor="middle">BROWSER API</text>
+    <path d="M846 510H890" fill="none" stroke="#A1A1AA" stroke-width="4" marker-end="url(#arrow-gray)"/>
+    <path d="M1007 474V440H894V416" fill="none" stroke="#FE750E" stroke-width="4" marker-end="url(#arrow-orange)"/>
+    <text x="306" y="558" font-size="18" fill="#A1A1AA" text-anchor="middle">CLI + local Chrome</text>
+    <text x="894" y="558" font-size="18" fill="#FEA35F" text-anchor="middle">hosted stack or browser only</text>
   </g>
 </svg>

--- a/docs/cloud/images/which-product-dark.svg
+++ b/docs/cloud/images/which-product-dark.svg
@@ -1,66 +1,39 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="700" viewBox="0 0 1200 700" role="img" aria-labelledby="title desc">
-  <title id="title">Choose a local or cloud Browser Use setup</title>
-  <desc id="desc">On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or connect through Browser API to the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI at the same level above that Cloud Browser. Browser API is the browser-only route.</desc>
+  <title id="title">Choose local Chrome or the Browser Use cloud</title>
+  <desc id="desc">On your computer, local agents sit above matching Browser Use CLI and Playwright CLI boxes. The CLIs choose one local path to real Chrome or one cloud path directly to Cloud Browser. In Cloud V4, matching OpenCode and Browser Use CLI boxes run above that Cloud Browser.</desc>
   <defs>
-    <marker id="arrow-orange" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#FE750E"/></marker>
-    <marker id="arrow-gray" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#A1A1AA"/></marker>
+    <marker id="orange-arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#FE750E"/></marker>
+    <marker id="gray-arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#A1A1AA"/></marker>
   </defs>
   <rect width="1200" height="700" fill="#09090B"/>
   <g font-family="Inter, ui-sans-serif, system-ui, sans-serif">
-    <text x="338" y="39" font-size="26" font-weight="750" fill="#F4F4F5" text-anchor="middle">YOUR COMPUTER</text>
-    <rect x="28" y="52" width="620" height="586" rx="28" fill="#27272A" stroke="#52525B" stroke-width="3"/>
-    <circle cx="338" cy="68" r="4" fill="#71717A"/>
-    <rect x="50" y="78" width="576" height="536" rx="17" fill="#111113" stroke="#52525B" stroke-width="2"/>
-    <rect x="74" y="102" width="528" height="486" rx="15" fill="#17171A" stroke="#52525B" stroke-width="2"/>
-    <path d="M74 149H602" stroke="#52525B" stroke-width="2"/>
-    <circle cx="96" cy="126" r="6" fill="#FF5F57"/><circle cx="117" cy="126" r="6" fill="#FEBC2E"/><circle cx="138" cy="126" r="6" fill="#28C840"/>
-    <rect x="168" y="115" width="394" height="23" rx="11" fill="#27272A"/>
-    <text x="365" y="132" font-size="13" fill="#A1A1AA" text-anchor="middle">local</text>
-
-    <rect x="99" y="174" width="478" height="68" rx="18" fill="#27272A" stroke="#A1A1AA" stroke-width="2" stroke-dasharray="8 7"/>
-    <text x="338" y="199" font-size="14" font-weight="700" fill="#A1A1AA" text-anchor="middle">LOCAL AGENTS</text>
-    <text x="338" y="226" font-size="18" font-weight="650" fill="#F4F4F5" text-anchor="middle">Claude Code · Codex · OpenCode · Hermes Agent</text>
-    <path d="M338 242V267H212V286" fill="none" stroke="#A1A1AA" stroke-width="3" marker-end="url(#arrow-gray)"/>
-    <path d="M338 267H464V286" fill="none" stroke="#A1A1AA" stroke-width="3" marker-end="url(#arrow-gray)"/>
-
-    <rect x="99" y="292" width="226" height="74" rx="18" fill="#24140B" stroke="#FE750E" stroke-width="3"/>
-    <text x="212" y="337" font-size="20" font-weight="750" fill="#F4F4F5" text-anchor="middle">BROWSER USE CLI</text>
-    <rect x="351" y="292" width="226" height="74" rx="18" fill="#17171A" stroke="#A1A1AA" stroke-width="3"/>
-    <text x="464" y="318" font-size="13" font-weight="700" fill="#A1A1AA" text-anchor="middle">OTHER COMPUTER-USE CLIs</text>
-    <text x="464" y="344" font-size="14" font-weight="650" fill="#F4F4F5" text-anchor="middle">Playwright CLI · Agent Browser</text>
-
-    <path d="M212 366V404M464 366V404M212 404H464M338 404V440" fill="none" stroke="#A1A1AA" stroke-width="3" marker-end="url(#arrow-gray)"/>
-    <text x="309" y="429" font-size="13" font-weight="700" fill="#A1A1AA" text-anchor="end">LOCAL</text>
-    <rect x="190" y="446" width="296" height="106" rx="20" fill="#17171A" stroke="#A1A1AA" stroke-width="3"/>
-    <path d="M190 478H486" stroke="#52525B" stroke-width="2"/>
-    <circle cx="212" cy="462" r="5" fill="#FF5F57"/><circle cx="230" cy="462" r="5" fill="#FEBC2E"/><circle cx="248" cy="462" r="5" fill="#28C840"/>
-    <text x="338" y="512" font-size="22" font-weight="750" fill="#F4F4F5" text-anchor="middle">REAL CHROME</text>
-    <text x="338" y="538" font-size="15" fill="#A1A1AA" text-anchor="middle">your tabs · cookies · logins</text>
-    <path d="M78 638H598L632 672H44Z" fill="#27272A" stroke="#52525B" stroke-width="3" stroke-linejoin="round"/>
-    <path d="M263 654H413" stroke="#71717A" stroke-width="4" stroke-linecap="round"/>
-
-    <rect x="686" y="52" width="486" height="620" rx="28" fill="#17100B" stroke="#FE750E" stroke-width="3"/>
-    <text x="929" y="91" font-size="26" font-weight="750" fill="#F4F4F5" text-anchor="middle">OUR CLOUD</text>
-    <rect x="716" y="112" width="426" height="404" rx="24" fill="#111113" stroke="#FE750E" stroke-width="2"/>
-    <text x="929" y="148" font-size="17" font-weight="800" fill="#FEA35F" text-anchor="middle">CLOUD V4 API</text>
-    <rect x="748" y="172" width="164" height="68" rx="17" fill="#27272A" stroke="#A1A1AA" stroke-width="2" stroke-dasharray="8 7"/>
-    <text x="830" y="214" font-size="20" font-weight="750" fill="#F4F4F5" text-anchor="middle">OPENCODE</text>
-    <rect x="946" y="172" width="164" height="68" rx="17" fill="#24140B" stroke="#FE750E" stroke-width="3"/>
-    <text x="1028" y="199" font-size="13" font-weight="700" fill="#FEA35F" text-anchor="middle">SAME LEVEL</text>
-    <text x="1028" y="222" font-size="16" font-weight="750" fill="#F4F4F5" text-anchor="middle">BROWSER USE CLI</text>
-    <path d="M830 240V277M1028 240V277M830 277H1028M929 277V326" fill="none" stroke="#FE750E" stroke-width="3" marker-end="url(#arrow-orange)"/>
-
-    <rect x="794" y="332" width="270" height="126" rx="22" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
-    <path d="M794 367H1064" stroke="#7C3A0B" stroke-width="2"/>
-    <circle cx="816" cy="349" r="5" fill="#FF5F57"/><circle cx="834" cy="349" r="5" fill="#FEBC2E"/><circle cx="852" cy="349" r="5" fill="#28C840"/>
-    <text x="929" y="410" font-size="23" font-weight="800" fill="#F4F4F5" text-anchor="middle">CLOUD BROWSER</text>
-    <text x="929" y="438" font-size="15" fill="#FEA35F" text-anchor="middle">stealth · profiles · proxies</text>
-
-    <path d="M464 404H666V602H814" fill="none" stroke="#FE750E" stroke-width="4" marker-end="url(#arrow-orange)"/>
-    <text x="646" y="390" font-size="13" font-weight="800" fill="#FEA35F" text-anchor="end">OR CLOUD</text>
-    <rect x="820" y="566" width="218" height="74" rx="19" fill="#24140B" stroke="#FE750E" stroke-width="3"/>
-    <text x="929" y="596" font-size="20" font-weight="800" fill="#F4F4F5" text-anchor="middle">BROWSER API</text>
-    <text x="929" y="621" font-size="14" fill="#FEA35F" text-anchor="middle">browser only</text>
-    <path d="M929 566V464" fill="none" stroke="#FE750E" stroke-width="4" marker-end="url(#arrow-orange)"/>
+    <text x="300" y="43" fill="#F4F4F5" font-size="25" font-weight="750" text-anchor="middle">YOUR COMPUTER</text>
+    <rect x="30" y="64" width="540" height="78" rx="17" fill="#27272A" stroke="#A1A1AA" stroke-width="3"/>
+    <text x="300" y="94" fill="#A1A1AA" font-size="13" font-weight="750" text-anchor="middle">LOCAL AGENTS</text>
+    <text x="300" y="121" fill="#F4F4F5" font-size="18" font-weight="650" text-anchor="middle">Claude Code · Codex · OpenCode · Hermes Agent</text>
+    <rect x="30" y="184" width="252" height="78" rx="17" fill="#24140B" stroke="#FE750E" stroke-width="3"/>
+    <text x="156" y="230" fill="#F4F4F5" font-size="19" font-weight="750" text-anchor="middle">BROWSER USE CLI</text>
+    <rect x="318" y="184" width="252" height="78" rx="17" fill="#27272A" stroke="#A1A1AA" stroke-width="3"/>
+    <text x="444" y="230" fill="#F4F4F5" font-size="19" font-weight="750" text-anchor="middle">PLAYWRIGHT CLI</text>
+    <path d="M156 262V310H300M444 262V310H300V392" fill="none" stroke="#A1A1AA" stroke-width="3" marker-end="url(#gray-arrow)"/>
+    <text x="269" y="365" fill="#A1A1AA" font-size="13" font-weight="800" text-anchor="end">LOCAL</text>
+    <rect x="165" y="402" width="270" height="118" rx="20" fill="#17171A" stroke="#A1A1AA" stroke-width="3"/>
+    <path d="M165 437H435" stroke="#52525B" stroke-width="2"/>
+    <circle cx="188" cy="420" r="5" fill="#FF5F57"/><circle cx="206" cy="420" r="5" fill="#FEBC2E"/><circle cx="224" cy="420" r="5" fill="#28C840"/>
+    <text x="300" y="478" fill="#F4F4F5" font-size="22" font-weight="800" text-anchor="middle">REAL CHROME</text>
+    <text x="300" y="502" fill="#A1A1AA" font-size="14" text-anchor="middle">your tabs · cookies · logins</text>
+    <rect x="635" y="30" width="535" height="640" rx="27" fill="#17100B" stroke="#FE750E" stroke-width="3"/>
+    <text x="902" y="75" fill="#F4F4F5" font-size="25" font-weight="750" text-anchor="middle">OUR CLOUD</text>
+    <text x="902" y="102" fill="#FEA35F" font-size="15" font-weight="800" text-anchor="middle">CLOUD V4 API</text>
+    <rect x="675" y="132" width="210" height="78" rx="17" fill="#27272A" stroke="#A1A1AA" stroke-width="3"/>
+    <text x="780" y="178" fill="#F4F4F5" font-size="19" font-weight="750" text-anchor="middle">OPENCODE</text>
+    <rect x="920" y="132" width="210" height="78" rx="17" fill="#24140B" stroke="#FE750E" stroke-width="3"/>
+    <text x="1025" y="178" fill="#F4F4F5" font-size="19" font-weight="750" text-anchor="middle">BROWSER USE CLI</text>
+    <path d="M780 210V307H902M1025 210V307H902V382" fill="none" stroke="#FE750E" stroke-width="3" marker-end="url(#orange-arrow)"/>
+    <rect x="767" y="392" width="270" height="118" rx="20" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
+    <text x="902" y="448" fill="#F4F4F5" font-size="22" font-weight="800" text-anchor="middle">CLOUD BROWSER</text>
+    <text x="902" y="476" fill="#FEA35F" font-size="14" text-anchor="middle">stealth · profiles · proxies</text>
+    <path d="M444 262V325H610V451H757" fill="none" stroke="#FE750E" stroke-width="4" marker-end="url(#orange-arrow)"/>
+    <text x="601" y="309" fill="#FEA35F" font-size="13" font-weight="800" text-anchor="end">CLOUD</text>
   </g>
 </svg>

--- a/docs/cloud/images/which-product-dark.svg
+++ b/docs/cloud/images/which-product-dark.svg
@@ -20,7 +20,10 @@
     <rect x="320" y="255" width="260" height="80" rx="30" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
     <path d="M680 240 C640 240 630 180 690 175 C690 120 790 100 815 150 C850 110 940 120 935 180 C1000 175 1010 240 960 250 L700 250 Z" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
     <rect x="700" y="285" width="460" height="88" rx="30" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
-    <rect x="700" y="390" width="460" height="80" rx="30" fill="#111113" stroke="#A1A1AA" stroke-width="4" stroke-dasharray="16 12"/>
+    <rect x="700" y="390" width="185" height="80" rx="30" fill="#111113" stroke="#A1A1AA" stroke-width="4" stroke-dasharray="16 12"/>
+    <path d="M890 430 C905 423 905 437 920 430" stroke="#A1A1AA" stroke-width="4"/>
+    <path d="M905 416 L920 430 L905 444" stroke="#A1A1AA" stroke-width="4"/>
+    <rect x="925" y="390" width="235" height="80" rx="30" fill="#23170F" stroke="#FE750E" stroke-width="4"/>
   </g>
   <g font-family="Virgil, Comic Sans MS, cursive">
     <text x="320" y="110" font-size="30" fill="#A1A1AA" text-anchor="middle">YOUR MACHINE</text>
@@ -33,7 +36,9 @@
     <text x="815" y="205" font-size="34" fill="#F4F4F5" text-anchor="middle">OUR CLOUD</text>
     <text x="930" y="322" font-size="24" fill="#F4F4F5" text-anchor="middle">FULLY HOSTED AGENT = V4</text>
     <text x="930" y="352" font-size="19" fill="#A1A1AA" text-anchor="middle">send a prompt, get the result back</text>
-    <text x="930" y="424" font-size="24" fill="#F4F4F5" text-anchor="middle">ONLY THE BROWSER</text>
-    <text x="930" y="452" font-size="19" fill="#A1A1AA" text-anchor="middle">your own agent, over CDP</text>
+    <text x="792" y="424" font-size="21" fill="#F4F4F5" text-anchor="middle">YOUR AGENT</text>
+    <text x="792" y="451" font-size="16" fill="#A1A1AA" text-anchor="middle">anywhere</text>
+    <text x="1042" y="424" font-size="21" fill="#F4F4F5" text-anchor="middle">BROWSER API</text>
+    <text x="1042" y="451" font-size="16" fill="#A1A1AA" text-anchor="middle">only our browser</text>
   </g>
 </svg>

--- a/docs/cloud/images/which-product-dark.svg
+++ b/docs/cloud/images/which-product-dark.svg
@@ -23,13 +23,13 @@
   </g>
   <g font-family="Virgil, Comic Sans MS, cursive">
     <text x="210" y="150" font-size="40" fill="#F4F4F5" text-anchor="middle">YOUR AGENT</text>
-    <text x="210" y="200" font-size="22" fill="#A1A1AA" text-anchor="middle">codex · claude code · hermes</text>
+    <text x="210" y="200" font-size="20" fill="#A1A1AA" text-anchor="middle">codex · claude code · hermes</text>
     <text x="600" y="150" font-size="40" fill="#F4F4F5" text-anchor="middle">BROWSER USE CLI</text>
     <text x="600" y="200" font-size="22" fill="#A1A1AA" text-anchor="middle">the harness your agent runs</text>
     <text x="990" y="150" font-size="40" fill="#F4F4F5" text-anchor="middle">BROWSER</text>
-    <text x="990" y="200" font-size="22" fill="#A1A1AA" text-anchor="middle">your chrome · our cloud browser</text>
+    <text x="990" y="200" font-size="20" fill="#A1A1AA" text-anchor="middle">your chrome · our cloud browser</text>
     <text x="600" y="350" font-size="30" fill="#FE750E" text-anchor="middle">ALL THREE, HOSTED = CLOUD V4 (one API call)</text>
-    <text x="410" y="425" font-size="26" fill="#A1A1AA" text-anchor="middle">YOUR AGENT + OUR CLI + ANY BROWSER = CLI</text>
-    <text x="990" y="425" font-size="26" fill="#A1A1AA" text-anchor="middle">ONLY THE BROWSER = BROWSER API</text>
+    <text x="410" y="425" font-size="24" fill="#A1A1AA" text-anchor="middle">YOUR AGENT + OUR CLI + ANY BROWSER = CLI</text>
+    <text x="990" y="425" font-size="21" fill="#A1A1AA" text-anchor="middle">BROWSER ONLY = BROWSER API</text>
   </g>
 </svg>

--- a/docs/cloud/images/which-product-dark.svg
+++ b/docs/cloud/images/which-product-dark.svg
@@ -1,35 +1,39 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="460" viewBox="0 0 1200 460" role="img" aria-labelledby="title desc">
-  <title id="title">Three parts of Browser Use</title>
-  <desc id="desc">Your agent, the Browser Use CLI, and a browser. Take all three hosted as Cloud v4, bring your own agent with our CLI, or take only the browser.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="500" viewBox="0 0 1200 500" role="img" aria-labelledby="title desc">
+  <title id="title">Which Browser Use do I need</title>
+  <desc id="desc">On your machine: Claude Code or Codex run the Browser Use CLI against your own Chrome or one of our cloud browsers. In our cloud: the fully hosted agent you send a prompt to, or just a browser for your own agent.</desc>
   <defs>
     <filter id="rough">
       <feTurbulence type="fractalNoise" baseFrequency=".01" numOctaves="2" seed="7" result="noise"/>
       <feDisplacementMap in="SourceGraphic" in2="noise" scale="1.4"/>
     </filter>
   </defs>
-  <rect width="1200" height="460" fill="#09090B"/>
-  <rect x="20" y="20" width="1160" height="420" fill="none" stroke="#27272A" stroke-width="2"/>
+  <rect width="1200" height="500" fill="#09090B"/>
+  <rect x="20" y="20" width="1160" height="460" fill="none" stroke="#27272A" stroke-width="2"/>
   <g fill="none" stroke-linecap="round" stroke-linejoin="round" filter="url(#rough)">
-    <rect x="60" y="90" width="300" height="150" rx="30" fill="#111113" stroke="#A1A1AA" stroke-width="4" stroke-dasharray="16 12"/>
-    <path d="M365 165 C402 157 418 173 445 165" stroke="#A1A1AA" stroke-width="4"/>
-    <path d="M423 150 L445 165 L423 182" stroke="#A1A1AA" stroke-width="4"/>
-    <rect x="450" y="90" width="300" height="150" rx="30" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
-    <path d="M755 165 C792 157 808 173 835 165" stroke="#A1A1AA" stroke-width="4"/>
-    <path d="M813 150 L835 165 L813 182" stroke="#A1A1AA" stroke-width="4"/>
-    <rect x="840" y="90" width="300" height="150" rx="30" fill="#111113" stroke="#A1A1AA" stroke-width="4" stroke-dasharray="16 12"/>
-    <path d="M70 290 L70 320 L1130 320 L1130 290" stroke="#FE750E" stroke-width="4"/>
-    <path d="M70 360 L70 390 L750 390 L750 360" stroke="#A1A1AA" stroke-width="4"/>
-    <path d="M850 360 L850 390 L1130 390 L1130 360" stroke="#A1A1AA" stroke-width="4"/>
+    <rect x="40" y="70" width="560" height="300" rx="22" fill="#111113" stroke="#A1A1AA" stroke-width="4"/>
+    <path d="M20 370 L620 370 L600 405 L40 405 Z" fill="#111113" stroke="#A1A1AA" stroke-width="4"/>
+    <rect x="70" y="130" width="200" height="90" rx="30" fill="#111113" stroke="#A1A1AA" stroke-width="4" stroke-dasharray="16 12"/>
+    <path d="M275 175 C300 167 292 183 315 175" stroke="#A1A1AA" stroke-width="4"/>
+    <path d="M293 160 L315 175 L293 192" stroke="#A1A1AA" stroke-width="4"/>
+    <rect x="320" y="130" width="260" height="90" rx="30" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
+    <rect x="70" y="255" width="200" height="80" rx="30" fill="#111113" stroke="#A1A1AA" stroke-width="4" stroke-dasharray="16 12"/>
+    <rect x="320" y="255" width="260" height="80" rx="30" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
+    <path d="M680 240 C640 240 630 180 690 175 C690 120 790 100 815 150 C850 110 940 120 935 180 C1000 175 1010 240 960 250 L700 250 Z" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
+    <rect x="700" y="285" width="460" height="88" rx="30" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
+    <rect x="700" y="390" width="460" height="80" rx="30" fill="#111113" stroke="#A1A1AA" stroke-width="4" stroke-dasharray="16 12"/>
   </g>
   <g font-family="Virgil, Comic Sans MS, cursive">
-    <text x="210" y="150" font-size="40" fill="#F4F4F5" text-anchor="middle">YOUR AGENT</text>
-    <text x="210" y="200" font-size="20" fill="#A1A1AA" text-anchor="middle">codex · claude code · hermes</text>
-    <text x="600" y="150" font-size="40" fill="#F4F4F5" text-anchor="middle">BROWSER USE CLI</text>
-    <text x="600" y="200" font-size="22" fill="#A1A1AA" text-anchor="middle">the harness your agent runs</text>
-    <text x="990" y="150" font-size="40" fill="#F4F4F5" text-anchor="middle">BROWSER</text>
-    <text x="990" y="200" font-size="20" fill="#A1A1AA" text-anchor="middle">your chrome · our cloud browser</text>
-    <text x="600" y="350" font-size="30" fill="#FE750E" text-anchor="middle">ALL THREE, HOSTED = CLOUD V4 (one API call)</text>
-    <text x="410" y="425" font-size="24" fill="#A1A1AA" text-anchor="middle">YOUR AGENT + OUR CLI + ANY BROWSER = CLI</text>
-    <text x="990" y="425" font-size="21" fill="#A1A1AA" text-anchor="middle">BROWSER ONLY = BROWSER API</text>
+    <text x="320" y="110" font-size="30" fill="#A1A1AA" text-anchor="middle">YOUR MACHINE</text>
+    <text x="170" y="172" font-size="25" fill="#F4F4F5" text-anchor="middle">YOUR AGENT</text>
+    <text x="170" y="200" font-size="18" fill="#A1A1AA" text-anchor="middle">claude code · codex</text>
+    <text x="450" y="185" font-size="24" fill="#F4F4F5" text-anchor="middle">BROWSER USE CLI</text>
+    <text x="170" y="303" font-size="24" fill="#F4F4F5" text-anchor="middle">YOUR CHROME</text>
+    <text x="450" y="303" font-size="22" fill="#F4F4F5" text-anchor="middle">OUR CLOUD BROWSER</text>
+    <text x="320" y="358" font-size="20" fill="#A1A1AA" text-anchor="middle">pick either browser</text>
+    <text x="815" y="205" font-size="34" fill="#F4F4F5" text-anchor="middle">OUR CLOUD</text>
+    <text x="930" y="322" font-size="24" fill="#F4F4F5" text-anchor="middle">FULLY HOSTED AGENT = V4</text>
+    <text x="930" y="352" font-size="19" fill="#A1A1AA" text-anchor="middle">send a prompt, get the result back</text>
+    <text x="930" y="424" font-size="24" fill="#F4F4F5" text-anchor="middle">ONLY THE BROWSER</text>
+    <text x="930" y="452" font-size="19" fill="#A1A1AA" text-anchor="middle">your own agent, over CDP</text>
   </g>
 </svg>

--- a/docs/cloud/images/which-product-dark.svg
+++ b/docs/cloud/images/which-product-dark.svg
@@ -1,48 +1,66 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="620" viewBox="0 0 1200 620" role="img" aria-labelledby="title desc">
-  <title id="title">Where each Browser Use part runs</title>
-  <desc id="desc">Claude Code or Codex use Browser Use CLI on your machine. The CLI drives real Chrome locally or connects to the single Cloud Browser in our cloud. OpenCode and Browser Use CLI also run beside Cloud Browser as the fully hosted stack. Your own agent can connect directly through the Browser API.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="700" viewBox="0 0 1200 700" role="img" aria-labelledby="title desc">
+  <title id="title">Choose a local or cloud Browser Use setup</title>
+  <desc id="desc">On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or connect through Browser API to the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI at the same level above that Cloud Browser. Browser API is the browser-only route.</desc>
   <defs>
-    <filter id="rough"><feTurbulence type="fractalNoise" baseFrequency=".012" numOctaves="2" seed="7" result="noise"/><feDisplacementMap in="SourceGraphic" in2="noise" scale="1.2"/></filter>
     <marker id="arrow-orange" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#FE750E"/></marker>
     <marker id="arrow-gray" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#A1A1AA"/></marker>
   </defs>
-  <rect width="1200" height="620" fill="#09090B"/>
-  <g filter="url(#rough)" font-family="Virgil, Comic Sans MS, cursive">
-    <rect x="28" y="28" width="556" height="564" rx="30" fill="#111113" stroke="#52525B" stroke-width="3"/>
-    <rect x="616" y="28" width="556" height="564" rx="30" fill="#17100B" stroke="#FE750E" stroke-width="3"/>
-    <text x="306" y="77" font-size="30" fill="#F4F4F5" text-anchor="middle">YOUR MACHINE</text>
-    <text x="894" y="77" font-size="30" fill="#F4F4F5" text-anchor="middle">OUR CLOUD</text>
-    <rect x="66" y="112" width="214" height="78" rx="24" fill="#17171A" stroke="#A1A1AA" stroke-width="3" stroke-dasharray="13 10"/>
-    <text x="173" y="145" font-size="22" fill="#F4F4F5" text-anchor="middle">YOUR AGENT</text>
-    <text x="173" y="173" font-size="16" fill="#A1A1AA" text-anchor="middle">Claude Code · Codex</text>
-    <rect x="330" y="112" width="216" height="78" rx="24" fill="#24140B" stroke="#FE750E" stroke-width="3"/>
-    <text x="438" y="160" font-size="21" fill="#F4F4F5" text-anchor="middle">BROWSER USE CLI</text>
-    <path d="M280 151H324" fill="none" stroke="#A1A1AA" stroke-width="4" marker-end="url(#arrow-gray)"/>
-    <rect x="126" y="274" width="360" height="136" rx="26" fill="#17171A" stroke="#A1A1AA" stroke-width="3"/>
-    <circle cx="156" cy="302" r="6" fill="#FF5F57"/><circle cx="177" cy="302" r="6" fill="#FEBC2E"/><circle cx="198" cy="302" r="6" fill="#28C840"/>
-    <text x="306" y="348" font-size="24" fill="#F4F4F5" text-anchor="middle">REAL CHROME</text>
-    <text x="306" y="382" font-size="17" fill="#A1A1AA" text-anchor="middle">tabs · cookies · logins</text>
-    <path d="M438 190V236H306V268" fill="none" stroke="#A1A1AA" stroke-width="4" marker-end="url(#arrow-gray)"/>
-    <rect x="672" y="112" width="174" height="76" rx="24" fill="#17171A" stroke="#A1A1AA" stroke-width="3" stroke-dasharray="13 10"/>
-    <text x="759" y="159" font-size="22" fill="#F4F4F5" text-anchor="middle">OPENCODE</text>
-    <rect x="896" y="112" width="222" height="76" rx="24" fill="#24140B" stroke="#FE750E" stroke-width="3"/>
-    <text x="1007" y="159" font-size="20" fill="#F4F4F5" text-anchor="middle">BROWSER USE CLI</text>
-    <path d="M846 150H890" fill="none" stroke="#FE750E" stroke-width="4" marker-end="url(#arrow-orange)"/>
-    <rect x="760" y="274" width="268" height="136" rx="28" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
-    <circle cx="790" cy="302" r="6" fill="#FF5F57"/><circle cx="811" cy="302" r="6" fill="#FEBC2E"/><circle cx="832" cy="302" r="6" fill="#28C840"/>
-    <text x="894" y="348" font-size="25" fill="#F4F4F5" text-anchor="middle">CLOUD BROWSER</text>
-    <text x="894" y="382" font-size="17" fill="#FEA35F" text-anchor="middle">stealth · profiles · proxies</text>
-    <path d="M1007 188V232H894V268" fill="none" stroke="#FE750E" stroke-width="4" marker-end="url(#arrow-orange)"/>
-    <path d="M438 190V224H650V342H754" fill="none" stroke="#FE750E" stroke-width="4" marker-end="url(#arrow-orange)"/>
-    <text x="608" y="214" font-size="16" fill="#FEA35F" text-anchor="middle">or connect to our cloud</text>
-    <rect x="672" y="474" width="174" height="72" rx="22" fill="#17171A" stroke="#A1A1AA" stroke-width="3" stroke-dasharray="13 10"/>
-    <text x="759" y="505" font-size="19" fill="#F4F4F5" text-anchor="middle">YOUR AGENT</text>
-    <text x="759" y="530" font-size="15" fill="#A1A1AA" text-anchor="middle">anywhere</text>
-    <rect x="896" y="474" width="222" height="72" rx="22" fill="#17100B" stroke="#FE750E" stroke-width="3"/>
-    <text x="1007" y="518" font-size="20" fill="#F4F4F5" text-anchor="middle">BROWSER API</text>
-    <path d="M846 510H890" fill="none" stroke="#A1A1AA" stroke-width="4" marker-end="url(#arrow-gray)"/>
-    <path d="M1007 474V440H894V416" fill="none" stroke="#FE750E" stroke-width="4" marker-end="url(#arrow-orange)"/>
-    <text x="306" y="558" font-size="18" fill="#A1A1AA" text-anchor="middle">CLI + local Chrome</text>
-    <text x="894" y="558" font-size="18" fill="#FEA35F" text-anchor="middle">hosted stack or browser only</text>
+  <rect width="1200" height="700" fill="#09090B"/>
+  <g font-family="Inter, ui-sans-serif, system-ui, sans-serif">
+    <text x="338" y="39" font-size="26" font-weight="750" fill="#F4F4F5" text-anchor="middle">YOUR COMPUTER</text>
+    <rect x="28" y="52" width="620" height="586" rx="28" fill="#27272A" stroke="#52525B" stroke-width="3"/>
+    <circle cx="338" cy="68" r="4" fill="#71717A"/>
+    <rect x="50" y="78" width="576" height="536" rx="17" fill="#111113" stroke="#52525B" stroke-width="2"/>
+    <rect x="74" y="102" width="528" height="486" rx="15" fill="#17171A" stroke="#52525B" stroke-width="2"/>
+    <path d="M74 149H602" stroke="#52525B" stroke-width="2"/>
+    <circle cx="96" cy="126" r="6" fill="#FF5F57"/><circle cx="117" cy="126" r="6" fill="#FEBC2E"/><circle cx="138" cy="126" r="6" fill="#28C840"/>
+    <rect x="168" y="115" width="394" height="23" rx="11" fill="#27272A"/>
+    <text x="365" y="132" font-size="13" fill="#A1A1AA" text-anchor="middle">local</text>
+
+    <rect x="99" y="174" width="478" height="68" rx="18" fill="#27272A" stroke="#A1A1AA" stroke-width="2" stroke-dasharray="8 7"/>
+    <text x="338" y="199" font-size="14" font-weight="700" fill="#A1A1AA" text-anchor="middle">LOCAL AGENTS</text>
+    <text x="338" y="226" font-size="18" font-weight="650" fill="#F4F4F5" text-anchor="middle">Claude Code · Codex · OpenCode · Hermes Agent</text>
+    <path d="M338 242V267H212V286" fill="none" stroke="#A1A1AA" stroke-width="3" marker-end="url(#arrow-gray)"/>
+    <path d="M338 267H464V286" fill="none" stroke="#A1A1AA" stroke-width="3" marker-end="url(#arrow-gray)"/>
+
+    <rect x="99" y="292" width="226" height="74" rx="18" fill="#24140B" stroke="#FE750E" stroke-width="3"/>
+    <text x="212" y="337" font-size="20" font-weight="750" fill="#F4F4F5" text-anchor="middle">BROWSER USE CLI</text>
+    <rect x="351" y="292" width="226" height="74" rx="18" fill="#17171A" stroke="#A1A1AA" stroke-width="3"/>
+    <text x="464" y="318" font-size="13" font-weight="700" fill="#A1A1AA" text-anchor="middle">OTHER COMPUTER-USE CLIs</text>
+    <text x="464" y="344" font-size="14" font-weight="650" fill="#F4F4F5" text-anchor="middle">Playwright CLI · Agent Browser</text>
+
+    <path d="M212 366V404M464 366V404M212 404H464M338 404V440" fill="none" stroke="#A1A1AA" stroke-width="3" marker-end="url(#arrow-gray)"/>
+    <text x="309" y="429" font-size="13" font-weight="700" fill="#A1A1AA" text-anchor="end">LOCAL</text>
+    <rect x="190" y="446" width="296" height="106" rx="20" fill="#17171A" stroke="#A1A1AA" stroke-width="3"/>
+    <path d="M190 478H486" stroke="#52525B" stroke-width="2"/>
+    <circle cx="212" cy="462" r="5" fill="#FF5F57"/><circle cx="230" cy="462" r="5" fill="#FEBC2E"/><circle cx="248" cy="462" r="5" fill="#28C840"/>
+    <text x="338" y="512" font-size="22" font-weight="750" fill="#F4F4F5" text-anchor="middle">REAL CHROME</text>
+    <text x="338" y="538" font-size="15" fill="#A1A1AA" text-anchor="middle">your tabs · cookies · logins</text>
+    <path d="M78 638H598L632 672H44Z" fill="#27272A" stroke="#52525B" stroke-width="3" stroke-linejoin="round"/>
+    <path d="M263 654H413" stroke="#71717A" stroke-width="4" stroke-linecap="round"/>
+
+    <rect x="686" y="52" width="486" height="620" rx="28" fill="#17100B" stroke="#FE750E" stroke-width="3"/>
+    <text x="929" y="91" font-size="26" font-weight="750" fill="#F4F4F5" text-anchor="middle">OUR CLOUD</text>
+    <rect x="716" y="112" width="426" height="404" rx="24" fill="#111113" stroke="#FE750E" stroke-width="2"/>
+    <text x="929" y="148" font-size="17" font-weight="800" fill="#FEA35F" text-anchor="middle">CLOUD V4 API</text>
+    <rect x="748" y="172" width="164" height="68" rx="17" fill="#27272A" stroke="#A1A1AA" stroke-width="2" stroke-dasharray="8 7"/>
+    <text x="830" y="214" font-size="20" font-weight="750" fill="#F4F4F5" text-anchor="middle">OPENCODE</text>
+    <rect x="946" y="172" width="164" height="68" rx="17" fill="#24140B" stroke="#FE750E" stroke-width="3"/>
+    <text x="1028" y="199" font-size="13" font-weight="700" fill="#FEA35F" text-anchor="middle">SAME LEVEL</text>
+    <text x="1028" y="222" font-size="16" font-weight="750" fill="#F4F4F5" text-anchor="middle">BROWSER USE CLI</text>
+    <path d="M830 240V277M1028 240V277M830 277H1028M929 277V326" fill="none" stroke="#FE750E" stroke-width="3" marker-end="url(#arrow-orange)"/>
+
+    <rect x="794" y="332" width="270" height="126" rx="22" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
+    <path d="M794 367H1064" stroke="#7C3A0B" stroke-width="2"/>
+    <circle cx="816" cy="349" r="5" fill="#FF5F57"/><circle cx="834" cy="349" r="5" fill="#FEBC2E"/><circle cx="852" cy="349" r="5" fill="#28C840"/>
+    <text x="929" y="410" font-size="23" font-weight="800" fill="#F4F4F5" text-anchor="middle">CLOUD BROWSER</text>
+    <text x="929" y="438" font-size="15" fill="#FEA35F" text-anchor="middle">stealth · profiles · proxies</text>
+
+    <path d="M464 404H666V602H814" fill="none" stroke="#FE750E" stroke-width="4" marker-end="url(#arrow-orange)"/>
+    <text x="646" y="390" font-size="13" font-weight="800" fill="#FEA35F" text-anchor="end">OR CLOUD</text>
+    <rect x="820" y="566" width="218" height="74" rx="19" fill="#24140B" stroke="#FE750E" stroke-width="3"/>
+    <text x="929" y="596" font-size="20" font-weight="800" fill="#F4F4F5" text-anchor="middle">BROWSER API</text>
+    <text x="929" y="621" font-size="14" fill="#FEA35F" text-anchor="middle">browser only</text>
+    <path d="M929 566V464" fill="none" stroke="#FE750E" stroke-width="4" marker-end="url(#arrow-orange)"/>
   </g>
 </svg>

--- a/docs/cloud/images/which-product-dark.svg
+++ b/docs/cloud/images/which-product-dark.svg
@@ -1,39 +1,51 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="700" viewBox="0 0 1200 700" role="img" aria-labelledby="title desc">
-  <title id="title">Choose local Chrome or the Browser Use cloud</title>
-  <desc id="desc">On your computer, local agents sit above matching Browser Use CLI and Playwright CLI boxes. The CLIs choose one local path to real Chrome or one cloud path directly to Cloud Browser. In Cloud V4, matching OpenCode and Browser Use CLI boxes run above that Cloud Browser.</desc>
-  <defs>
-    <marker id="orange-arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#FE750E"/></marker>
-    <marker id="gray-arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#A1A1AA"/></marker>
-  </defs>
-  <rect width="1200" height="700" fill="#09090B"/>
-  <g font-family="Inter, ui-sans-serif, system-ui, sans-serif">
-    <text x="300" y="43" fill="#F4F4F5" font-size="25" font-weight="750" text-anchor="middle">YOUR COMPUTER</text>
-    <rect x="30" y="64" width="540" height="78" rx="17" fill="#27272A" stroke="#A1A1AA" stroke-width="3"/>
-    <text x="300" y="94" fill="#A1A1AA" font-size="13" font-weight="750" text-anchor="middle">LOCAL AGENTS</text>
-    <text x="300" y="121" fill="#F4F4F5" font-size="18" font-weight="650" text-anchor="middle">Claude Code · Codex · OpenCode · Hermes Agent</text>
-    <rect x="30" y="184" width="252" height="78" rx="17" fill="#24140B" stroke="#FE750E" stroke-width="3"/>
-    <text x="156" y="230" fill="#F4F4F5" font-size="19" font-weight="750" text-anchor="middle">BROWSER USE CLI</text>
-    <rect x="318" y="184" width="252" height="78" rx="17" fill="#27272A" stroke="#A1A1AA" stroke-width="3"/>
-    <text x="444" y="230" fill="#F4F4F5" font-size="19" font-weight="750" text-anchor="middle">PLAYWRIGHT CLI</text>
-    <path d="M156 262V310H300M444 262V310H300V392" fill="none" stroke="#A1A1AA" stroke-width="3" marker-end="url(#gray-arrow)"/>
-    <text x="269" y="365" fill="#A1A1AA" font-size="13" font-weight="800" text-anchor="end">LOCAL</text>
-    <rect x="165" y="402" width="270" height="118" rx="20" fill="#17171A" stroke="#A1A1AA" stroke-width="3"/>
-    <path d="M165 437H435" stroke="#52525B" stroke-width="2"/>
-    <circle cx="188" cy="420" r="5" fill="#FF5F57"/><circle cx="206" cy="420" r="5" fill="#FEBC2E"/><circle cx="224" cy="420" r="5" fill="#28C840"/>
-    <text x="300" y="478" fill="#F4F4F5" font-size="22" font-weight="800" text-anchor="middle">REAL CHROME</text>
-    <text x="300" y="502" fill="#A1A1AA" font-size="14" text-anchor="middle">your tabs · cookies · logins</text>
-    <rect x="635" y="30" width="535" height="640" rx="27" fill="#17100B" stroke="#FE750E" stroke-width="3"/>
-    <text x="902" y="75" fill="#F4F4F5" font-size="25" font-weight="750" text-anchor="middle">OUR CLOUD</text>
-    <text x="902" y="102" fill="#FEA35F" font-size="15" font-weight="800" text-anchor="middle">CLOUD V4 API</text>
-    <rect x="675" y="132" width="210" height="78" rx="17" fill="#27272A" stroke="#A1A1AA" stroke-width="3"/>
-    <text x="780" y="178" fill="#F4F4F5" font-size="19" font-weight="750" text-anchor="middle">OPENCODE</text>
-    <rect x="920" y="132" width="210" height="78" rx="17" fill="#24140B" stroke="#FE750E" stroke-width="3"/>
-    <text x="1025" y="178" fill="#F4F4F5" font-size="19" font-weight="750" text-anchor="middle">BROWSER USE CLI</text>
-    <path d="M780 210V307H902M1025 210V307H902V382" fill="none" stroke="#FE750E" stroke-width="3" marker-end="url(#orange-arrow)"/>
-    <rect x="767" y="392" width="270" height="118" rx="20" fill="#24140B" stroke="#FE750E" stroke-width="4"/>
-    <text x="902" y="448" fill="#F4F4F5" font-size="22" font-weight="800" text-anchor="middle">CLOUD BROWSER</text>
-    <text x="902" y="476" fill="#FEA35F" font-size="14" text-anchor="middle">stealth · profiles · proxies</text>
-    <path d="M444 262V325H610V451H757" fill="none" stroke="#FE750E" stroke-width="4" marker-end="url(#orange-arrow)"/>
-    <text x="601" y="309" fill="#FEA35F" font-size="13" font-weight="800" text-anchor="end">CLOUD</text>
-  </g>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="674" viewBox="0 0 1200 674" role="img" aria-labelledby="title desc">
+<title id="title">Choose your agent, CLI and browser</title>
+<desc id="desc">Both columns share three aligned rows: agent, CLI, browser. On your computer, choose Claude Code, Codex, OpenCode or Hermes Agent, then Playwright CLI or Browser Use CLI. Both CLIs can use real Chrome or the single Cloud Browser in our cloud. Hosted V4 runs OpenCode, Browser Use CLI and that Cloud Browser. Profile Sync copies selected cookies from real Chrome to a cloud profile; it is a separate, explicit step. Send a prompt through the V4 API and get a result back.</desc>
+<defs><marker id="gray-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto"><path d="M0 0L7 3.5L0 7Z" fill="#A1A1AA"/></marker><marker id="orange-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto"><path d="M0 0L7 3.5L0 7Z" fill="#FFAA66"/></marker></defs>
+<rect width="1200" height="674" fill="#18181B"/><g font-family="Inter, ui-sans-serif, system-ui, sans-serif">
+<rect x="648" y="18" width="524" height="620" rx="17" fill="#29211B" stroke="#835733" stroke-width="2.5"/>
+<text x="298" y="62" fill="#FAFAFA" font-size="25" font-weight="750" text-anchor="middle">YOUR COMPUTER</text>
+<text x="298" y="91" fill="#C0C0C8" font-size="17" font-weight="450" text-anchor="middle">Choose each part</text>
+<text x="910" y="62" fill="#FAFAFA" font-size="25" font-weight="750" text-anchor="middle">OUR CLOUD</text>
+<text x="910" y="91" fill="#C0C0C8" font-size="17" font-weight="450" text-anchor="middle">Send a prompt, get a result</text>
+<rect x="48" y="128" width="500" height="96" rx="17" fill="#27272A" stroke="#A1A1AA" stroke-width="2.5"/>
+<text x="298" y="161" fill="#C0C0C8" font-size="14" font-weight="700" text-anchor="middle">YOUR AGENT</text>
+<text x="298" y="195" fill="#FAFAFA" font-size="18" font-weight="600" text-anchor="middle">Claude Code · Codex · OpenCode · Hermes Agent</text>
+<rect x="784" y="128" width="252" height="96" rx="17" fill="#27272A" stroke="#A1A1AA" stroke-width="2.5"/>
+<text x="910" y="184" fill="#FAFAFA" font-size="23" font-weight="750" text-anchor="middle">OpenCode</text>
+<path d="M298 224V245H167V270" fill="none" stroke="#A1A1AA" stroke-width="2.5" stroke-linejoin="round" marker-end="url(#gray-arrow)"/>
+<path d="M298 245H429V270" fill="none" stroke="#A1A1AA" stroke-width="2.5" stroke-linejoin="round" marker-end="url(#gray-arrow)"/>
+<path d="M910 224V270" fill="none" stroke="#A1A1AA" stroke-width="2.5" stroke-linejoin="round" marker-end="url(#gray-arrow)"/>
+<rect x="48" y="280" width="238" height="78" rx="17" fill="#27272A" stroke="#A1A1AA" stroke-width="2.5"/>
+<text x="167" y="327" fill="#FAFAFA" font-size="21" font-weight="750" text-anchor="middle">Playwright CLI</text>
+<rect x="310" y="280" width="238" height="78" rx="17" fill="#3A281A" stroke="#FFAA66" stroke-width="2.5"/>
+<text x="429" y="327" fill="#FAFAFA" font-size="21" font-weight="750" text-anchor="middle">Browser Use CLI</text>
+<rect x="784" y="280" width="252" height="78" rx="17" fill="#3A281A" stroke="#FFAA66" stroke-width="2.5"/>
+<text x="910" y="327" fill="#FAFAFA" font-size="21" font-weight="750" text-anchor="middle">Browser Use CLI</text>
+<path d="M167 358V395H429V358" fill="none" stroke="#A1A1AA" stroke-width="2.5" stroke-linejoin="round"/>
+<path d="M167 395V444" fill="none" stroke="#A1A1AA" stroke-width="2.5" marker-end="url(#gray-arrow)"/>
+<path d="M429 395V425H746V520H772" fill="none" stroke="#FFAA66" stroke-width="2.5" stroke-linejoin="round" marker-end="url(#orange-arrow)"/>
+<path d="M910 358V444" fill="none" stroke="#FFAA66" stroke-width="2.5" marker-end="url(#orange-arrow)"/>
+<circle cx="167" cy="395" r="4" fill="#A1A1AA"/>
+<circle cx="429" cy="395" r="4" fill="#FFAA66"/>
+<text x="125" y="423" fill="#C0C0C8" font-size="14" font-weight="750" text-anchor="middle">LOCAL</text>
+<text x="585" y="413" fill="#FFAA66" font-size="14" font-weight="750" text-anchor="middle">CLOUD</text>
+<rect x="41" y="454" width="252" height="124" rx="17" fill="#18181B" stroke="#A1A1AA" stroke-width="2.5"/>
+<path d="M41 481H293" fill="none" stroke="#A1A1AA" stroke-width="2.5" stroke-linejoin="round"/>
+<circle cx="55" cy="468" r="2.6" fill="#A1A1AA"/>
+<circle cx="65" cy="468" r="2.6" fill="#A1A1AA"/>
+<circle cx="75" cy="468" r="2.6" fill="#A1A1AA"/>
+<text x="167" y="525" fill="#FAFAFA" font-size="24" font-weight="750" text-anchor="middle">Real Chrome</text>
+<text x="167" y="553" fill="#C0C0C8" font-size="16" font-weight="450" text-anchor="middle">your tabs · cookies · logins</text>
+<rect x="784" y="454" width="252" height="124" rx="17" fill="#3A281A" stroke="#FFAA66" stroke-width="2.5"/>
+<path d="M784 481H1036" fill="none" stroke="#FFAA66" stroke-width="2.5" stroke-linejoin="round"/>
+<circle cx="798" cy="468" r="2.6" fill="#FFAA66"/>
+<circle cx="808" cy="468" r="2.6" fill="#FFAA66"/>
+<circle cx="818" cy="468" r="2.6" fill="#FFAA66"/>
+<text x="910" y="525" fill="#FAFAFA" font-size="24" font-weight="750" text-anchor="middle">Cloud Browser</text>
+<text x="910" y="553" fill="#C0C0C8" font-size="16" font-weight="450" text-anchor="middle">profiles · stealth · proxies</text>
+<path d="M305 561H772" fill="none" stroke="#A1A1AA" stroke-width="2.2" stroke-dasharray="7 6" marker-end="url(#gray-arrow)"/>
+<text x="538" y="587" fill="#C0C0C8" font-size="16" font-weight="600" text-anchor="middle">Profile Sync · cookies</text>
+<text x="910" y="613" fill="#FFAA66" font-size="17" font-weight="600" text-anchor="middle">Hosted V4 API</text>
+<text x="298" y="625" fill="#C0C0C8" font-size="17" font-weight="500" text-anchor="middle">Either CLI can control either browser.</text>
+</g></svg>

--- a/docs/cloud/images/which-product-light-mobile.svg
+++ b/docs/cloud/images/which-product-light-mobile.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="360" height="704" viewBox="0 0 360 704" role="img" aria-labelledby="title desc">
+<title id="title">Choose your agent, CLI and browser</title>
+<desc id="desc">Both columns share three aligned rows: agent, CLI, browser. On your computer, choose Claude Code, Codex, OpenCode or Hermes Agent, then Playwright CLI or Browser Use CLI. Both CLIs can use real Chrome or the single Cloud Browser in our cloud. Hosted V4 runs OpenCode, Browser Use CLI and that Cloud Browser. Profile Sync copies selected cookies from real Chrome to a cloud profile; it is a separate, explicit step. Send a prompt through the V4 API and get a result back.</desc>
+<defs><marker id="gray-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto"><path d="M0 0L7 3.5L0 7Z" fill="#71717A"/></marker><marker id="orange-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto"><path d="M0 0L7 3.5L0 7Z" fill="#C94D00"/></marker></defs>
+<rect width="360" height="704" fill="#FFFFFF"/><g font-family="Inter, ui-sans-serif, system-ui, sans-serif">
+<rect x="196" y="10" width="156" height="686" rx="12" fill="#FFF7ED" stroke="#F2C99E" stroke-width="1.7"/>
+<text x="90" y="39" fill="#242428" font-size="16" font-weight="750" text-anchor="middle">YOUR COMPUTER</text>
+<text x="90" y="63" fill="#606068" font-size="16" font-weight="450" text-anchor="middle">Choose each part</text>
+<text x="274" y="39" fill="#242428" font-size="16" font-weight="750" text-anchor="middle">OUR CLOUD</text>
+<text x="274" y="63" fill="#C94D00" font-size="16" font-weight="600" text-anchor="middle">Send a prompt.</text>
+<text x="274" y="84" fill="#606068" font-size="16" font-weight="450" text-anchor="middle">Get a result.</text>
+<rect x="8" y="95" width="166" height="128" rx="12" fill="#F4F4F5" stroke="#71717A" stroke-width="1.7"/>
+<text x="91" y="119" fill="#606068" font-size="16" font-weight="700" text-anchor="middle">YOUR AGENT</text>
+<text x="91" y="143" fill="#242428" font-size="16" font-weight="600" text-anchor="middle">Claude Code</text>
+<text x="91" y="165" fill="#242428" font-size="16" font-weight="600" text-anchor="middle">Codex · OpenCode</text>
+<text x="91" y="187" fill="#242428" font-size="16" font-weight="600" text-anchor="middle">Hermes Agent</text>
+<rect x="208" y="95" width="132" height="128" rx="12" fill="#F4F4F5" stroke="#71717A" stroke-width="1.7"/>
+<text x="274" y="166" fill="#242428" font-size="18" font-weight="750" text-anchor="middle">OpenCode</text>
+<path d="M91 223V253" fill="none" stroke="#71717A" stroke-width="2" stroke-linejoin="round" marker-end="url(#gray-arrow)"/>
+<path d="M274 223V253" fill="none" stroke="#71717A" stroke-width="2" stroke-linejoin="round" marker-end="url(#gray-arrow)"/>
+<rect x="8" y="263" width="166" height="92" rx="12" fill="#FFF0DF" stroke="#C94D00" stroke-width="1.7"/>
+<text x="91" y="292" fill="#242428" font-size="16" font-weight="750" text-anchor="middle">Playwright CLI</text>
+<text x="91" y="316" fill="#606068" font-size="16" font-weight="450" text-anchor="middle">or</text>
+<text x="91" y="340" fill="#242428" font-size="16" font-weight="600" text-anchor="middle">Browser Use CLI</text>
+<rect x="208" y="263" width="132" height="92" rx="12" fill="#FFF0DF" stroke="#C94D00" stroke-width="1.7"/>
+<text x="274" y="303" fill="#242428" font-size="16" font-weight="750" text-anchor="middle">Browser Use</text>
+<text x="274" y="326" fill="#242428" font-size="16" font-weight="750" text-anchor="middle">CLI</text>
+<path d="M50 355V379H132V355" fill="none" stroke="#71717A" stroke-width="2" stroke-linejoin="round"/>
+<path d="M50 379V406H87V425" fill="none" stroke="#71717A" stroke-width="2" stroke-linejoin="round" marker-end="url(#gray-arrow)"/>
+<path d="M132 379H183V489H202" fill="none" stroke="#C94D00" stroke-width="2" stroke-linejoin="round" marker-end="url(#orange-arrow)"/>
+<path d="M274 355V425" fill="none" stroke="#C94D00" stroke-width="2" marker-end="url(#orange-arrow)"/>
+<circle cx="50" cy="379" r="3" fill="#71717A"/>
+<circle cx="132" cy="379" r="3" fill="#C94D00"/>
+<rect x="18" y="435" width="138" height="108" rx="12" fill="#FFFFFF" stroke="#71717A" stroke-width="1.7"/>
+<path d="M18 462H156" fill="none" stroke="#71717A" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="32" cy="449" r="2.6" fill="#71717A"/>
+<circle cx="42" cy="449" r="2.6" fill="#71717A"/>
+<circle cx="52" cy="449" r="2.6" fill="#71717A"/>
+<text x="87" y="491" fill="#242428" font-size="16" font-weight="750" text-anchor="middle">Real Chrome</text>
+<text x="87" y="514" fill="#606068" font-size="16" font-weight="450" text-anchor="middle">your tabs,</text>
+<text x="87" y="532" fill="#606068" font-size="16" font-weight="450" text-anchor="middle">cookies, logins</text>
+<rect x="208" y="435" width="132" height="108" rx="12" fill="#FFF0DF" stroke="#C94D00" stroke-width="1.7"/>
+<path d="M208 462H340" fill="none" stroke="#C94D00" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="222" cy="449" r="2.6" fill="#C94D00"/>
+<circle cx="232" cy="449" r="2.6" fill="#C94D00"/>
+<circle cx="242" cy="449" r="2.6" fill="#C94D00"/>
+<text x="274" y="491" fill="#242428" font-size="16" font-weight="750" text-anchor="middle">Cloud Browser</text>
+<text x="274" y="514" fill="#606068" font-size="16" font-weight="450" text-anchor="middle">profiles, stealth,</text>
+<text x="274" y="532" fill="#606068" font-size="16" font-weight="450" text-anchor="middle">proxies</text>
+<path d="M87 543V573H274V553" fill="none" stroke="#71717A" stroke-width="2" stroke-dasharray="6 5" stroke-linejoin="round" marker-end="url(#gray-arrow)"/>
+<text x="182" y="599" fill="#606068" font-size="16" font-weight="600" text-anchor="middle">Profile Sync · cookies</text>
+<text x="89" y="651" fill="#606068" font-size="16" font-weight="600" text-anchor="middle">Both CLIs.</text>
+<text x="89" y="673" fill="#606068" font-size="16" font-weight="600" text-anchor="middle">Either browser.</text>
+<text x="274" y="651" fill="#C94D00" font-size="16" font-weight="600" text-anchor="middle">Hosted V4 API</text>
+</g></svg>

--- a/docs/cloud/images/which-product-light-mobile.svg
+++ b/docs/cloud/images/which-product-light-mobile.svg
@@ -48,6 +48,7 @@
 <text x="274" y="514" fill="#606068" font-size="16" font-weight="450" text-anchor="middle">profiles, stealth,</text>
 <text x="274" y="532" fill="#606068" font-size="16" font-weight="450" text-anchor="middle">proxies</text>
 <path d="M87 543V573H274V553" fill="none" stroke="#71717A" stroke-width="2" stroke-dasharray="6 5" stroke-linejoin="round" marker-end="url(#gray-arrow)"/>
+<rect x="80" y="580" width="204" height="26" rx="4" fill="#FFFFFF"/>
 <text x="182" y="599" fill="#606068" font-size="16" font-weight="600" text-anchor="middle">Profile Sync · cookies</text>
 <text x="89" y="651" fill="#606068" font-size="16" font-weight="600" text-anchor="middle">Both CLIs.</text>
 <text x="89" y="673" fill="#606068" font-size="16" font-weight="600" text-anchor="middle">Either browser.</text>

--- a/docs/cloud/images/which-product-light.svg
+++ b/docs/cloud/images/which-product-light.svg
@@ -1,48 +1,66 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="620" viewBox="0 0 1200 620" role="img" aria-labelledby="title desc">
-  <title id="title">Where each Browser Use part runs</title>
-  <desc id="desc">Claude Code or Codex use Browser Use CLI on your machine. The CLI drives real Chrome locally or connects to the single Cloud Browser in our cloud. OpenCode and Browser Use CLI also run beside Cloud Browser as the fully hosted stack. Your own agent can connect directly through the Browser API.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="700" viewBox="0 0 1200 700" role="img" aria-labelledby="title desc">
+  <title id="title">Choose a local or cloud Browser Use setup</title>
+  <desc id="desc">On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or connect through Browser API to the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI at the same level above that Cloud Browser. Browser API is the browser-only route.</desc>
   <defs>
-    <filter id="rough"><feTurbulence type="fractalNoise" baseFrequency=".012" numOctaves="2" seed="7" result="noise"/><feDisplacementMap in="SourceGraphic" in2="noise" scale="1.2"/></filter>
     <marker id="arrow-orange" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#E96505"/></marker>
     <marker id="arrow-gray" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#71717A"/></marker>
   </defs>
-  <rect width="1200" height="620" fill="#FFFFFF"/>
-  <g filter="url(#rough)" font-family="Virgil, Comic Sans MS, cursive">
-    <rect x="28" y="28" width="556" height="564" rx="30" fill="#FAFAFA" stroke="#A1A1AA" stroke-width="3"/>
-    <rect x="616" y="28" width="556" height="564" rx="30" fill="#FFF7ED" stroke="#E96505" stroke-width="3"/>
-    <text x="306" y="77" font-size="30" fill="#18181B" text-anchor="middle">YOUR MACHINE</text>
-    <text x="894" y="77" font-size="30" fill="#18181B" text-anchor="middle">OUR CLOUD</text>
-    <rect x="66" y="112" width="214" height="78" rx="24" fill="#FFFFFF" stroke="#71717A" stroke-width="3" stroke-dasharray="13 10"/>
-    <text x="173" y="145" font-size="22" fill="#18181B" text-anchor="middle">YOUR AGENT</text>
-    <text x="173" y="173" font-size="16" fill="#71717A" text-anchor="middle">Claude Code · Codex</text>
-    <rect x="330" y="112" width="216" height="78" rx="24" fill="#FFF3E8" stroke="#E96505" stroke-width="3"/>
-    <text x="438" y="160" font-size="21" fill="#18181B" text-anchor="middle">BROWSER USE CLI</text>
-    <path d="M280 151H324" fill="none" stroke="#71717A" stroke-width="4" marker-end="url(#arrow-gray)"/>
-    <rect x="126" y="274" width="360" height="136" rx="26" fill="#FFFFFF" stroke="#71717A" stroke-width="3"/>
-    <circle cx="156" cy="302" r="6" fill="#FF5F57"/><circle cx="177" cy="302" r="6" fill="#FEBC2E"/><circle cx="198" cy="302" r="6" fill="#28C840"/>
-    <text x="306" y="348" font-size="24" fill="#18181B" text-anchor="middle">REAL CHROME</text>
-    <text x="306" y="382" font-size="17" fill="#71717A" text-anchor="middle">tabs · cookies · logins</text>
-    <path d="M438 190V236H306V268" fill="none" stroke="#71717A" stroke-width="4" marker-end="url(#arrow-gray)"/>
-    <rect x="672" y="112" width="174" height="76" rx="24" fill="#FFFFFF" stroke="#71717A" stroke-width="3" stroke-dasharray="13 10"/>
-    <text x="759" y="159" font-size="22" fill="#18181B" text-anchor="middle">OPENCODE</text>
-    <rect x="896" y="112" width="222" height="76" rx="24" fill="#FFF3E8" stroke="#E96505" stroke-width="3"/>
-    <text x="1007" y="159" font-size="20" fill="#18181B" text-anchor="middle">BROWSER USE CLI</text>
-    <path d="M846 150H890" fill="none" stroke="#E96505" stroke-width="4" marker-end="url(#arrow-orange)"/>
-    <rect x="760" y="274" width="268" height="136" rx="28" fill="#FFF3E8" stroke="#E96505" stroke-width="4"/>
-    <circle cx="790" cy="302" r="6" fill="#FF5F57"/><circle cx="811" cy="302" r="6" fill="#FEBC2E"/><circle cx="832" cy="302" r="6" fill="#28C840"/>
-    <text x="894" y="348" font-size="25" fill="#18181B" text-anchor="middle">CLOUD BROWSER</text>
-    <text x="894" y="382" font-size="17" fill="#B84D00" text-anchor="middle">stealth · profiles · proxies</text>
-    <path d="M1007 188V232H894V268" fill="none" stroke="#E96505" stroke-width="4" marker-end="url(#arrow-orange)"/>
-    <path d="M438 190V224H650V342H754" fill="none" stroke="#E96505" stroke-width="4" marker-end="url(#arrow-orange)"/>
-    <text x="608" y="214" font-size="16" fill="#B84D00" text-anchor="middle">or connect to our cloud</text>
-    <rect x="672" y="474" width="174" height="72" rx="22" fill="#FFFFFF" stroke="#71717A" stroke-width="3" stroke-dasharray="13 10"/>
-    <text x="759" y="505" font-size="19" fill="#18181B" text-anchor="middle">YOUR AGENT</text>
-    <text x="759" y="530" font-size="15" fill="#71717A" text-anchor="middle">anywhere</text>
-    <rect x="896" y="474" width="222" height="72" rx="22" fill="#FFF3E8" stroke="#E96505" stroke-width="3"/>
-    <text x="1007" y="518" font-size="20" fill="#18181B" text-anchor="middle">BROWSER API</text>
-    <path d="M846 510H890" fill="none" stroke="#71717A" stroke-width="4" marker-end="url(#arrow-gray)"/>
-    <path d="M1007 474V440H894V416" fill="none" stroke="#E96505" stroke-width="4" marker-end="url(#arrow-orange)"/>
-    <text x="306" y="558" font-size="18" fill="#71717A" text-anchor="middle">CLI + local Chrome</text>
-    <text x="894" y="558" font-size="18" fill="#B84D00" text-anchor="middle">hosted stack or browser only</text>
+  <rect width="1200" height="700" fill="#FFFFFF"/>
+  <g font-family="Inter, ui-sans-serif, system-ui, sans-serif">
+    <text x="338" y="39" font-size="26" font-weight="750" fill="#18181B" text-anchor="middle">YOUR COMPUTER</text>
+    <rect x="28" y="52" width="620" height="586" rx="28" fill="#27272A" stroke="#18181B" stroke-width="3"/>
+    <circle cx="338" cy="68" r="4" fill="#71717A"/>
+    <rect x="50" y="78" width="576" height="536" rx="17" fill="#FAFAFA" stroke="#A1A1AA" stroke-width="2"/>
+    <rect x="74" y="102" width="528" height="486" rx="15" fill="#FFFFFF" stroke="#D4D4D8" stroke-width="2"/>
+    <path d="M74 149H602" stroke="#D4D4D8" stroke-width="2"/>
+    <circle cx="96" cy="126" r="6" fill="#FF5F57"/><circle cx="117" cy="126" r="6" fill="#FEBC2E"/><circle cx="138" cy="126" r="6" fill="#28C840"/>
+    <rect x="168" y="115" width="394" height="23" rx="11" fill="#F4F4F5"/>
+    <text x="365" y="132" font-size="13" fill="#71717A" text-anchor="middle">local</text>
+
+    <rect x="99" y="174" width="478" height="68" rx="18" fill="#F4F4F5" stroke="#A1A1AA" stroke-width="2" stroke-dasharray="8 7"/>
+    <text x="338" y="199" font-size="14" font-weight="700" fill="#71717A" text-anchor="middle">LOCAL AGENTS</text>
+    <text x="338" y="226" font-size="18" font-weight="650" fill="#18181B" text-anchor="middle">Claude Code · Codex · OpenCode · Hermes Agent</text>
+    <path d="M338 242V267H212V286" fill="none" stroke="#71717A" stroke-width="3" marker-end="url(#arrow-gray)"/>
+    <path d="M338 267H464V286" fill="none" stroke="#71717A" stroke-width="3" marker-end="url(#arrow-gray)"/>
+
+    <rect x="99" y="292" width="226" height="74" rx="18" fill="#FFF3E8" stroke="#E96505" stroke-width="3"/>
+    <text x="212" y="337" font-size="20" font-weight="750" fill="#18181B" text-anchor="middle">BROWSER USE CLI</text>
+    <rect x="351" y="292" width="226" height="74" rx="18" fill="#FFFFFF" stroke="#71717A" stroke-width="3"/>
+    <text x="464" y="318" font-size="13" font-weight="700" fill="#71717A" text-anchor="middle">OTHER COMPUTER-USE CLIs</text>
+    <text x="464" y="344" font-size="14" font-weight="650" fill="#18181B" text-anchor="middle">Playwright CLI · Agent Browser</text>
+
+    <path d="M212 366V404M464 366V404M212 404H464M338 404V440" fill="none" stroke="#71717A" stroke-width="3" marker-end="url(#arrow-gray)"/>
+    <text x="309" y="429" font-size="13" font-weight="700" fill="#71717A" text-anchor="end">LOCAL</text>
+    <rect x="190" y="446" width="296" height="106" rx="20" fill="#FFFFFF" stroke="#71717A" stroke-width="3"/>
+    <path d="M190 478H486" stroke="#D4D4D8" stroke-width="2"/>
+    <circle cx="212" cy="462" r="5" fill="#FF5F57"/><circle cx="230" cy="462" r="5" fill="#FEBC2E"/><circle cx="248" cy="462" r="5" fill="#28C840"/>
+    <text x="338" y="512" font-size="22" font-weight="750" fill="#18181B" text-anchor="middle">REAL CHROME</text>
+    <text x="338" y="538" font-size="15" fill="#71717A" text-anchor="middle">your tabs · cookies · logins</text>
+    <path d="M78 638H598L632 672H44Z" fill="#E4E4E7" stroke="#18181B" stroke-width="3" stroke-linejoin="round"/>
+    <path d="M263 654H413" stroke="#A1A1AA" stroke-width="4" stroke-linecap="round"/>
+
+    <rect x="686" y="52" width="486" height="620" rx="28" fill="#FFF7ED" stroke="#E96505" stroke-width="3"/>
+    <text x="929" y="91" font-size="26" font-weight="750" fill="#18181B" text-anchor="middle">OUR CLOUD</text>
+    <rect x="716" y="112" width="426" height="404" rx="24" fill="#FFFFFF" stroke="#E96505" stroke-width="2"/>
+    <text x="929" y="148" font-size="17" font-weight="800" fill="#B84D00" text-anchor="middle">CLOUD V4 API</text>
+    <rect x="748" y="172" width="164" height="68" rx="17" fill="#F4F4F5" stroke="#71717A" stroke-width="2" stroke-dasharray="8 7"/>
+    <text x="830" y="214" font-size="20" font-weight="750" fill="#18181B" text-anchor="middle">OPENCODE</text>
+    <rect x="946" y="172" width="164" height="68" rx="17" fill="#FFF3E8" stroke="#E96505" stroke-width="3"/>
+    <text x="1028" y="199" font-size="13" font-weight="700" fill="#B84D00" text-anchor="middle">SAME LEVEL</text>
+    <text x="1028" y="222" font-size="16" font-weight="750" fill="#18181B" text-anchor="middle">BROWSER USE CLI</text>
+    <path d="M830 240V277M1028 240V277M830 277H1028M929 277V326" fill="none" stroke="#E96505" stroke-width="3" marker-end="url(#arrow-orange)"/>
+
+    <rect x="794" y="332" width="270" height="126" rx="22" fill="#FFF3E8" stroke="#E96505" stroke-width="4"/>
+    <path d="M794 367H1064" stroke="#F6B98A" stroke-width="2"/>
+    <circle cx="816" cy="349" r="5" fill="#FF5F57"/><circle cx="834" cy="349" r="5" fill="#FEBC2E"/><circle cx="852" cy="349" r="5" fill="#28C840"/>
+    <text x="929" y="410" font-size="23" font-weight="800" fill="#18181B" text-anchor="middle">CLOUD BROWSER</text>
+    <text x="929" y="438" font-size="15" fill="#B84D00" text-anchor="middle">stealth · profiles · proxies</text>
+
+    <path d="M464 404H666V602H814" fill="none" stroke="#E96505" stroke-width="4" marker-end="url(#arrow-orange)"/>
+    <text x="646" y="390" font-size="13" font-weight="800" fill="#B84D00" text-anchor="end">OR CLOUD</text>
+    <rect x="820" y="566" width="218" height="74" rx="19" fill="#FFF3E8" stroke="#E96505" stroke-width="3"/>
+    <text x="929" y="596" font-size="20" font-weight="800" fill="#18181B" text-anchor="middle">BROWSER API</text>
+    <text x="929" y="621" font-size="14" fill="#B84D00" text-anchor="middle">browser only</text>
+    <path d="M929 566V464" fill="none" stroke="#E96505" stroke-width="4" marker-end="url(#arrow-orange)"/>
   </g>
 </svg>

--- a/docs/cloud/images/which-product-light.svg
+++ b/docs/cloud/images/which-product-light.svg
@@ -1,35 +1,39 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="460" viewBox="0 0 1200 460" role="img" aria-labelledby="title desc">
-  <title id="title">Three parts of Browser Use</title>
-  <desc id="desc">Your agent, the Browser Use CLI, and a browser. Take all three hosted as Cloud v4, bring your own agent with our CLI, or take only the browser.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="500" viewBox="0 0 1200 500" role="img" aria-labelledby="title desc">
+  <title id="title">Which Browser Use do I need</title>
+  <desc id="desc">On your machine: Claude Code or Codex run the Browser Use CLI against your own Chrome or one of our cloud browsers. In our cloud: the fully hosted agent you send a prompt to, or just a browser for your own agent.</desc>
   <defs>
     <filter id="rough">
       <feTurbulence type="fractalNoise" baseFrequency=".01" numOctaves="2" seed="7" result="noise"/>
       <feDisplacementMap in="SourceGraphic" in2="noise" scale="1.4"/>
     </filter>
   </defs>
-  <rect width="1200" height="460" fill="#FFFFFF"/>
-  <rect x="20" y="20" width="1160" height="420" fill="none" stroke="#E4E4E7" stroke-width="2"/>
+  <rect width="1200" height="500" fill="#FFFFFF"/>
+  <rect x="20" y="20" width="1160" height="460" fill="none" stroke="#E4E4E7" stroke-width="2"/>
   <g fill="none" stroke-linecap="round" stroke-linejoin="round" filter="url(#rough)">
-    <rect x="60" y="90" width="300" height="150" rx="30" fill="#FAFAFA" stroke="#71717A" stroke-width="4" stroke-dasharray="16 12"/>
-    <path d="M365 165 C402 157 418 173 445 165" stroke="#71717A" stroke-width="4"/>
-    <path d="M423 150 L445 165 L423 182" stroke="#71717A" stroke-width="4"/>
-    <rect x="450" y="90" width="300" height="150" rx="30" fill="#FFF3E8" stroke="#FE750E" stroke-width="4"/>
-    <path d="M755 165 C792 157 808 173 835 165" stroke="#71717A" stroke-width="4"/>
-    <path d="M813 150 L835 165 L813 182" stroke="#71717A" stroke-width="4"/>
-    <rect x="840" y="90" width="300" height="150" rx="30" fill="#FAFAFA" stroke="#71717A" stroke-width="4" stroke-dasharray="16 12"/>
-    <path d="M70 290 L70 320 L1130 320 L1130 290" stroke="#FE750E" stroke-width="4"/>
-    <path d="M70 360 L70 390 L750 390 L750 360" stroke="#71717A" stroke-width="4"/>
-    <path d="M850 360 L850 390 L1130 390 L1130 360" stroke="#71717A" stroke-width="4"/>
+    <rect x="40" y="70" width="560" height="300" rx="22" fill="#FAFAFA" stroke="#71717A" stroke-width="4"/>
+    <path d="M20 370 L620 370 L600 405 L40 405 Z" fill="#FAFAFA" stroke="#71717A" stroke-width="4"/>
+    <rect x="70" y="130" width="200" height="90" rx="30" fill="#FAFAFA" stroke="#71717A" stroke-width="4" stroke-dasharray="16 12"/>
+    <path d="M275 175 C300 167 292 183 315 175" stroke="#71717A" stroke-width="4"/>
+    <path d="M293 160 L315 175 L293 192" stroke="#71717A" stroke-width="4"/>
+    <rect x="320" y="130" width="260" height="90" rx="30" fill="#FFF3E8" stroke="#FE750E" stroke-width="4"/>
+    <rect x="70" y="255" width="200" height="80" rx="30" fill="#FAFAFA" stroke="#71717A" stroke-width="4" stroke-dasharray="16 12"/>
+    <rect x="320" y="255" width="260" height="80" rx="30" fill="#FFF3E8" stroke="#FE750E" stroke-width="4"/>
+    <path d="M680 240 C640 240 630 180 690 175 C690 120 790 100 815 150 C850 110 940 120 935 180 C1000 175 1010 240 960 250 L700 250 Z" fill="#FFF3E8" stroke="#FE750E" stroke-width="4"/>
+    <rect x="700" y="285" width="460" height="88" rx="30" fill="#FFF3E8" stroke="#FE750E" stroke-width="4"/>
+    <rect x="700" y="390" width="460" height="80" rx="30" fill="#FAFAFA" stroke="#71717A" stroke-width="4" stroke-dasharray="16 12"/>
   </g>
   <g font-family="Virgil, Comic Sans MS, cursive">
-    <text x="210" y="150" font-size="40" fill="#18181B" text-anchor="middle">YOUR AGENT</text>
-    <text x="210" y="200" font-size="20" fill="#52525B" text-anchor="middle">codex · claude code · hermes</text>
-    <text x="600" y="150" font-size="40" fill="#18181B" text-anchor="middle">BROWSER USE CLI</text>
-    <text x="600" y="200" font-size="22" fill="#52525B" text-anchor="middle">the harness your agent runs</text>
-    <text x="990" y="150" font-size="40" fill="#18181B" text-anchor="middle">BROWSER</text>
-    <text x="990" y="200" font-size="20" fill="#52525B" text-anchor="middle">your chrome · our cloud browser</text>
-    <text x="600" y="350" font-size="30" fill="#FE750E" text-anchor="middle">ALL THREE, HOSTED = CLOUD V4 (one API call)</text>
-    <text x="410" y="425" font-size="24" fill="#52525B" text-anchor="middle">YOUR AGENT + OUR CLI + ANY BROWSER = CLI</text>
-    <text x="990" y="425" font-size="21" fill="#52525B" text-anchor="middle">BROWSER ONLY = BROWSER API</text>
+    <text x="320" y="110" font-size="30" fill="#52525B" text-anchor="middle">YOUR MACHINE</text>
+    <text x="170" y="172" font-size="25" fill="#18181B" text-anchor="middle">YOUR AGENT</text>
+    <text x="170" y="200" font-size="18" fill="#52525B" text-anchor="middle">claude code · codex</text>
+    <text x="450" y="185" font-size="24" fill="#18181B" text-anchor="middle">BROWSER USE CLI</text>
+    <text x="170" y="303" font-size="24" fill="#18181B" text-anchor="middle">YOUR CHROME</text>
+    <text x="450" y="303" font-size="22" fill="#18181B" text-anchor="middle">OUR CLOUD BROWSER</text>
+    <text x="320" y="358" font-size="20" fill="#52525B" text-anchor="middle">pick either browser</text>
+    <text x="815" y="205" font-size="34" fill="#18181B" text-anchor="middle">OUR CLOUD</text>
+    <text x="930" y="322" font-size="24" fill="#18181B" text-anchor="middle">FULLY HOSTED AGENT = V4</text>
+    <text x="930" y="352" font-size="19" fill="#52525B" text-anchor="middle">send a prompt, get the result back</text>
+    <text x="930" y="424" font-size="24" fill="#18181B" text-anchor="middle">ONLY THE BROWSER</text>
+    <text x="930" y="452" font-size="19" fill="#52525B" text-anchor="middle">your own agent, over CDP</text>
   </g>
 </svg>

--- a/docs/cloud/images/which-product-light.svg
+++ b/docs/cloud/images/which-product-light.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="460" viewBox="0 0 1200 460" role="img" aria-labelledby="title desc">
+  <title id="title">Three parts of Browser Use</title>
+  <desc id="desc">Your agent, the Browser Use CLI, and a browser. Take all three hosted as Cloud v4, bring your own agent with our CLI, or take only the browser.</desc>
+  <defs>
+    <filter id="rough">
+      <feTurbulence type="fractalNoise" baseFrequency=".01" numOctaves="2" seed="7" result="noise"/>
+      <feDisplacementMap in="SourceGraphic" in2="noise" scale="1.4"/>
+    </filter>
+  </defs>
+  <rect width="1200" height="460" fill="#FFFFFF"/>
+  <rect x="20" y="20" width="1160" height="420" fill="none" stroke="#E4E4E7" stroke-width="2"/>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round" filter="url(#rough)">
+    <rect x="60" y="90" width="300" height="150" rx="30" fill="#FAFAFA" stroke="#71717A" stroke-width="4" stroke-dasharray="16 12"/>
+    <path d="M365 165 C402 157 418 173 445 165" stroke="#71717A" stroke-width="4"/>
+    <path d="M423 150 L445 165 L423 182" stroke="#71717A" stroke-width="4"/>
+    <rect x="450" y="90" width="300" height="150" rx="30" fill="#FFF3E8" stroke="#FE750E" stroke-width="4"/>
+    <path d="M755 165 C792 157 808 173 835 165" stroke="#71717A" stroke-width="4"/>
+    <path d="M813 150 L835 165 L813 182" stroke="#71717A" stroke-width="4"/>
+    <rect x="840" y="90" width="300" height="150" rx="30" fill="#FAFAFA" stroke="#71717A" stroke-width="4" stroke-dasharray="16 12"/>
+    <path d="M70 290 L70 320 L1130 320 L1130 290" stroke="#FE750E" stroke-width="4"/>
+    <path d="M70 360 L70 390 L750 390 L750 360" stroke="#71717A" stroke-width="4"/>
+    <path d="M850 360 L850 390 L1130 390 L1130 360" stroke="#71717A" stroke-width="4"/>
+  </g>
+  <g font-family="Virgil, Comic Sans MS, cursive">
+    <text x="210" y="150" font-size="40" fill="#18181B" text-anchor="middle">YOUR AGENT</text>
+    <text x="210" y="200" font-size="22" fill="#52525B" text-anchor="middle">codex · claude code · hermes</text>
+    <text x="600" y="150" font-size="40" fill="#18181B" text-anchor="middle">BROWSER USE CLI</text>
+    <text x="600" y="200" font-size="22" fill="#52525B" text-anchor="middle">the harness your agent runs</text>
+    <text x="990" y="150" font-size="40" fill="#18181B" text-anchor="middle">BROWSER</text>
+    <text x="990" y="200" font-size="22" fill="#52525B" text-anchor="middle">your chrome · our cloud browser</text>
+    <text x="600" y="350" font-size="30" fill="#FE750E" text-anchor="middle">ALL THREE, HOSTED = CLOUD V4 (one API call)</text>
+    <text x="410" y="425" font-size="26" fill="#52525B" text-anchor="middle">YOUR AGENT + OUR CLI + ANY BROWSER = CLI</text>
+    <text x="990" y="425" font-size="26" fill="#52525B" text-anchor="middle">ONLY THE BROWSER = BROWSER API</text>
+  </g>
+</svg>

--- a/docs/cloud/images/which-product-light.svg
+++ b/docs/cloud/images/which-product-light.svg
@@ -1,39 +1,51 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="700" viewBox="0 0 1200 700" role="img" aria-labelledby="title desc">
-  <title id="title">Choose local Chrome or the Browser Use cloud</title>
-  <desc id="desc">On your computer, local agents sit above matching Browser Use CLI and Playwright CLI boxes. The CLIs choose one local path to real Chrome or one cloud path directly to Cloud Browser. In Cloud V4, matching OpenCode and Browser Use CLI boxes run above that Cloud Browser.</desc>
-  <defs>
-    <marker id="orange-arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#E96505"/></marker>
-    <marker id="gray-arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#71717A"/></marker>
-  </defs>
-  <rect width="1200" height="700" fill="#FFFFFF"/>
-  <g font-family="Inter, ui-sans-serif, system-ui, sans-serif">
-    <text x="300" y="43" fill="#18181B" font-size="25" font-weight="750" text-anchor="middle">YOUR COMPUTER</text>
-    <rect x="30" y="64" width="540" height="78" rx="17" fill="#F4F4F5" stroke="#71717A" stroke-width="3"/>
-    <text x="300" y="94" fill="#71717A" font-size="13" font-weight="750" text-anchor="middle">LOCAL AGENTS</text>
-    <text x="300" y="121" fill="#18181B" font-size="18" font-weight="650" text-anchor="middle">Claude Code · Codex · OpenCode · Hermes Agent</text>
-    <rect x="30" y="184" width="252" height="78" rx="17" fill="#FFF3E8" stroke="#E96505" stroke-width="3"/>
-    <text x="156" y="230" fill="#18181B" font-size="19" font-weight="750" text-anchor="middle">BROWSER USE CLI</text>
-    <rect x="318" y="184" width="252" height="78" rx="17" fill="#F4F4F5" stroke="#71717A" stroke-width="3"/>
-    <text x="444" y="230" fill="#18181B" font-size="19" font-weight="750" text-anchor="middle">PLAYWRIGHT CLI</text>
-    <path d="M156 262V310H300M444 262V310H300V392" fill="none" stroke="#71717A" stroke-width="3" marker-end="url(#gray-arrow)"/>
-    <text x="269" y="365" fill="#71717A" font-size="13" font-weight="800" text-anchor="end">LOCAL</text>
-    <rect x="165" y="402" width="270" height="118" rx="20" fill="#FFFFFF" stroke="#71717A" stroke-width="3"/>
-    <path d="M165 437H435" stroke="#D4D4D8" stroke-width="2"/>
-    <circle cx="188" cy="420" r="5" fill="#FF5F57"/><circle cx="206" cy="420" r="5" fill="#FEBC2E"/><circle cx="224" cy="420" r="5" fill="#28C840"/>
-    <text x="300" y="478" fill="#18181B" font-size="22" font-weight="800" text-anchor="middle">REAL CHROME</text>
-    <text x="300" y="502" fill="#71717A" font-size="14" text-anchor="middle">your tabs · cookies · logins</text>
-    <rect x="635" y="30" width="535" height="640" rx="27" fill="#FFF7ED" stroke="#E96505" stroke-width="3"/>
-    <text x="902" y="75" fill="#18181B" font-size="25" font-weight="750" text-anchor="middle">OUR CLOUD</text>
-    <text x="902" y="102" fill="#B84D00" font-size="15" font-weight="800" text-anchor="middle">CLOUD V4 API</text>
-    <rect x="675" y="132" width="210" height="78" rx="17" fill="#F4F4F5" stroke="#71717A" stroke-width="3"/>
-    <text x="780" y="178" fill="#18181B" font-size="19" font-weight="750" text-anchor="middle">OPENCODE</text>
-    <rect x="920" y="132" width="210" height="78" rx="17" fill="#FFF3E8" stroke="#E96505" stroke-width="3"/>
-    <text x="1025" y="178" fill="#18181B" font-size="19" font-weight="750" text-anchor="middle">BROWSER USE CLI</text>
-    <path d="M780 210V307H902M1025 210V307H902V382" fill="none" stroke="#E96505" stroke-width="3" marker-end="url(#orange-arrow)"/>
-    <rect x="767" y="392" width="270" height="118" rx="20" fill="#FFF3E8" stroke="#E96505" stroke-width="4"/>
-    <text x="902" y="448" fill="#18181B" font-size="22" font-weight="800" text-anchor="middle">CLOUD BROWSER</text>
-    <text x="902" y="476" fill="#B84D00" font-size="14" text-anchor="middle">stealth · profiles · proxies</text>
-    <path d="M444 262V325H610V451H757" fill="none" stroke="#E96505" stroke-width="4" marker-end="url(#orange-arrow)"/>
-    <text x="601" y="309" fill="#B84D00" font-size="13" font-weight="800" text-anchor="end">CLOUD</text>
-  </g>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="674" viewBox="0 0 1200 674" role="img" aria-labelledby="title desc">
+<title id="title">Choose your agent, CLI and browser</title>
+<desc id="desc">Both columns share three aligned rows: agent, CLI, browser. On your computer, choose Claude Code, Codex, OpenCode or Hermes Agent, then Playwright CLI or Browser Use CLI. Both CLIs can use real Chrome or the single Cloud Browser in our cloud. Hosted V4 runs OpenCode, Browser Use CLI and that Cloud Browser. Profile Sync copies selected cookies from real Chrome to a cloud profile; it is a separate, explicit step. Send a prompt through the V4 API and get a result back.</desc>
+<defs><marker id="gray-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto"><path d="M0 0L7 3.5L0 7Z" fill="#71717A"/></marker><marker id="orange-arrow" markerWidth="7" markerHeight="7" refX="6" refY="3.5" orient="auto"><path d="M0 0L7 3.5L0 7Z" fill="#C94D00"/></marker></defs>
+<rect width="1200" height="674" fill="#FFFFFF"/><g font-family="Inter, ui-sans-serif, system-ui, sans-serif">
+<rect x="648" y="18" width="524" height="620" rx="17" fill="#FFF7ED" stroke="#F2C99E" stroke-width="2.5"/>
+<text x="298" y="62" fill="#242428" font-size="25" font-weight="750" text-anchor="middle">YOUR COMPUTER</text>
+<text x="298" y="91" fill="#606068" font-size="17" font-weight="450" text-anchor="middle">Choose each part</text>
+<text x="910" y="62" fill="#242428" font-size="25" font-weight="750" text-anchor="middle">OUR CLOUD</text>
+<text x="910" y="91" fill="#606068" font-size="17" font-weight="450" text-anchor="middle">Send a prompt, get a result</text>
+<rect x="48" y="128" width="500" height="96" rx="17" fill="#F4F4F5" stroke="#71717A" stroke-width="2.5"/>
+<text x="298" y="161" fill="#606068" font-size="14" font-weight="700" text-anchor="middle">YOUR AGENT</text>
+<text x="298" y="195" fill="#242428" font-size="18" font-weight="600" text-anchor="middle">Claude Code · Codex · OpenCode · Hermes Agent</text>
+<rect x="784" y="128" width="252" height="96" rx="17" fill="#F4F4F5" stroke="#71717A" stroke-width="2.5"/>
+<text x="910" y="184" fill="#242428" font-size="23" font-weight="750" text-anchor="middle">OpenCode</text>
+<path d="M298 224V245H167V270" fill="none" stroke="#71717A" stroke-width="2.5" stroke-linejoin="round" marker-end="url(#gray-arrow)"/>
+<path d="M298 245H429V270" fill="none" stroke="#71717A" stroke-width="2.5" stroke-linejoin="round" marker-end="url(#gray-arrow)"/>
+<path d="M910 224V270" fill="none" stroke="#71717A" stroke-width="2.5" stroke-linejoin="round" marker-end="url(#gray-arrow)"/>
+<rect x="48" y="280" width="238" height="78" rx="17" fill="#F4F4F5" stroke="#71717A" stroke-width="2.5"/>
+<text x="167" y="327" fill="#242428" font-size="21" font-weight="750" text-anchor="middle">Playwright CLI</text>
+<rect x="310" y="280" width="238" height="78" rx="17" fill="#FFF0DF" stroke="#C94D00" stroke-width="2.5"/>
+<text x="429" y="327" fill="#242428" font-size="21" font-weight="750" text-anchor="middle">Browser Use CLI</text>
+<rect x="784" y="280" width="252" height="78" rx="17" fill="#FFF0DF" stroke="#C94D00" stroke-width="2.5"/>
+<text x="910" y="327" fill="#242428" font-size="21" font-weight="750" text-anchor="middle">Browser Use CLI</text>
+<path d="M167 358V395H429V358" fill="none" stroke="#71717A" stroke-width="2.5" stroke-linejoin="round"/>
+<path d="M167 395V444" fill="none" stroke="#71717A" stroke-width="2.5" marker-end="url(#gray-arrow)"/>
+<path d="M429 395V425H746V520H772" fill="none" stroke="#C94D00" stroke-width="2.5" stroke-linejoin="round" marker-end="url(#orange-arrow)"/>
+<path d="M910 358V444" fill="none" stroke="#C94D00" stroke-width="2.5" marker-end="url(#orange-arrow)"/>
+<circle cx="167" cy="395" r="4" fill="#71717A"/>
+<circle cx="429" cy="395" r="4" fill="#C94D00"/>
+<text x="125" y="423" fill="#606068" font-size="14" font-weight="750" text-anchor="middle">LOCAL</text>
+<text x="585" y="413" fill="#C94D00" font-size="14" font-weight="750" text-anchor="middle">CLOUD</text>
+<rect x="41" y="454" width="252" height="124" rx="17" fill="#FFFFFF" stroke="#71717A" stroke-width="2.5"/>
+<path d="M41 481H293" fill="none" stroke="#71717A" stroke-width="2.5" stroke-linejoin="round"/>
+<circle cx="55" cy="468" r="2.6" fill="#71717A"/>
+<circle cx="65" cy="468" r="2.6" fill="#71717A"/>
+<circle cx="75" cy="468" r="2.6" fill="#71717A"/>
+<text x="167" y="525" fill="#242428" font-size="24" font-weight="750" text-anchor="middle">Real Chrome</text>
+<text x="167" y="553" fill="#606068" font-size="16" font-weight="450" text-anchor="middle">your tabs · cookies · logins</text>
+<rect x="784" y="454" width="252" height="124" rx="17" fill="#FFF0DF" stroke="#C94D00" stroke-width="2.5"/>
+<path d="M784 481H1036" fill="none" stroke="#C94D00" stroke-width="2.5" stroke-linejoin="round"/>
+<circle cx="798" cy="468" r="2.6" fill="#C94D00"/>
+<circle cx="808" cy="468" r="2.6" fill="#C94D00"/>
+<circle cx="818" cy="468" r="2.6" fill="#C94D00"/>
+<text x="910" y="525" fill="#242428" font-size="24" font-weight="750" text-anchor="middle">Cloud Browser</text>
+<text x="910" y="553" fill="#606068" font-size="16" font-weight="450" text-anchor="middle">profiles · stealth · proxies</text>
+<path d="M305 561H772" fill="none" stroke="#71717A" stroke-width="2.2" stroke-dasharray="7 6" marker-end="url(#gray-arrow)"/>
+<text x="538" y="587" fill="#606068" font-size="16" font-weight="600" text-anchor="middle">Profile Sync · cookies</text>
+<text x="910" y="613" fill="#C94D00" font-size="17" font-weight="600" text-anchor="middle">Hosted V4 API</text>
+<text x="298" y="625" fill="#606068" font-size="17" font-weight="500" text-anchor="middle">Either CLI can control either browser.</text>
+</g></svg>

--- a/docs/cloud/images/which-product-light.svg
+++ b/docs/cloud/images/which-product-light.svg
@@ -1,44 +1,48 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="500" viewBox="0 0 1200 500" role="img" aria-labelledby="title desc">
-  <title id="title">Which Browser Use do I need</title>
-  <desc id="desc">On your machine: Claude Code or Codex run the Browser Use CLI against your own Chrome or one of our cloud browsers. In our cloud: the fully hosted agent you send a prompt to, or just a browser for your own agent.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="620" viewBox="0 0 1200 620" role="img" aria-labelledby="title desc">
+  <title id="title">Where each Browser Use part runs</title>
+  <desc id="desc">Claude Code or Codex use Browser Use CLI on your machine. The CLI drives real Chrome locally or connects to the single Cloud Browser in our cloud. OpenCode and Browser Use CLI also run beside Cloud Browser as the fully hosted stack. Your own agent can connect directly through the Browser API.</desc>
   <defs>
-    <filter id="rough">
-      <feTurbulence type="fractalNoise" baseFrequency=".01" numOctaves="2" seed="7" result="noise"/>
-      <feDisplacementMap in="SourceGraphic" in2="noise" scale="1.4"/>
-    </filter>
+    <filter id="rough"><feTurbulence type="fractalNoise" baseFrequency=".012" numOctaves="2" seed="7" result="noise"/><feDisplacementMap in="SourceGraphic" in2="noise" scale="1.2"/></filter>
+    <marker id="arrow-orange" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#E96505"/></marker>
+    <marker id="arrow-gray" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#71717A"/></marker>
   </defs>
-  <rect width="1200" height="500" fill="#FFFFFF"/>
-  <rect x="20" y="20" width="1160" height="460" fill="none" stroke="#E4E4E7" stroke-width="2"/>
-  <g fill="none" stroke-linecap="round" stroke-linejoin="round" filter="url(#rough)">
-    <rect x="40" y="70" width="560" height="300" rx="22" fill="#FAFAFA" stroke="#71717A" stroke-width="4"/>
-    <path d="M20 370 L620 370 L600 405 L40 405 Z" fill="#FAFAFA" stroke="#71717A" stroke-width="4"/>
-    <rect x="70" y="130" width="200" height="90" rx="30" fill="#FAFAFA" stroke="#71717A" stroke-width="4" stroke-dasharray="16 12"/>
-    <path d="M275 175 C300 167 292 183 315 175" stroke="#71717A" stroke-width="4"/>
-    <path d="M293 160 L315 175 L293 192" stroke="#71717A" stroke-width="4"/>
-    <rect x="320" y="130" width="260" height="90" rx="30" fill="#FFF3E8" stroke="#FE750E" stroke-width="4"/>
-    <rect x="70" y="255" width="200" height="80" rx="30" fill="#FAFAFA" stroke="#71717A" stroke-width="4" stroke-dasharray="16 12"/>
-    <rect x="320" y="255" width="260" height="80" rx="30" fill="#FFF3E8" stroke="#FE750E" stroke-width="4"/>
-    <path d="M680 240 C640 240 630 180 690 175 C690 120 790 100 815 150 C850 110 940 120 935 180 C1000 175 1010 240 960 250 L700 250 Z" fill="#FFF3E8" stroke="#FE750E" stroke-width="4"/>
-    <rect x="700" y="285" width="460" height="88" rx="30" fill="#FFF3E8" stroke="#FE750E" stroke-width="4"/>
-    <rect x="700" y="390" width="185" height="80" rx="30" fill="#FAFAFA" stroke="#71717A" stroke-width="4" stroke-dasharray="16 12"/>
-    <path d="M890 430 C905 423 905 437 920 430" stroke="#71717A" stroke-width="4"/>
-    <path d="M905 416 L920 430 L905 444" stroke="#71717A" stroke-width="4"/>
-    <rect x="925" y="390" width="235" height="80" rx="30" fill="#FFF3E8" stroke="#FE750E" stroke-width="4"/>
-  </g>
-  <g font-family="Virgil, Comic Sans MS, cursive">
-    <text x="320" y="110" font-size="30" fill="#52525B" text-anchor="middle">YOUR MACHINE</text>
-    <text x="170" y="172" font-size="25" fill="#18181B" text-anchor="middle">YOUR AGENT</text>
-    <text x="170" y="200" font-size="18" fill="#52525B" text-anchor="middle">claude code · codex</text>
-    <text x="450" y="185" font-size="24" fill="#18181B" text-anchor="middle">BROWSER USE CLI</text>
-    <text x="170" y="303" font-size="24" fill="#18181B" text-anchor="middle">YOUR CHROME</text>
-    <text x="450" y="303" font-size="22" fill="#18181B" text-anchor="middle">OUR CLOUD BROWSER</text>
-    <text x="320" y="358" font-size="20" fill="#52525B" text-anchor="middle">pick either browser</text>
-    <text x="815" y="205" font-size="34" fill="#18181B" text-anchor="middle">OUR CLOUD</text>
-    <text x="930" y="322" font-size="24" fill="#18181B" text-anchor="middle">FULLY HOSTED AGENT = V4</text>
-    <text x="930" y="352" font-size="19" fill="#52525B" text-anchor="middle">send a prompt, get the result back</text>
-    <text x="792" y="424" font-size="21" fill="#18181B" text-anchor="middle">YOUR AGENT</text>
-    <text x="792" y="451" font-size="16" fill="#52525B" text-anchor="middle">anywhere</text>
-    <text x="1042" y="424" font-size="21" fill="#18181B" text-anchor="middle">BROWSER API</text>
-    <text x="1042" y="451" font-size="16" fill="#52525B" text-anchor="middle">only our browser</text>
+  <rect width="1200" height="620" fill="#FFFFFF"/>
+  <g filter="url(#rough)" font-family="Virgil, Comic Sans MS, cursive">
+    <rect x="28" y="28" width="556" height="564" rx="30" fill="#FAFAFA" stroke="#A1A1AA" stroke-width="3"/>
+    <rect x="616" y="28" width="556" height="564" rx="30" fill="#FFF7ED" stroke="#E96505" stroke-width="3"/>
+    <text x="306" y="77" font-size="30" fill="#18181B" text-anchor="middle">YOUR MACHINE</text>
+    <text x="894" y="77" font-size="30" fill="#18181B" text-anchor="middle">OUR CLOUD</text>
+    <rect x="66" y="112" width="214" height="78" rx="24" fill="#FFFFFF" stroke="#71717A" stroke-width="3" stroke-dasharray="13 10"/>
+    <text x="173" y="145" font-size="22" fill="#18181B" text-anchor="middle">YOUR AGENT</text>
+    <text x="173" y="173" font-size="16" fill="#71717A" text-anchor="middle">Claude Code · Codex</text>
+    <rect x="330" y="112" width="216" height="78" rx="24" fill="#FFF3E8" stroke="#E96505" stroke-width="3"/>
+    <text x="438" y="160" font-size="21" fill="#18181B" text-anchor="middle">BROWSER USE CLI</text>
+    <path d="M280 151H324" fill="none" stroke="#71717A" stroke-width="4" marker-end="url(#arrow-gray)"/>
+    <rect x="126" y="274" width="360" height="136" rx="26" fill="#FFFFFF" stroke="#71717A" stroke-width="3"/>
+    <circle cx="156" cy="302" r="6" fill="#FF5F57"/><circle cx="177" cy="302" r="6" fill="#FEBC2E"/><circle cx="198" cy="302" r="6" fill="#28C840"/>
+    <text x="306" y="348" font-size="24" fill="#18181B" text-anchor="middle">REAL CHROME</text>
+    <text x="306" y="382" font-size="17" fill="#71717A" text-anchor="middle">tabs · cookies · logins</text>
+    <path d="M438 190V236H306V268" fill="none" stroke="#71717A" stroke-width="4" marker-end="url(#arrow-gray)"/>
+    <rect x="672" y="112" width="174" height="76" rx="24" fill="#FFFFFF" stroke="#71717A" stroke-width="3" stroke-dasharray="13 10"/>
+    <text x="759" y="159" font-size="22" fill="#18181B" text-anchor="middle">OPENCODE</text>
+    <rect x="896" y="112" width="222" height="76" rx="24" fill="#FFF3E8" stroke="#E96505" stroke-width="3"/>
+    <text x="1007" y="159" font-size="20" fill="#18181B" text-anchor="middle">BROWSER USE CLI</text>
+    <path d="M846 150H890" fill="none" stroke="#E96505" stroke-width="4" marker-end="url(#arrow-orange)"/>
+    <rect x="760" y="274" width="268" height="136" rx="28" fill="#FFF3E8" stroke="#E96505" stroke-width="4"/>
+    <circle cx="790" cy="302" r="6" fill="#FF5F57"/><circle cx="811" cy="302" r="6" fill="#FEBC2E"/><circle cx="832" cy="302" r="6" fill="#28C840"/>
+    <text x="894" y="348" font-size="25" fill="#18181B" text-anchor="middle">CLOUD BROWSER</text>
+    <text x="894" y="382" font-size="17" fill="#B84D00" text-anchor="middle">stealth · profiles · proxies</text>
+    <path d="M1007 188V232H894V268" fill="none" stroke="#E96505" stroke-width="4" marker-end="url(#arrow-orange)"/>
+    <path d="M438 190V224H650V342H754" fill="none" stroke="#E96505" stroke-width="4" marker-end="url(#arrow-orange)"/>
+    <text x="608" y="214" font-size="16" fill="#B84D00" text-anchor="middle">or connect to our cloud</text>
+    <rect x="672" y="474" width="174" height="72" rx="22" fill="#FFFFFF" stroke="#71717A" stroke-width="3" stroke-dasharray="13 10"/>
+    <text x="759" y="505" font-size="19" fill="#18181B" text-anchor="middle">YOUR AGENT</text>
+    <text x="759" y="530" font-size="15" fill="#71717A" text-anchor="middle">anywhere</text>
+    <rect x="896" y="474" width="222" height="72" rx="22" fill="#FFF3E8" stroke="#E96505" stroke-width="3"/>
+    <text x="1007" y="518" font-size="20" fill="#18181B" text-anchor="middle">BROWSER API</text>
+    <path d="M846 510H890" fill="none" stroke="#71717A" stroke-width="4" marker-end="url(#arrow-gray)"/>
+    <path d="M1007 474V440H894V416" fill="none" stroke="#E96505" stroke-width="4" marker-end="url(#arrow-orange)"/>
+    <text x="306" y="558" font-size="18" fill="#71717A" text-anchor="middle">CLI + local Chrome</text>
+    <text x="894" y="558" font-size="18" fill="#B84D00" text-anchor="middle">hosted stack or browser only</text>
   </g>
 </svg>

--- a/docs/cloud/images/which-product-light.svg
+++ b/docs/cloud/images/which-product-light.svg
@@ -20,7 +20,10 @@
     <rect x="320" y="255" width="260" height="80" rx="30" fill="#FFF3E8" stroke="#FE750E" stroke-width="4"/>
     <path d="M680 240 C640 240 630 180 690 175 C690 120 790 100 815 150 C850 110 940 120 935 180 C1000 175 1010 240 960 250 L700 250 Z" fill="#FFF3E8" stroke="#FE750E" stroke-width="4"/>
     <rect x="700" y="285" width="460" height="88" rx="30" fill="#FFF3E8" stroke="#FE750E" stroke-width="4"/>
-    <rect x="700" y="390" width="460" height="80" rx="30" fill="#FAFAFA" stroke="#71717A" stroke-width="4" stroke-dasharray="16 12"/>
+    <rect x="700" y="390" width="185" height="80" rx="30" fill="#FAFAFA" stroke="#71717A" stroke-width="4" stroke-dasharray="16 12"/>
+    <path d="M890 430 C905 423 905 437 920 430" stroke="#71717A" stroke-width="4"/>
+    <path d="M905 416 L920 430 L905 444" stroke="#71717A" stroke-width="4"/>
+    <rect x="925" y="390" width="235" height="80" rx="30" fill="#FFF3E8" stroke="#FE750E" stroke-width="4"/>
   </g>
   <g font-family="Virgil, Comic Sans MS, cursive">
     <text x="320" y="110" font-size="30" fill="#52525B" text-anchor="middle">YOUR MACHINE</text>
@@ -33,7 +36,9 @@
     <text x="815" y="205" font-size="34" fill="#18181B" text-anchor="middle">OUR CLOUD</text>
     <text x="930" y="322" font-size="24" fill="#18181B" text-anchor="middle">FULLY HOSTED AGENT = V4</text>
     <text x="930" y="352" font-size="19" fill="#52525B" text-anchor="middle">send a prompt, get the result back</text>
-    <text x="930" y="424" font-size="24" fill="#18181B" text-anchor="middle">ONLY THE BROWSER</text>
-    <text x="930" y="452" font-size="19" fill="#52525B" text-anchor="middle">your own agent, over CDP</text>
+    <text x="792" y="424" font-size="21" fill="#18181B" text-anchor="middle">YOUR AGENT</text>
+    <text x="792" y="451" font-size="16" fill="#52525B" text-anchor="middle">anywhere</text>
+    <text x="1042" y="424" font-size="21" fill="#18181B" text-anchor="middle">BROWSER API</text>
+    <text x="1042" y="451" font-size="16" fill="#52525B" text-anchor="middle">only our browser</text>
   </g>
 </svg>

--- a/docs/cloud/images/which-product-light.svg
+++ b/docs/cloud/images/which-product-light.svg
@@ -1,66 +1,39 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="700" viewBox="0 0 1200 700" role="img" aria-labelledby="title desc">
-  <title id="title">Choose a local or cloud Browser Use setup</title>
-  <desc id="desc">On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or connect through Browser API to the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI at the same level above that Cloud Browser. Browser API is the browser-only route.</desc>
+  <title id="title">Choose local Chrome or the Browser Use cloud</title>
+  <desc id="desc">On your computer, local agents sit above matching Browser Use CLI and Playwright CLI boxes. The CLIs choose one local path to real Chrome or one cloud path directly to Cloud Browser. In Cloud V4, matching OpenCode and Browser Use CLI boxes run above that Cloud Browser.</desc>
   <defs>
-    <marker id="arrow-orange" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#E96505"/></marker>
-    <marker id="arrow-gray" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#71717A"/></marker>
+    <marker id="orange-arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#E96505"/></marker>
+    <marker id="gray-arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto"><path d="M0 0L10 5L0 10Z" fill="#71717A"/></marker>
   </defs>
   <rect width="1200" height="700" fill="#FFFFFF"/>
   <g font-family="Inter, ui-sans-serif, system-ui, sans-serif">
-    <text x="338" y="39" font-size="26" font-weight="750" fill="#18181B" text-anchor="middle">YOUR COMPUTER</text>
-    <rect x="28" y="52" width="620" height="586" rx="28" fill="#27272A" stroke="#18181B" stroke-width="3"/>
-    <circle cx="338" cy="68" r="4" fill="#71717A"/>
-    <rect x="50" y="78" width="576" height="536" rx="17" fill="#FAFAFA" stroke="#A1A1AA" stroke-width="2"/>
-    <rect x="74" y="102" width="528" height="486" rx="15" fill="#FFFFFF" stroke="#D4D4D8" stroke-width="2"/>
-    <path d="M74 149H602" stroke="#D4D4D8" stroke-width="2"/>
-    <circle cx="96" cy="126" r="6" fill="#FF5F57"/><circle cx="117" cy="126" r="6" fill="#FEBC2E"/><circle cx="138" cy="126" r="6" fill="#28C840"/>
-    <rect x="168" y="115" width="394" height="23" rx="11" fill="#F4F4F5"/>
-    <text x="365" y="132" font-size="13" fill="#71717A" text-anchor="middle">local</text>
-
-    <rect x="99" y="174" width="478" height="68" rx="18" fill="#F4F4F5" stroke="#A1A1AA" stroke-width="2" stroke-dasharray="8 7"/>
-    <text x="338" y="199" font-size="14" font-weight="700" fill="#71717A" text-anchor="middle">LOCAL AGENTS</text>
-    <text x="338" y="226" font-size="18" font-weight="650" fill="#18181B" text-anchor="middle">Claude Code · Codex · OpenCode · Hermes Agent</text>
-    <path d="M338 242V267H212V286" fill="none" stroke="#71717A" stroke-width="3" marker-end="url(#arrow-gray)"/>
-    <path d="M338 267H464V286" fill="none" stroke="#71717A" stroke-width="3" marker-end="url(#arrow-gray)"/>
-
-    <rect x="99" y="292" width="226" height="74" rx="18" fill="#FFF3E8" stroke="#E96505" stroke-width="3"/>
-    <text x="212" y="337" font-size="20" font-weight="750" fill="#18181B" text-anchor="middle">BROWSER USE CLI</text>
-    <rect x="351" y="292" width="226" height="74" rx="18" fill="#FFFFFF" stroke="#71717A" stroke-width="3"/>
-    <text x="464" y="318" font-size="13" font-weight="700" fill="#71717A" text-anchor="middle">OTHER COMPUTER-USE CLIs</text>
-    <text x="464" y="344" font-size="14" font-weight="650" fill="#18181B" text-anchor="middle">Playwright CLI · Agent Browser</text>
-
-    <path d="M212 366V404M464 366V404M212 404H464M338 404V440" fill="none" stroke="#71717A" stroke-width="3" marker-end="url(#arrow-gray)"/>
-    <text x="309" y="429" font-size="13" font-weight="700" fill="#71717A" text-anchor="end">LOCAL</text>
-    <rect x="190" y="446" width="296" height="106" rx="20" fill="#FFFFFF" stroke="#71717A" stroke-width="3"/>
-    <path d="M190 478H486" stroke="#D4D4D8" stroke-width="2"/>
-    <circle cx="212" cy="462" r="5" fill="#FF5F57"/><circle cx="230" cy="462" r="5" fill="#FEBC2E"/><circle cx="248" cy="462" r="5" fill="#28C840"/>
-    <text x="338" y="512" font-size="22" font-weight="750" fill="#18181B" text-anchor="middle">REAL CHROME</text>
-    <text x="338" y="538" font-size="15" fill="#71717A" text-anchor="middle">your tabs · cookies · logins</text>
-    <path d="M78 638H598L632 672H44Z" fill="#E4E4E7" stroke="#18181B" stroke-width="3" stroke-linejoin="round"/>
-    <path d="M263 654H413" stroke="#A1A1AA" stroke-width="4" stroke-linecap="round"/>
-
-    <rect x="686" y="52" width="486" height="620" rx="28" fill="#FFF7ED" stroke="#E96505" stroke-width="3"/>
-    <text x="929" y="91" font-size="26" font-weight="750" fill="#18181B" text-anchor="middle">OUR CLOUD</text>
-    <rect x="716" y="112" width="426" height="404" rx="24" fill="#FFFFFF" stroke="#E96505" stroke-width="2"/>
-    <text x="929" y="148" font-size="17" font-weight="800" fill="#B84D00" text-anchor="middle">CLOUD V4 API</text>
-    <rect x="748" y="172" width="164" height="68" rx="17" fill="#F4F4F5" stroke="#71717A" stroke-width="2" stroke-dasharray="8 7"/>
-    <text x="830" y="214" font-size="20" font-weight="750" fill="#18181B" text-anchor="middle">OPENCODE</text>
-    <rect x="946" y="172" width="164" height="68" rx="17" fill="#FFF3E8" stroke="#E96505" stroke-width="3"/>
-    <text x="1028" y="199" font-size="13" font-weight="700" fill="#B84D00" text-anchor="middle">SAME LEVEL</text>
-    <text x="1028" y="222" font-size="16" font-weight="750" fill="#18181B" text-anchor="middle">BROWSER USE CLI</text>
-    <path d="M830 240V277M1028 240V277M830 277H1028M929 277V326" fill="none" stroke="#E96505" stroke-width="3" marker-end="url(#arrow-orange)"/>
-
-    <rect x="794" y="332" width="270" height="126" rx="22" fill="#FFF3E8" stroke="#E96505" stroke-width="4"/>
-    <path d="M794 367H1064" stroke="#F6B98A" stroke-width="2"/>
-    <circle cx="816" cy="349" r="5" fill="#FF5F57"/><circle cx="834" cy="349" r="5" fill="#FEBC2E"/><circle cx="852" cy="349" r="5" fill="#28C840"/>
-    <text x="929" y="410" font-size="23" font-weight="800" fill="#18181B" text-anchor="middle">CLOUD BROWSER</text>
-    <text x="929" y="438" font-size="15" fill="#B84D00" text-anchor="middle">stealth · profiles · proxies</text>
-
-    <path d="M464 404H666V602H814" fill="none" stroke="#E96505" stroke-width="4" marker-end="url(#arrow-orange)"/>
-    <text x="646" y="390" font-size="13" font-weight="800" fill="#B84D00" text-anchor="end">OR CLOUD</text>
-    <rect x="820" y="566" width="218" height="74" rx="19" fill="#FFF3E8" stroke="#E96505" stroke-width="3"/>
-    <text x="929" y="596" font-size="20" font-weight="800" fill="#18181B" text-anchor="middle">BROWSER API</text>
-    <text x="929" y="621" font-size="14" fill="#B84D00" text-anchor="middle">browser only</text>
-    <path d="M929 566V464" fill="none" stroke="#E96505" stroke-width="4" marker-end="url(#arrow-orange)"/>
+    <text x="300" y="43" fill="#18181B" font-size="25" font-weight="750" text-anchor="middle">YOUR COMPUTER</text>
+    <rect x="30" y="64" width="540" height="78" rx="17" fill="#F4F4F5" stroke="#71717A" stroke-width="3"/>
+    <text x="300" y="94" fill="#71717A" font-size="13" font-weight="750" text-anchor="middle">LOCAL AGENTS</text>
+    <text x="300" y="121" fill="#18181B" font-size="18" font-weight="650" text-anchor="middle">Claude Code · Codex · OpenCode · Hermes Agent</text>
+    <rect x="30" y="184" width="252" height="78" rx="17" fill="#FFF3E8" stroke="#E96505" stroke-width="3"/>
+    <text x="156" y="230" fill="#18181B" font-size="19" font-weight="750" text-anchor="middle">BROWSER USE CLI</text>
+    <rect x="318" y="184" width="252" height="78" rx="17" fill="#F4F4F5" stroke="#71717A" stroke-width="3"/>
+    <text x="444" y="230" fill="#18181B" font-size="19" font-weight="750" text-anchor="middle">PLAYWRIGHT CLI</text>
+    <path d="M156 262V310H300M444 262V310H300V392" fill="none" stroke="#71717A" stroke-width="3" marker-end="url(#gray-arrow)"/>
+    <text x="269" y="365" fill="#71717A" font-size="13" font-weight="800" text-anchor="end">LOCAL</text>
+    <rect x="165" y="402" width="270" height="118" rx="20" fill="#FFFFFF" stroke="#71717A" stroke-width="3"/>
+    <path d="M165 437H435" stroke="#D4D4D8" stroke-width="2"/>
+    <circle cx="188" cy="420" r="5" fill="#FF5F57"/><circle cx="206" cy="420" r="5" fill="#FEBC2E"/><circle cx="224" cy="420" r="5" fill="#28C840"/>
+    <text x="300" y="478" fill="#18181B" font-size="22" font-weight="800" text-anchor="middle">REAL CHROME</text>
+    <text x="300" y="502" fill="#71717A" font-size="14" text-anchor="middle">your tabs · cookies · logins</text>
+    <rect x="635" y="30" width="535" height="640" rx="27" fill="#FFF7ED" stroke="#E96505" stroke-width="3"/>
+    <text x="902" y="75" fill="#18181B" font-size="25" font-weight="750" text-anchor="middle">OUR CLOUD</text>
+    <text x="902" y="102" fill="#B84D00" font-size="15" font-weight="800" text-anchor="middle">CLOUD V4 API</text>
+    <rect x="675" y="132" width="210" height="78" rx="17" fill="#F4F4F5" stroke="#71717A" stroke-width="3"/>
+    <text x="780" y="178" fill="#18181B" font-size="19" font-weight="750" text-anchor="middle">OPENCODE</text>
+    <rect x="920" y="132" width="210" height="78" rx="17" fill="#FFF3E8" stroke="#E96505" stroke-width="3"/>
+    <text x="1025" y="178" fill="#18181B" font-size="19" font-weight="750" text-anchor="middle">BROWSER USE CLI</text>
+    <path d="M780 210V307H902M1025 210V307H902V382" fill="none" stroke="#E96505" stroke-width="3" marker-end="url(#orange-arrow)"/>
+    <rect x="767" y="392" width="270" height="118" rx="20" fill="#FFF3E8" stroke="#E96505" stroke-width="4"/>
+    <text x="902" y="448" fill="#18181B" font-size="22" font-weight="800" text-anchor="middle">CLOUD BROWSER</text>
+    <text x="902" y="476" fill="#B84D00" font-size="14" text-anchor="middle">stealth · profiles · proxies</text>
+    <path d="M444 262V325H610V451H757" fill="none" stroke="#E96505" stroke-width="4" marker-end="url(#orange-arrow)"/>
+    <text x="601" y="309" fill="#B84D00" font-size="13" font-weight="800" text-anchor="end">CLOUD</text>
   </g>
 </svg>

--- a/docs/cloud/images/which-product-light.svg
+++ b/docs/cloud/images/which-product-light.svg
@@ -23,13 +23,13 @@
   </g>
   <g font-family="Virgil, Comic Sans MS, cursive">
     <text x="210" y="150" font-size="40" fill="#18181B" text-anchor="middle">YOUR AGENT</text>
-    <text x="210" y="200" font-size="22" fill="#52525B" text-anchor="middle">codex · claude code · hermes</text>
+    <text x="210" y="200" font-size="20" fill="#52525B" text-anchor="middle">codex · claude code · hermes</text>
     <text x="600" y="150" font-size="40" fill="#18181B" text-anchor="middle">BROWSER USE CLI</text>
     <text x="600" y="200" font-size="22" fill="#52525B" text-anchor="middle">the harness your agent runs</text>
     <text x="990" y="150" font-size="40" fill="#18181B" text-anchor="middle">BROWSER</text>
-    <text x="990" y="200" font-size="22" fill="#52525B" text-anchor="middle">your chrome · our cloud browser</text>
+    <text x="990" y="200" font-size="20" fill="#52525B" text-anchor="middle">your chrome · our cloud browser</text>
     <text x="600" y="350" font-size="30" fill="#FE750E" text-anchor="middle">ALL THREE, HOSTED = CLOUD V4 (one API call)</text>
-    <text x="410" y="425" font-size="26" fill="#52525B" text-anchor="middle">YOUR AGENT + OUR CLI + ANY BROWSER = CLI</text>
-    <text x="990" y="425" font-size="26" fill="#52525B" text-anchor="middle">ONLY THE BROWSER = BROWSER API</text>
+    <text x="410" y="425" font-size="24" fill="#52525B" text-anchor="middle">YOUR AGENT + OUR CLI + ANY BROWSER = CLI</text>
+    <text x="990" y="425" font-size="21" fill="#52525B" text-anchor="middle">BROWSER ONLY = BROWSER API</text>
   </g>
 </svg>

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -153,7 +153,7 @@ Use the full hosted stack for scheduled work, tasks your users trigger, and work
 
 ## Only the browser
 
-Use the [Browser API](https://docs.browser-use.com/cloud/browser/stealth) when you only need the hosted browser. Browser Use CLI or a custom computer-use CLI can connect to the same Cloud Browser from your computer or your own cloud; Browser API does not add a hosted agent.
+Use the [Browser API](https://docs.browser-use.com/cloud/browser/quickstart) when you only need the hosted browser. Browser Use CLI or a custom computer-use CLI can connect to the same Cloud Browser from your computer or your own cloud; Browser API does not add a hosted agent.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -126,29 +126,30 @@ curl -X PATCH \
 Source: https://docs.browser-use.com/cloud/which-product
 
 
-Browser Use is one API key and three ways to use it. Start from where your agent runs.
+Browser Use is three parts. An agent, the Browser Use CLI it runs, and a browser. You can take all three, or only the parts you need.
 
-| You want | Use | What runs where |
+<img src="/cloud/images/which-product-light.svg" alt="Your agent, the Browser Use CLI, and a browser; all three hosted is Cloud v4" noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="Your agent, the Browser Use CLI, and a browser; all three hosted is Cloud v4" noZoom className="hidden dark:block" />
+
+| You bring | You take from us | That is |
 |---|---|---|
-| Your own agent, running locally, driving your own browser | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent (Claude Code, Codex, Gemini CLI) writes Python over CDP against your Chrome |
-| A deployed agent you call through an API | [Browser Use Cloud v4](https://docs.browser-use.com/cloud/quickstart) | Our agent and our browsers, hosted; one API call in, a result out |
-| Only a browser: you bring your own agent, or you just need browser automation | [Browser infrastructure](https://docs.browser-use.com/cloud/browser/stealth) | Our stealth browsers with proxies, profiles and CAPTCHA handling, reachable over CDP from any agent |
+| Nothing. Send a task, get a result | Agent, CLI and browser, hosted | [Cloud v4](https://docs.browser-use.com/cloud/quickstart) |
+| Your agent: Codex, Claude Code, Hermes | The CLI, plus your Chrome or one of our cloud browsers | [Browser Use CLI](/open-source/browser-use-cli) |
+| Your agent and your own harness | Only the browser, over CDP | [Browser API](https://docs.browser-use.com/cloud/browser/stealth) |
+
+## Cloud v4
+
+The whole stack on our side. One API call or the chat at [cloud.browser-use.com](https://cloud.browser-use.com); the agent, the CLI, the browsers, proxies and live preview are hosted.
 
 ## Browser Use CLI
 
-For an agent that runs on your machine. The coding agent you already use gets a skill that talks to a browser over CDP: your running Chrome with its tabs, cookies and logins, or one of our cloud browsers. Setup is one prompt; see [Browser Use CLI](/open-source/browser-use-cli).
+Your coding agent gets the CLI as a skill and drives a browser over CDP. Your running Chrome, with its tabs and logins, or a cloud browser from us with `browser-use auth login`. Hermes ships with it by default. Setup is one prompt, see [Browser Use CLI](/open-source/browser-use-cli).
 
-## Browser Use Cloud v4
+## Browser API
 
-For an agent that runs on our side. Send a task through the API or the chat at [cloud.browser-use.com](https://cloud.browser-use.com) and get the result back. The agent, the browsers, the proxies and the live preview are all hosted. This is the CLI and our browser together, as a service.
+You have an agent and a harness and only need the browser. Create a stealth browser with residential proxies, persistent profiles and CAPTCHA handling, connect over CDP from anything.
 
-## Browser infrastructure
-
-For teams that have an agent and only need the browser. Create a stealth browser with residential proxies, persistent profiles and CAPTCHA handling, connect over CDP, and drive it from any framework or your own code.
-
-## They share one account
-
-One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) authenticates the CLI's cloud browsers (`browser-use auth login`), the v4 API, and the browser API. Credits and profiles live in the same project.
+One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.
 
 # Choosing an Agent
 Source: https://docs.browser-use.com/cloud/choosing-an-agent

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -128,24 +128,24 @@ Source: https://docs.browser-use.com/cloud/which-product
 
 Pick where your agent and browser should run.
 
-<img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex use Browser Use CLI with real Chrome or connect to the browser in our cloud. In our cloud, OpenCode, Browser Use CLI, and Cloud Browser form the fully hosted stack. Your own agent can also connect directly through the Browser API." noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex use Browser Use CLI with real Chrome or connect to the browser in our cloud. In our cloud, OpenCode, Browser Use CLI, and Cloud Browser form the fully hosted stack. Your own agent can also connect directly through the Browser API." noZoom className="hidden dark:block" />
+<img src="/cloud/images/which-product-light.svg" alt="On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other local agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI together above that Cloud Browser. Browser API is the browser-only route." noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other local agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI together above that Cloud Browser. Browser API is the browser-only route." noZoom className="hidden dark:block" />
 
-## On your machine
+## On your computer
 
-Claude Code, Codex, or another coding agent runs the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli) on your machine. The CLI either drives your real Chrome, with its tabs and logins, or connects to the hosted browser shown in our cloud.
+Claude Code, Codex, OpenCode, Hermes Agent, or another local agent can run the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli) on your computer. Local computer-use CLIs such as Playwright CLI and Agent Browser fit the same shape. They can control real Chrome, with its tabs and logins, or use the single hosted browser shown in our cloud.
 
 Start with real Chrome. Connect to our cloud when a site blocks you or you need many browsers at once. Run `browser-use auth login` once before the first cloud connection.
 
 ## In our cloud
 
-[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs OpenCode, Browser Use CLI, and Cloud Browser together. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
+[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs OpenCode and Browser Use CLI at the same level, with Cloud Browser underneath. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your computer.
 
 Use the full hosted stack for scheduled work, tasks your users trigger, and work that should keep running without your computer.
 
 ## Only the browser
 
-Bring your own agent and connect directly to the same hosted browser through the [Browser API](https://docs.browser-use.com/cloud/browser/stealth). Your agent can run on your machine or in your own cloud.
+Use the [Browser API](https://docs.browser-use.com/cloud/browser/stealth) when you only need the hosted browser. Browser Use CLI or a custom computer-use CLI can connect to the same Cloud Browser from your computer or your own cloud; Browser API does not add a hosted agent.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -126,31 +126,31 @@ curl -X PATCH \
 Source: https://docs.browser-use.com/cloud/which-product
 
 
-Three ways to use Browser Use. Run our CLI next to your own agent, hand the whole task to a hosted agent, or take only a browser.
+Three products. The difference is where your agent runs and whether you want us to provide the agent, the browser, or both.
 
 <img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="block dark:hidden" />
 <img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="hidden dark:block" />
 
 ## Browser Use CLI
 
-Your agent stays yours. Claude Code, Codex or anything else picks up the [Browser Use CLI](/open-source/browser-use-cli) as a skill and drives a browser over CDP. Hermes ships with it by default.
+Claude Code, Codex or another agent runs on your machine with the [Browser Use CLI](/open-source/browser-use-cli). The CLI drives a browser over CDP.
 
 You get two browsers to choose from:
 
 - **Your own Chrome**, with the tabs and logins you already have.
 - **Our cloud browser**, with stealth, residential proxies and CAPTCHA handling. Run `browser-use auth login` once.
 
-Same CLI either way. Start local, switch to the cloud when a site blocks you or you need many browsers at once.
+Same agent and CLI either way. Start with your Chrome. Switch to our cloud browser when a site blocks you or you need many browsers at once.
 
 ## Fully hosted agent
 
-[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs the whole thing on our side: the agent, the CLI and the browser. You send a prompt, you get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
+[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs the agent and browser for you. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
 
 Use it for scheduled work, for tasks your users trigger, and anywhere you do not want to babysit a browser.
 
 ## Only the browser
 
-You already have an agent and a harness and just need a browser that does not get blocked. Create one from the [Browser API](https://docs.browser-use.com/cloud/browser/stealth) and connect over CDP from anything.
+You already have an agent and only want our browser. Your agent can run on your machine or in your own cloud. Create a browser from the [Browser API](https://docs.browser-use.com/cloud/browser/stealth) and connect over CDP.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -128,8 +128,14 @@ Source: https://docs.browser-use.com/cloud/which-product
 
 Pick where your agent and browser should run.
 
-<img src="/cloud/images/which-product-light.svg" alt="On your computer, Claude Code, Codex, OpenCode, and Hermes Agent sit above Browser Use CLI and Playwright CLI. The CLIs use either real Chrome locally or the Cloud Browser directly. In Cloud v4, OpenCode and Browser Use CLI run above that Cloud Browser." noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="On your computer, Claude Code, Codex, OpenCode, and Hermes Agent sit above Browser Use CLI and Playwright CLI. The CLIs use either real Chrome locally or the Cloud Browser directly. In Cloud v4, OpenCode and Browser Use CLI run above that Cloud Browser." noZoom className="hidden dark:block" />
+<picture className="block dark:hidden">
+  <source media="(max-width: 600px)" srcSet="/cloud/images/which-product-light-mobile.svg" />
+  <img src="/cloud/images/which-product-light.svg" alt="On your computer, choose Claude Code, Codex, OpenCode or Hermes Agent, then Playwright CLI or Browser Use CLI. Either CLI can use real Chrome or the single Cloud Browser. A separate Profile Sync step copies selected cookies from real Chrome to a cloud profile. Hosted V4 runs OpenCode, Browser Use CLI and Cloud Browser: send a prompt, get a result." noZoom />
+</picture>
+<picture className="hidden dark:block">
+  <source media="(max-width: 600px)" srcSet="/cloud/images/which-product-dark-mobile.svg" />
+  <img src="/cloud/images/which-product-dark.svg" alt="On your computer, choose Claude Code, Codex, OpenCode or Hermes Agent, then Playwright CLI or Browser Use CLI. Either CLI can use real Chrome or the single Cloud Browser. A separate Profile Sync step copies selected cookies from real Chrome to a cloud profile. Hosted V4 runs OpenCode, Browser Use CLI and Cloud Browser: send a prompt, get a result." noZoom />
+</picture>
 
 ## On your computer
 
@@ -137,9 +143,11 @@ Claude Code, Codex, OpenCode, Hermes Agent, or another local agent can run the [
 
 Start with real Chrome. Connect to our cloud when a site blocks you or you need many browsers at once. Run `browser-use auth login` once before the first cloud connection.
 
+[Profile Sync](https://docs.browser-use.com/cloud/guides/profile-sync) copies selected cookies from real Chrome into a cloud profile. Run it explicitly for the accounts you want to use in the cloud; the dashed line does not mean automatic synchronization.
+
 ## In our cloud
 
-[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs OpenCode and Browser Use CLI at the same level, with Cloud Browser underneath. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your computer.
+[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs OpenCode, Browser Use CLI and Cloud Browser. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your computer.
 
 Use the full hosted stack for scheduled work, tasks your users trigger, and work that should keep running without your computer.
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -126,45 +126,29 @@ curl -X PATCH \
 Source: https://docs.browser-use.com/cloud/which-product
 
 
-Browser Use is one API key and five ways to use it. Start from what you want to happen, not from the product name.
+Browser Use is one API key and three ways to use it. Start from where your agent runs.
 
 | You want | Use | What runs where |
 |---|---|---|
-| A result from a browser task, by API or chat, without running anything yourself | [Browser Use Cloud](https://docs.browser-use.com/cloud/quickstart) | Our agent and our stealth browsers, in our cloud |
-| Your coding agent (Claude Code, Codex, Gemini CLI) to drive a browser you are logged into | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent, your Chrome or a cloud browser, Python over CDP |
-| To build your own agent in Python with any LLM | [Browser Use library](/open-source/quickstart) | Your code, your model, a local or self-hosted browser |
-| A desktop app instead of a terminal | [Browser Use Desktop](https://github.com/browser-use/desktop) | The CLI with a window around it, on your machine |
-| An always-on agent you text from your phone | [Browser Use Box](https://github.com/browser-use/bux) | Claude Code plus a real browser on a VPS you own, via Telegram |
+| Your own agent, running locally, driving your own browser | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent (Claude Code, Codex, Gemini CLI) writes Python over CDP against your Chrome |
+| A deployed agent you call through an API | [Browser Use Cloud v4](https://docs.browser-use.com/cloud/quickstart) | Our agent and our browsers, hosted; one API call in, a result out |
+| Only a browser: you bring your own agent, or you just need browser automation | [Browser infrastructure](https://docs.browser-use.com/cloud/guides/browser-api) | Our stealth browsers with proxies, profiles and CAPTCHA handling, reachable over CDP from any agent |
 
-## Cloud
+## Browser Use CLI
 
-Send a task, get a result. The v4 API and the chat UI at [cloud.browser-use.com](https://cloud.browser-use.com) run the agent on hosted stealth browsers with residential proxies, CAPTCHA solving, persistent profiles, and a live preview. Nothing to install; the SDK is optional.
+For an agent that runs on your machine. The coding agent you already use gets a skill that talks to a browser over CDP: your running Chrome with its tabs, cookies and logins, or one of our cloud browsers. Setup is one prompt; see [Browser Use CLI](/open-source/browser-use-cli).
 
-Pick this when you need stealth or proxies, when the task runs on a server, or when you want to scale to many sessions.
+## Browser Use Cloud v4
 
-## Browser Use CLI (`browser-use`)
+For an agent that runs on our side. Send a task through the API or the chat at [cloud.browser-use.com](https://cloud.browser-use.com) and get the result back. The agent, the browsers, the proxies and the live preview are all hosted. This is the CLI and our browser together, as a service.
 
-A skill for coding agents, backed by the open-source [browser-harness](https://github.com/browser-use/browser-harness) project. The agent writes Python that talks to a browser over CDP: your running Chrome with its tabs, cookies, and logins, a Browser Use cloud browser, or any CDP endpoint.
+## Browser infrastructure
 
-Pick this when you are already inside Claude Code or Codex and want it to click, type, and read pages in a browser you control. Setup is a single prompt; see [Browser Use CLI](/open-source/browser-use-cli).
-
-## Browser Use library (`pip install browser-use`)
-
-The Python framework the company started with. Bring your own LLM, run the agent in your own process, and customize tools, prompts, and the browser session. Works with a local browser or with cloud browsers through the same API key.
-
-Pick this when you are building your own agent product or need full control over the loop.
-
-## Browser Use Desktop
-
-An open-source desktop app for people who do not live in a terminal. It gives the CLI a window: type a goal, watch the browser, approve steps. Same local-browser model as the CLI.
-
-## Browser Use Box (BUX)
-
-One install script turns any Ubuntu box into a 24/7 agent with Claude Code, the CLI, and a real browser preinstalled. You talk to it over Telegram. Pick this when you want an agent that keeps working while your laptop is closed.
+For teams that have an agent and only need the browser. Create a stealth browser with residential proxies, persistent profiles and CAPTCHA handling, connect over CDP, and drive it from any framework or your own code.
 
 ## They share one account
 
-The same API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) authenticates the SDK, the CLI's cloud browsers (`browser-use auth login`), the library's `ChatBrowserUse` model, and Browser Use Box. Credits and profiles live in the same project.
+One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) authenticates the CLI's cloud browsers (`browser-use auth login`), the v4 API, and the browser API. Credits and profiles live in the same project.
 
 # Choosing an Agent
 Source: https://docs.browser-use.com/cloud/choosing-an-agent

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -128,8 +128,8 @@ Source: https://docs.browser-use.com/cloud/which-product
 
 Pick where your agent and browser should run.
 
-<img src="/cloud/images/which-product-light.svg" alt="On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other local agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI together above that Cloud Browser. Browser API is the browser-only route." noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other local agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI together above that Cloud Browser. Browser API is the browser-only route." noZoom className="hidden dark:block" />
+<img src="/cloud/images/which-product-light.svg" alt="On your computer, Claude Code, Codex, OpenCode, and Hermes Agent sit above Browser Use CLI and Playwright CLI. The CLIs use either real Chrome locally or the Cloud Browser directly. In Cloud v4, OpenCode and Browser Use CLI run above that Cloud Browser." noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="On your computer, Claude Code, Codex, OpenCode, and Hermes Agent sit above Browser Use CLI and Playwright CLI. The CLIs use either real Chrome locally or the Cloud Browser directly. In Cloud v4, OpenCode and Browser Use CLI run above that Cloud Browser." noZoom className="hidden dark:block" />
 
 ## On your computer
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -126,28 +126,31 @@ curl -X PATCH \
 Source: https://docs.browser-use.com/cloud/which-product
 
 
-Browser Use is three parts. An agent, the Browser Use CLI it runs, and a browser. You can take all three, or only the parts you need.
+Three ways to use Browser Use. Run our CLI next to your own agent, hand the whole task to a hosted agent, or take only a browser.
 
-<img src="/cloud/images/which-product-light.svg" alt="Your agent, the Browser Use CLI, and a browser; all three hosted is Cloud v4" noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="Your agent, the Browser Use CLI, and a browser; all three hosted is Cloud v4" noZoom className="hidden dark:block" />
-
-| You bring | You take from us | That is |
-|---|---|---|
-| Nothing. Send a task, get a result | Agent, CLI and browser, hosted | [Cloud v4](https://docs.browser-use.com/cloud/quickstart) |
-| Your agent: Codex, Claude Code, Hermes | The CLI, plus your Chrome or one of our cloud browsers | [Browser Use CLI](/open-source/browser-use-cli) |
-| Your agent and your own harness | Only the browser, over CDP | [Browser API](https://docs.browser-use.com/cloud/browser/stealth) |
-
-## Cloud v4
-
-The whole stack on our side. One API call or the chat at [cloud.browser-use.com](https://cloud.browser-use.com); the agent, the CLI, the browsers, proxies and live preview are hosted.
+<img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="hidden dark:block" />
 
 ## Browser Use CLI
 
-Your coding agent gets the CLI as a skill and drives a browser over CDP. Your running Chrome, with its tabs and logins, or a cloud browser from us with `browser-use auth login`. Hermes ships with it by default. Setup is one prompt, see [Browser Use CLI](/open-source/browser-use-cli).
+Your agent stays yours. Claude Code, Codex or anything else picks up the [Browser Use CLI](/open-source/browser-use-cli) as a skill and drives a browser over CDP. Hermes ships with it by default.
 
-## Browser API
+You get two browsers to choose from:
 
-You have an agent and a harness and only need the browser. Create a stealth browser with residential proxies, persistent profiles and CAPTCHA handling, connect over CDP from anything.
+- **Your own Chrome**, with the tabs and logins you already have.
+- **Our cloud browser**, with stealth, residential proxies and CAPTCHA handling. Run `browser-use auth login` once.
+
+Same CLI either way. Start local, switch to the cloud when a site blocks you or you need many browsers at once.
+
+## Fully hosted agent
+
+[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs the whole thing on our side: the agent, the CLI and the browser. You send a prompt, you get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
+
+Use it for scheduled work, for tasks your users trigger, and anywhere you do not want to babysit a browser.
+
+## Only the browser
+
+You already have an agent and a harness and just need a browser that does not get blocked. Create one from the [Browser API](https://docs.browser-use.com/cloud/browser/stealth) and connect over CDP from anything.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -126,31 +126,26 @@ curl -X PATCH \
 Source: https://docs.browser-use.com/cloud/which-product
 
 
-Three products. The difference is where your agent runs and whether you want us to provide the agent, the browser, or both.
+Pick where your agent and browser should run.
 
-<img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="hidden dark:block" />
+<img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex use Browser Use CLI with real Chrome or connect to the browser in our cloud. In our cloud, OpenCode, Browser Use CLI, and Cloud Browser form the fully hosted stack. Your own agent can also connect directly through the Browser API." noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex use Browser Use CLI with real Chrome or connect to the browser in our cloud. In our cloud, OpenCode, Browser Use CLI, and Cloud Browser form the fully hosted stack. Your own agent can also connect directly through the Browser API." noZoom className="hidden dark:block" />
 
-## Browser Use CLI
+## On your machine
 
-Claude Code, Codex or another agent runs on your machine with the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli). The CLI drives a browser over CDP.
+Claude Code, Codex, or another coding agent runs the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli) on your machine. The CLI either drives your real Chrome, with its tabs and logins, or connects to the hosted browser shown in our cloud.
 
-You get two browsers to choose from:
+Start with real Chrome. Connect to our cloud when a site blocks you or you need many browsers at once. Run `browser-use auth login` once before the first cloud connection.
 
-- **Your own Chrome**, with the tabs and logins you already have.
-- **Our cloud browser**, with stealth, residential proxies and CAPTCHA handling. Run `browser-use auth login` once.
+## In our cloud
 
-Same agent and CLI either way. Start with your Chrome. Switch to our cloud browser when a site blocks you or you need many browsers at once.
+[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs OpenCode, Browser Use CLI, and Cloud Browser together. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
 
-## Fully hosted agent
-
-[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs the agent and browser for you. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
-
-Use it for scheduled work, for tasks your users trigger, and anywhere you do not want to babysit a browser.
+Use the full hosted stack for scheduled work, tasks your users trigger, and work that should keep running without your computer.
 
 ## Only the browser
 
-You already have an agent and only want our browser. Your agent can run on your machine or in your own cloud. Create a browser from the [Browser API](https://docs.browser-use.com/cloud/browser/stealth) and connect over CDP.
+Bring your own agent and connect directly to the same hosted browser through the [Browser API](https://docs.browser-use.com/cloud/browser/stealth). Your agent can run on your machine or in your own cloud.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -132,7 +132,7 @@ Browser Use is one API key and three ways to use it. Start from where your agent
 |---|---|---|
 | Your own agent, running locally, driving your own browser | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent (Claude Code, Codex, Gemini CLI) writes Python over CDP against your Chrome |
 | A deployed agent you call through an API | [Browser Use Cloud v4](https://docs.browser-use.com/cloud/quickstart) | Our agent and our browsers, hosted; one API call in, a result out |
-| Only a browser: you bring your own agent, or you just need browser automation | [Browser infrastructure](https://docs.browser-use.com/cloud/guides/browser-api) | Our stealth browsers with proxies, profiles and CAPTCHA handling, reachable over CDP from any agent |
+| Only a browser: you bring your own agent, or you just need browser automation | [Browser infrastructure](https://docs.browser-use.com/cloud/browser/stealth) | Our stealth browsers with proxies, profiles and CAPTCHA handling, reachable over CDP from any agent |
 
 ## Browser Use CLI
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -133,7 +133,7 @@ Three products. The difference is where your agent runs and whether you want us 
 
 ## Browser Use CLI
 
-Claude Code, Codex or another agent runs on your machine with the [Browser Use CLI](/open-source/browser-use-cli). The CLI drives a browser over CDP.
+Claude Code, Codex or another agent runs on your machine with the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli). The CLI drives a browser over CDP.
 
 You get two browsers to choose from:
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -122,6 +122,50 @@ curl -X PATCH \
 [Copy for an LLM](https://docs.browser-use.com/cloud/llms.txt)
   Give your coding agent the compact API V4 context.
 
+# Which Browser Use do I need?
+Source: https://docs.browser-use.com/cloud/which-product
+
+
+Browser Use is one API key and five ways to use it. Start from what you want to happen, not from the product name.
+
+| You want | Use | What runs where |
+|---|---|---|
+| A result from a browser task, by API or chat, without running anything yourself | [Browser Use Cloud](https://docs.browser-use.com/cloud/quickstart) | Our agent and our stealth browsers, in our cloud |
+| Your coding agent (Claude Code, Codex, Gemini CLI) to drive a browser you are logged into | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent, your Chrome or a cloud browser, Python over CDP |
+| To build your own agent in Python with any LLM | [Browser Use library](/open-source/quickstart) | Your code, your model, a local or self-hosted browser |
+| A desktop app instead of a terminal | [Browser Use Desktop](https://github.com/browser-use/desktop) | The CLI with a window around it, on your machine |
+| An always-on agent you text from your phone | [Browser Use Box](https://github.com/browser-use/bux) | Claude Code plus a real browser on a VPS you own, via Telegram |
+
+## Cloud
+
+Send a task, get a result. The v4 API and the chat UI at [cloud.browser-use.com](https://cloud.browser-use.com) run the agent on hosted stealth browsers with residential proxies, CAPTCHA solving, persistent profiles, and a live preview. Nothing to install; the SDK is optional.
+
+Pick this when you need stealth or proxies, when the task runs on a server, or when you want to scale to many sessions.
+
+## Browser Use CLI (`browser-use`)
+
+A skill for coding agents, backed by the open-source [browser-harness](https://github.com/browser-use/browser-harness) project. The agent writes Python that talks to a browser over CDP: your running Chrome with its tabs, cookies, and logins, a Browser Use cloud browser, or any CDP endpoint.
+
+Pick this when you are already inside Claude Code or Codex and want it to click, type, and read pages in a browser you control. Setup is a single prompt; see [Browser Use CLI](/open-source/browser-use-cli).
+
+## Browser Use library (`pip install browser-use`)
+
+The Python framework the company started with. Bring your own LLM, run the agent in your own process, and customize tools, prompts, and the browser session. Works with a local browser or with cloud browsers through the same API key.
+
+Pick this when you are building your own agent product or need full control over the loop.
+
+## Browser Use Desktop
+
+An open-source desktop app for people who do not live in a terminal. It gives the CLI a window: type a goal, watch the browser, approve steps. Same local-browser model as the CLI.
+
+## Browser Use Box (BUX)
+
+One install script turns any Ubuntu box into a 24/7 agent with Claude Code, the CLI, and a real browser preinstalled. You talk to it over Telegram. Pick this when you want an agent that keeps working while your laptop is closed.
+
+## They share one account
+
+The same API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) authenticates the SDK, the CLI's cloud browsers (`browser-use auth login`), the library's `ChatBrowserUse` model, and Browser Use Box. Credits and profiles live in the same project.
+
 # Choosing an Agent
 Source: https://docs.browser-use.com/cloud/choosing-an-agent
 

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -67,7 +67,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): Run a hosted agent or launch a cloud browser.
-- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Our browser, our CLI, or both together hosted as v4: pick by where your agent runs.
+- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Three parts: your agent, our CLI, a browser. Take all three hosted, or only what you need.
 - [Choosing an Agent](https://docs.browser-use.com/cloud/choosing-an-agent): Compare Browser Use Cloud agents on accuracy, speed and price, and pick the right one for your task.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
 

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -67,7 +67,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): Run a hosted agent or launch a cloud browser.
-- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Three parts: your agent, our CLI, a browser. Take all three hosted, or only what you need.
+- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Run our CLI on your machine with your Chrome or our cloud browser, send a prompt to the fully hosted agent, or take only the browser.
 - [Choosing an Agent](https://docs.browser-use.com/cloud/choosing-an-agent): Compare Browser Use Cloud agents on accuracy, speed and price, and pick the right one for your task.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
 

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -67,7 +67,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): Run a hosted agent or launch a cloud browser.
-- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Cloud, the open-source library, the CLI for coding agents, the desktop app, or Browser Use Box: pick by where you want the browser and the agent to run.
+- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Our browser, our CLI, or both together hosted as v4: pick by where your agent runs.
 - [Choosing an Agent](https://docs.browser-use.com/cloud/choosing-an-agent): Compare Browser Use Cloud agents on accuracy, speed and price, and pick the right one for your task.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
 

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -67,7 +67,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): Run a hosted agent or launch a cloud browser.
-- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Run our CLI on your machine with your Chrome or our cloud browser, send a prompt to the fully hosted agent, or take only the browser.
+- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Keep Claude Code or Codex on your machine, send the whole task to our cloud, or take only our browser.
 - [Choosing an Agent](https://docs.browser-use.com/cloud/choosing-an-agent): Compare Browser Use Cloud agents on accuracy, speed and price, and pick the right one for your task.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
 

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -67,6 +67,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): Run a hosted agent or launch a cloud browser.
+- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Cloud, the open-source library, the CLI for coding agents, the desktop app, or Browser Use Box: pick by where you want the browser and the agent to run.
 - [Choosing an Agent](https://docs.browser-use.com/cloud/choosing-an-agent): Compare Browser Use Cloud agents on accuracy, speed and price, and pick the right one for your task.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
 

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -67,7 +67,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): Run a hosted agent or launch a cloud browser.
-- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Keep Claude Code or Codex on your machine, send the whole task to our cloud, or take only our browser.
+- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Run Browser Use on your machine, run the full stack in our cloud, or bring your own agent and use only the hosted browser.
 - [Choosing an Agent](https://docs.browser-use.com/cloud/choosing-an-agent): Compare Browser Use Cloud agents on accuracy, speed and price, and pick the right one for your task.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
 

--- a/docs/cloud/which-product.mdx
+++ b/docs/cloud/which-product.mdx
@@ -1,31 +1,34 @@
 ---
 title: "Which Browser Use do I need?"
 sidebarTitle: "Which product?"
-description: "Three parts: your agent, our CLI, a browser. Take all three hosted, or only what you need."
+description: "Run our CLI on your machine with your Chrome or our cloud browser, send a prompt to the fully hosted agent, or take only the browser."
 icon: "signs-post"
 ---
 
-Browser Use is three parts. An agent, the Browser Use CLI it runs, and a browser. You can take all three, or only the parts you need.
+Three ways to use Browser Use. Run our CLI next to your own agent, hand the whole task to a hosted agent, or take only a browser.
 
-<img src="/cloud/images/which-product-light.svg" alt="Your agent, the Browser Use CLI, and a browser; all three hosted is Cloud v4" noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="Your agent, the Browser Use CLI, and a browser; all three hosted is Cloud v4" noZoom className="hidden dark:block" />
-
-| You bring | You take from us | That is |
-|---|---|---|
-| Nothing. Send a task, get a result | Agent, CLI and browser, hosted | [Cloud v4](/cloud/quickstart) |
-| Your agent: Codex, Claude Code, Hermes | The CLI, plus your Chrome or one of our cloud browsers | [Browser Use CLI](/open-source/browser-use-cli) |
-| Your agent and your own harness | Only the browser, over CDP | [Browser API](/cloud/browser/stealth) |
-
-## Cloud v4
-
-The whole stack on our side. One API call or the chat at [cloud.browser-use.com](https://cloud.browser-use.com); the agent, the CLI, the browsers, proxies and live preview are hosted.
+<img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="hidden dark:block" />
 
 ## Browser Use CLI
 
-Your coding agent gets the CLI as a skill and drives a browser over CDP. Your running Chrome, with its tabs and logins, or a cloud browser from us with `browser-use auth login`. Hermes ships with it by default. Setup is one prompt, see [Browser Use CLI](/open-source/browser-use-cli).
+Your agent stays yours. Claude Code, Codex or anything else picks up the [Browser Use CLI](/open-source/browser-use-cli) as a skill and drives a browser over CDP. Hermes ships with it by default.
 
-## Browser API
+You get two browsers to choose from:
 
-You have an agent and a harness and only need the browser. Create a stealth browser with residential proxies, persistent profiles and CAPTCHA handling, connect over CDP from anything.
+- **Your own Chrome**, with the tabs and logins you already have.
+- **Our cloud browser**, with stealth, residential proxies and CAPTCHA handling. Run `browser-use auth login` once.
+
+Same CLI either way. Start local, switch to the cloud when a site blocks you or you need many browsers at once.
+
+## Fully hosted agent
+
+[Cloud v4](/cloud/quickstart) runs the whole thing on our side: the agent, the CLI and the browser. You send a prompt, you get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
+
+Use it for scheduled work, for tasks your users trigger, and anywhere you do not want to babysit a browser.
+
+## Only the browser
+
+You already have an agent and a harness and just need a browser that does not get blocked. Create one from the [Browser API](/cloud/browser/stealth) and connect over CDP from anything.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.

--- a/docs/cloud/which-product.mdx
+++ b/docs/cloud/which-product.mdx
@@ -1,34 +1,34 @@
 ---
 title: "Which Browser Use do I need?"
 sidebarTitle: "Which product?"
-description: "Run our CLI on your machine with your Chrome or our cloud browser, send a prompt to the fully hosted agent, or take only the browser."
+description: "Keep Claude Code or Codex on your machine, send the whole task to our cloud, or take only our browser."
 icon: "signs-post"
 ---
 
-Three ways to use Browser Use. Run our CLI next to your own agent, hand the whole task to a hosted agent, or take only a browser.
+Three products. The difference is where your agent runs and whether you want us to provide the agent, the browser, or both.
 
 <img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="block dark:hidden" />
 <img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="hidden dark:block" />
 
 ## Browser Use CLI
 
-Your agent stays yours. Claude Code, Codex or anything else picks up the [Browser Use CLI](/open-source/browser-use-cli) as a skill and drives a browser over CDP. Hermes ships with it by default.
+Claude Code, Codex or another agent runs on your machine with the [Browser Use CLI](/open-source/browser-use-cli). The CLI drives a browser over CDP.
 
 You get two browsers to choose from:
 
 - **Your own Chrome**, with the tabs and logins you already have.
 - **Our cloud browser**, with stealth, residential proxies and CAPTCHA handling. Run `browser-use auth login` once.
 
-Same CLI either way. Start local, switch to the cloud when a site blocks you or you need many browsers at once.
+Same agent and CLI either way. Start with your Chrome. Switch to our cloud browser when a site blocks you or you need many browsers at once.
 
 ## Fully hosted agent
 
-[Cloud v4](/cloud/quickstart) runs the whole thing on our side: the agent, the CLI and the browser. You send a prompt, you get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
+[Cloud v4](/cloud/quickstart) runs the agent and browser for you. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
 
 Use it for scheduled work, for tasks your users trigger, and anywhere you do not want to babysit a browser.
 
 ## Only the browser
 
-You already have an agent and a harness and just need a browser that does not get blocked. Create one from the [Browser API](/cloud/browser/stealth) and connect over CDP from anything.
+You already have an agent and only want our browser. Your agent can run on your machine or in your own cloud. Create a browser from the [Browser API](/cloud/browser/stealth) and connect over CDP.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.

--- a/docs/cloud/which-product.mdx
+++ b/docs/cloud/which-product.mdx
@@ -1,34 +1,29 @@
 ---
 title: "Which Browser Use do I need?"
 sidebarTitle: "Which product?"
-description: "Keep Claude Code or Codex on your machine, send the whole task to our cloud, or take only our browser."
+description: "Run Browser Use on your machine, run the full stack in our cloud, or bring your own agent and use only the hosted browser."
 icon: "signs-post"
 ---
 
-Three products. The difference is where your agent runs and whether you want us to provide the agent, the browser, or both.
+Pick where your agent and browser should run.
 
-<img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="hidden dark:block" />
+<img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex use Browser Use CLI with real Chrome or connect to the browser in our cloud. In our cloud, OpenCode, Browser Use CLI, and Cloud Browser form the fully hosted stack. Your own agent can also connect directly through the Browser API." noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex use Browser Use CLI with real Chrome or connect to the browser in our cloud. In our cloud, OpenCode, Browser Use CLI, and Cloud Browser form the fully hosted stack. Your own agent can also connect directly through the Browser API." noZoom className="hidden dark:block" />
 
-## Browser Use CLI
+## On your machine
 
-Claude Code, Codex or another agent runs on your machine with the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli). The CLI drives a browser over CDP.
+Claude Code, Codex, or another coding agent runs the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli) on your machine. The CLI either drives your real Chrome, with its tabs and logins, or connects to the hosted browser shown in our cloud.
 
-You get two browsers to choose from:
+Start with real Chrome. Connect to our cloud when a site blocks you or you need many browsers at once. Run `browser-use auth login` once before the first cloud connection.
 
-- **Your own Chrome**, with the tabs and logins you already have.
-- **Our cloud browser**, with stealth, residential proxies and CAPTCHA handling. Run `browser-use auth login` once.
+## In our cloud
 
-Same agent and CLI either way. Start with your Chrome. Switch to our cloud browser when a site blocks you or you need many browsers at once.
+[Cloud v4](/cloud/quickstart) runs OpenCode, Browser Use CLI, and Cloud Browser together. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
 
-## Fully hosted agent
-
-[Cloud v4](/cloud/quickstart) runs the agent and browser for you. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
-
-Use it for scheduled work, for tasks your users trigger, and anywhere you do not want to babysit a browser.
+Use the full hosted stack for scheduled work, tasks your users trigger, and work that should keep running without your computer.
 
 ## Only the browser
 
-You already have an agent and only want our browser. Your agent can run on your machine or in your own cloud. Create a browser from the [Browser API](/cloud/browser/stealth) and connect over CDP.
+Bring your own agent and connect directly to the same hosted browser through the [Browser API](/cloud/browser/stealth). Your agent can run on your machine or in your own cloud.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.

--- a/docs/cloud/which-product.mdx
+++ b/docs/cloud/which-product.mdx
@@ -11,7 +11,7 @@ Browser Use is one API key and three ways to use it. Start from where your agent
 |---|---|---|
 | Your own agent, running locally, driving your own browser | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent (Claude Code, Codex, Gemini CLI) writes Python over CDP against your Chrome |
 | A deployed agent you call through an API | [Browser Use Cloud v4](/cloud/quickstart) | Our agent and our browsers, hosted; one API call in, a result out |
-| Only a browser: you bring your own agent, or you just need browser automation | [Browser infrastructure](/cloud/guides/browser-api) | Our stealth browsers with proxies, profiles and CAPTCHA handling, reachable over CDP from any agent |
+| Only a browser: you bring your own agent, or you just need browser automation | [Browser infrastructure](/cloud/browser/stealth) | Our stealth browsers with proxies, profiles and CAPTCHA handling, reachable over CDP from any agent |
 
 ## Browser Use CLI
 

--- a/docs/cloud/which-product.mdx
+++ b/docs/cloud/which-product.mdx
@@ -32,6 +32,6 @@ Use the full hosted stack for scheduled work, tasks your users trigger, and work
 
 ## Only the browser
 
-Use the [Browser API](/cloud/browser/stealth) when you only need the hosted browser. Browser Use CLI or a custom computer-use CLI can connect to the same Cloud Browser from your computer or your own cloud; Browser API does not add a hosted agent.
+Use the [Browser API](/cloud/browser/quickstart) when you only need the hosted browser. Browser Use CLI or a custom computer-use CLI can connect to the same Cloud Browser from your computer or your own cloud; Browser API does not add a hosted agent.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.

--- a/docs/cloud/which-product.mdx
+++ b/docs/cloud/which-product.mdx
@@ -7,8 +7,14 @@ icon: "signs-post"
 
 Pick where your agent and browser should run.
 
-<img src="/cloud/images/which-product-light.svg" alt="On your computer, Claude Code, Codex, OpenCode, and Hermes Agent sit above Browser Use CLI and Playwright CLI. The CLIs use either real Chrome locally or the Cloud Browser directly. In Cloud v4, OpenCode and Browser Use CLI run above that Cloud Browser." noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="On your computer, Claude Code, Codex, OpenCode, and Hermes Agent sit above Browser Use CLI and Playwright CLI. The CLIs use either real Chrome locally or the Cloud Browser directly. In Cloud v4, OpenCode and Browser Use CLI run above that Cloud Browser." noZoom className="hidden dark:block" />
+<picture className="block dark:hidden">
+  <source media="(max-width: 600px)" srcSet="/cloud/images/which-product-light-mobile.svg" />
+  <img src="/cloud/images/which-product-light.svg" alt="On your computer, choose Claude Code, Codex, OpenCode or Hermes Agent, then Playwright CLI or Browser Use CLI. Either CLI can use real Chrome or the single Cloud Browser. A separate Profile Sync step copies selected cookies from real Chrome to a cloud profile. Hosted V4 runs OpenCode, Browser Use CLI and Cloud Browser: send a prompt, get a result." noZoom />
+</picture>
+<picture className="hidden dark:block">
+  <source media="(max-width: 600px)" srcSet="/cloud/images/which-product-dark-mobile.svg" />
+  <img src="/cloud/images/which-product-dark.svg" alt="On your computer, choose Claude Code, Codex, OpenCode or Hermes Agent, then Playwright CLI or Browser Use CLI. Either CLI can use real Chrome or the single Cloud Browser. A separate Profile Sync step copies selected cookies from real Chrome to a cloud profile. Hosted V4 runs OpenCode, Browser Use CLI and Cloud Browser: send a prompt, get a result." noZoom />
+</picture>
 
 ## On your computer
 
@@ -16,9 +22,11 @@ Claude Code, Codex, OpenCode, Hermes Agent, or another local agent can run the [
 
 Start with real Chrome. Connect to our cloud when a site blocks you or you need many browsers at once. Run `browser-use auth login` once before the first cloud connection.
 
+[Profile Sync](/cloud/guides/profile-sync) copies selected cookies from real Chrome into a cloud profile. Run it explicitly for the accounts you want to use in the cloud; the dashed line does not mean automatic synchronization.
+
 ## In our cloud
 
-[Cloud v4](/cloud/quickstart) runs OpenCode and Browser Use CLI at the same level, with Cloud Browser underneath. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your computer.
+[Cloud v4](/cloud/quickstart) runs OpenCode, Browser Use CLI and Cloud Browser. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your computer.
 
 Use the full hosted stack for scheduled work, tasks your users trigger, and work that should keep running without your computer.
 

--- a/docs/cloud/which-product.mdx
+++ b/docs/cloud/which-product.mdx
@@ -12,7 +12,7 @@ Three products. The difference is where your agent runs and whether you want us 
 
 ## Browser Use CLI
 
-Claude Code, Codex or another agent runs on your machine with the [Browser Use CLI](/open-source/browser-use-cli). The CLI drives a browser over CDP.
+Claude Code, Codex or another agent runs on your machine with the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli). The CLI drives a browser over CDP.
 
 You get two browsers to choose from:
 

--- a/docs/cloud/which-product.mdx
+++ b/docs/cloud/which-product.mdx
@@ -11,7 +11,7 @@ Browser Use is one API key and three ways to use it. Start from where your agent
 |---|---|---|
 | Your own agent, running locally, driving your own browser | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent (Claude Code, Codex, Gemini CLI) writes Python over CDP against your Chrome |
 | A deployed agent you call through an API | [Browser Use Cloud v4](/cloud/quickstart) | Our agent and our browsers, hosted; one API call in, a result out |
-| Only a browser: you bring your own agent, or you just need browser automation | [Browser infrastructure](/cloud/browser-api) | Our stealth browsers with proxies, profiles and CAPTCHA handling, reachable over CDP from any agent |
+| Only a browser: you bring your own agent, or you just need browser automation | [Browser infrastructure](/cloud/guides/browser-api) | Our stealth browsers with proxies, profiles and CAPTCHA handling, reachable over CDP from any agent |
 
 ## Browser Use CLI
 

--- a/docs/cloud/which-product.mdx
+++ b/docs/cloud/which-product.mdx
@@ -7,8 +7,8 @@ icon: "signs-post"
 
 Pick where your agent and browser should run.
 
-<img src="/cloud/images/which-product-light.svg" alt="On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other local agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI together above that Cloud Browser. Browser API is the browser-only route." noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other local agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI together above that Cloud Browser. Browser API is the browser-only route." noZoom className="hidden dark:block" />
+<img src="/cloud/images/which-product-light.svg" alt="On your computer, Claude Code, Codex, OpenCode, and Hermes Agent sit above Browser Use CLI and Playwright CLI. The CLIs use either real Chrome locally or the Cloud Browser directly. In Cloud v4, OpenCode and Browser Use CLI run above that Cloud Browser." noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="On your computer, Claude Code, Codex, OpenCode, and Hermes Agent sit above Browser Use CLI and Playwright CLI. The CLIs use either real Chrome locally or the Cloud Browser directly. In Cloud v4, OpenCode and Browser Use CLI run above that Cloud Browser." noZoom className="hidden dark:block" />
 
 ## On your computer
 

--- a/docs/cloud/which-product.mdx
+++ b/docs/cloud/which-product.mdx
@@ -1,0 +1,46 @@
+---
+title: "Which Browser Use do I need?"
+sidebarTitle: "Which product?"
+description: "Cloud, the open-source library, the CLI for coding agents, the desktop app, or Browser Use Box: pick by where you want the browser and the agent to run."
+icon: "signs-post"
+---
+
+Browser Use is one API key and five ways to use it. Start from what you want to happen, not from the product name.
+
+| You want | Use | What runs where |
+|---|---|---|
+| A result from a browser task, by API or chat, without running anything yourself | [Browser Use Cloud](/cloud/quickstart) | Our agent and our stealth browsers, in our cloud |
+| Your coding agent (Claude Code, Codex, Gemini CLI) to drive a browser you are logged into | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent, your Chrome or a cloud browser, Python over CDP |
+| To build your own agent in Python with any LLM | [Browser Use library](/open-source/quickstart) | Your code, your model, a local or self-hosted browser |
+| A desktop app instead of a terminal | [Browser Use Desktop](https://github.com/browser-use/desktop) | The CLI with a window around it, on your machine |
+| An always-on agent you text from your phone | [Browser Use Box](https://github.com/browser-use/bux) | Claude Code plus a real browser on a VPS you own, via Telegram |
+
+## Cloud
+
+Send a task, get a result. The v4 API and the chat UI at [cloud.browser-use.com](https://cloud.browser-use.com) run the agent on hosted stealth browsers with residential proxies, CAPTCHA solving, persistent profiles, and a live preview. Nothing to install; the SDK is optional.
+
+Pick this when you need stealth or proxies, when the task runs on a server, or when you want to scale to many sessions.
+
+## Browser Use CLI (`browser-use`)
+
+A skill for coding agents, backed by the open-source [browser-harness](https://github.com/browser-use/browser-harness) project. The agent writes Python that talks to a browser over CDP: your running Chrome with its tabs, cookies, and logins, a Browser Use cloud browser, or any CDP endpoint.
+
+Pick this when you are already inside Claude Code or Codex and want it to click, type, and read pages in a browser you control. Setup is a single prompt; see [Browser Use CLI](/open-source/browser-use-cli).
+
+## Browser Use library (`pip install browser-use`)
+
+The Python framework the company started with. Bring your own LLM, run the agent in your own process, and customize tools, prompts, and the browser session. Works with a local browser or with cloud browsers through the same API key.
+
+Pick this when you are building your own agent product or need full control over the loop.
+
+## Browser Use Desktop
+
+An open-source desktop app for people who do not live in a terminal. It gives the CLI a window: type a goal, watch the browser, approve steps. Same local-browser model as the CLI.
+
+## Browser Use Box (BUX)
+
+One install script turns any Ubuntu box into a 24/7 agent with Claude Code, the CLI, and a real browser preinstalled. You talk to it over Telegram. Pick this when you want an agent that keeps working while your laptop is closed.
+
+## They share one account
+
+The same API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) authenticates the SDK, the CLI's cloud browsers (`browser-use auth login`), the library's `ChatBrowserUse` model, and Browser Use Box. Credits and profiles live in the same project.

--- a/docs/cloud/which-product.mdx
+++ b/docs/cloud/which-product.mdx
@@ -1,30 +1,31 @@
 ---
 title: "Which Browser Use do I need?"
 sidebarTitle: "Which product?"
-description: "Our browser, our CLI, or both together hosted as v4: pick by where your agent runs."
+description: "Three parts: your agent, our CLI, a browser. Take all three hosted, or only what you need."
 icon: "signs-post"
 ---
 
-Browser Use is one API key and three ways to use it. Start from where your agent runs.
+Browser Use is three parts. An agent, the Browser Use CLI it runs, and a browser. You can take all three, or only the parts you need.
 
-| You want | Use | What runs where |
+<img src="/cloud/images/which-product-light.svg" alt="Your agent, the Browser Use CLI, and a browser; all three hosted is Cloud v4" noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="Your agent, the Browser Use CLI, and a browser; all three hosted is Cloud v4" noZoom className="hidden dark:block" />
+
+| You bring | You take from us | That is |
 |---|---|---|
-| Your own agent, running locally, driving your own browser | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent (Claude Code, Codex, Gemini CLI) writes Python over CDP against your Chrome |
-| A deployed agent you call through an API | [Browser Use Cloud v4](/cloud/quickstart) | Our agent and our browsers, hosted; one API call in, a result out |
-| Only a browser: you bring your own agent, or you just need browser automation | [Browser infrastructure](/cloud/browser/stealth) | Our stealth browsers with proxies, profiles and CAPTCHA handling, reachable over CDP from any agent |
+| Nothing. Send a task, get a result | Agent, CLI and browser, hosted | [Cloud v4](/cloud/quickstart) |
+| Your agent: Codex, Claude Code, Hermes | The CLI, plus your Chrome or one of our cloud browsers | [Browser Use CLI](/open-source/browser-use-cli) |
+| Your agent and your own harness | Only the browser, over CDP | [Browser API](/cloud/browser/stealth) |
+
+## Cloud v4
+
+The whole stack on our side. One API call or the chat at [cloud.browser-use.com](https://cloud.browser-use.com); the agent, the CLI, the browsers, proxies and live preview are hosted.
 
 ## Browser Use CLI
 
-For an agent that runs on your machine. The coding agent you already use gets a skill that talks to a browser over CDP: your running Chrome with its tabs, cookies and logins, or one of our cloud browsers. Setup is one prompt; see [Browser Use CLI](/open-source/browser-use-cli).
+Your coding agent gets the CLI as a skill and drives a browser over CDP. Your running Chrome, with its tabs and logins, or a cloud browser from us with `browser-use auth login`. Hermes ships with it by default. Setup is one prompt, see [Browser Use CLI](/open-source/browser-use-cli).
 
-## Browser Use Cloud v4
+## Browser API
 
-For an agent that runs on our side. Send a task through the API or the chat at [cloud.browser-use.com](https://cloud.browser-use.com) and get the result back. The agent, the browsers, the proxies and the live preview are all hosted. This is the CLI and our browser together, as a service.
+You have an agent and a harness and only need the browser. Create a stealth browser with residential proxies, persistent profiles and CAPTCHA handling, connect over CDP from anything.
 
-## Browser infrastructure
-
-For teams that have an agent and only need the browser. Create a stealth browser with residential proxies, persistent profiles and CAPTCHA handling, connect over CDP, and drive it from any framework or your own code.
-
-## They share one account
-
-One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) authenticates the CLI's cloud browsers (`browser-use auth login`), the v4 API, and the browser API. Credits and profiles live in the same project.
+One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.

--- a/docs/cloud/which-product.mdx
+++ b/docs/cloud/which-product.mdx
@@ -1,46 +1,30 @@
 ---
 title: "Which Browser Use do I need?"
 sidebarTitle: "Which product?"
-description: "Cloud, the open-source library, the CLI for coding agents, the desktop app, or Browser Use Box: pick by where you want the browser and the agent to run."
+description: "Our browser, our CLI, or both together hosted as v4: pick by where your agent runs."
 icon: "signs-post"
 ---
 
-Browser Use is one API key and five ways to use it. Start from what you want to happen, not from the product name.
+Browser Use is one API key and three ways to use it. Start from where your agent runs.
 
 | You want | Use | What runs where |
 |---|---|---|
-| A result from a browser task, by API or chat, without running anything yourself | [Browser Use Cloud](/cloud/quickstart) | Our agent and our stealth browsers, in our cloud |
-| Your coding agent (Claude Code, Codex, Gemini CLI) to drive a browser you are logged into | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent, your Chrome or a cloud browser, Python over CDP |
-| To build your own agent in Python with any LLM | [Browser Use library](/open-source/quickstart) | Your code, your model, a local or self-hosted browser |
-| A desktop app instead of a terminal | [Browser Use Desktop](https://github.com/browser-use/desktop) | The CLI with a window around it, on your machine |
-| An always-on agent you text from your phone | [Browser Use Box](https://github.com/browser-use/bux) | Claude Code plus a real browser on a VPS you own, via Telegram |
+| Your own agent, running locally, driving your own browser | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent (Claude Code, Codex, Gemini CLI) writes Python over CDP against your Chrome |
+| A deployed agent you call through an API | [Browser Use Cloud v4](/cloud/quickstart) | Our agent and our browsers, hosted; one API call in, a result out |
+| Only a browser: you bring your own agent, or you just need browser automation | [Browser infrastructure](/cloud/browser-api) | Our stealth browsers with proxies, profiles and CAPTCHA handling, reachable over CDP from any agent |
 
-## Cloud
+## Browser Use CLI
 
-Send a task, get a result. The v4 API and the chat UI at [cloud.browser-use.com](https://cloud.browser-use.com) run the agent on hosted stealth browsers with residential proxies, CAPTCHA solving, persistent profiles, and a live preview. Nothing to install; the SDK is optional.
+For an agent that runs on your machine. The coding agent you already use gets a skill that talks to a browser over CDP: your running Chrome with its tabs, cookies and logins, or one of our cloud browsers. Setup is one prompt; see [Browser Use CLI](/open-source/browser-use-cli).
 
-Pick this when you need stealth or proxies, when the task runs on a server, or when you want to scale to many sessions.
+## Browser Use Cloud v4
 
-## Browser Use CLI (`browser-use`)
+For an agent that runs on our side. Send a task through the API or the chat at [cloud.browser-use.com](https://cloud.browser-use.com) and get the result back. The agent, the browsers, the proxies and the live preview are all hosted. This is the CLI and our browser together, as a service.
 
-A skill for coding agents, backed by the open-source [browser-harness](https://github.com/browser-use/browser-harness) project. The agent writes Python that talks to a browser over CDP: your running Chrome with its tabs, cookies, and logins, a Browser Use cloud browser, or any CDP endpoint.
+## Browser infrastructure
 
-Pick this when you are already inside Claude Code or Codex and want it to click, type, and read pages in a browser you control. Setup is a single prompt; see [Browser Use CLI](/open-source/browser-use-cli).
-
-## Browser Use library (`pip install browser-use`)
-
-The Python framework the company started with. Bring your own LLM, run the agent in your own process, and customize tools, prompts, and the browser session. Works with a local browser or with cloud browsers through the same API key.
-
-Pick this when you are building your own agent product or need full control over the loop.
-
-## Browser Use Desktop
-
-An open-source desktop app for people who do not live in a terminal. It gives the CLI a window: type a goal, watch the browser, approve steps. Same local-browser model as the CLI.
-
-## Browser Use Box (BUX)
-
-One install script turns any Ubuntu box into a 24/7 agent with Claude Code, the CLI, and a real browser preinstalled. You talk to it over Telegram. Pick this when you want an agent that keeps working while your laptop is closed.
+For teams that have an agent and only need the browser. Create a stealth browser with residential proxies, persistent profiles and CAPTCHA handling, connect over CDP, and drive it from any framework or your own code.
 
 ## They share one account
 
-The same API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) authenticates the SDK, the CLI's cloud browsers (`browser-use auth login`), the library's `ChatBrowserUse` model, and Browser Use Box. Credits and profiles live in the same project.
+One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) authenticates the CLI's cloud browsers (`browser-use auth login`), the v4 API, and the browser API. Credits and profiles live in the same project.

--- a/docs/cloud/which-product.mdx
+++ b/docs/cloud/which-product.mdx
@@ -7,23 +7,23 @@ icon: "signs-post"
 
 Pick where your agent and browser should run.
 
-<img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex use Browser Use CLI with real Chrome or connect to the browser in our cloud. In our cloud, OpenCode, Browser Use CLI, and Cloud Browser form the fully hosted stack. Your own agent can also connect directly through the Browser API." noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex use Browser Use CLI with real Chrome or connect to the browser in our cloud. In our cloud, OpenCode, Browser Use CLI, and Cloud Browser form the fully hosted stack. Your own agent can also connect directly through the Browser API." noZoom className="hidden dark:block" />
+<img src="/cloud/images/which-product-light.svg" alt="On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other local agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI together above that Cloud Browser. Browser API is the browser-only route." noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other local agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI together above that Cloud Browser. Browser API is the browser-only route." noZoom className="hidden dark:block" />
 
-## On your machine
+## On your computer
 
-Claude Code, Codex, or another coding agent runs the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli) on your machine. The CLI either drives your real Chrome, with its tabs and logins, or connects to the hosted browser shown in our cloud.
+Claude Code, Codex, OpenCode, Hermes Agent, or another local agent can run the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli) on your computer. Local computer-use CLIs such as Playwright CLI and Agent Browser fit the same shape. They can control real Chrome, with its tabs and logins, or use the single hosted browser shown in our cloud.
 
 Start with real Chrome. Connect to our cloud when a site blocks you or you need many browsers at once. Run `browser-use auth login` once before the first cloud connection.
 
 ## In our cloud
 
-[Cloud v4](/cloud/quickstart) runs OpenCode, Browser Use CLI, and Cloud Browser together. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
+[Cloud v4](/cloud/quickstart) runs OpenCode and Browser Use CLI at the same level, with Cloud Browser underneath. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your computer.
 
 Use the full hosted stack for scheduled work, tasks your users trigger, and work that should keep running without your computer.
 
 ## Only the browser
 
-Bring your own agent and connect directly to the same hosted browser through the [Browser API](/cloud/browser/stealth). Your agent can run on your machine or in your own cloud.
+Use the [Browser API](/cloud/browser/stealth) when you only need the hosted browser. Browser Use CLI or a custom computer-use CLI can connect to the same Cloud Browser from your computer or your own cloud; Browser API does not add a hosted agent.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -66,6 +66,7 @@
                 "group": "Get Started",
                 "pages": [
                   "cloud/quickstart",
+                  "cloud/which-product",
                   "cloud/choosing-an-agent",
                   "cloud/vibecoding"
                 ]
@@ -237,6 +238,7 @@
             "group": "Get Started",
             "pages": [
               "open-source/introduction",
+              "cloud/which-product",
               "open-source/quickstart",
               "open-source/vibecoding",
               "open-source/supported-models",

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -153,7 +153,7 @@ Use the full hosted stack for scheduled work, tasks your users trigger, and work
 
 ## Only the browser
 
-Use the [Browser API](https://docs.browser-use.com/cloud/browser/stealth) when you only need the hosted browser. Browser Use CLI or a custom computer-use CLI can connect to the same Cloud Browser from your computer or your own cloud; Browser API does not add a hosted agent.
+Use the [Browser API](https://docs.browser-use.com/cloud/browser/quickstart) when you only need the hosted browser. Browser Use CLI or a custom computer-use CLI can connect to the same Cloud Browser from your computer or your own cloud; Browser API does not add a hosted agent.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -126,29 +126,30 @@ curl -X PATCH \
 Source: https://docs.browser-use.com/cloud/which-product
 
 
-Browser Use is one API key and three ways to use it. Start from where your agent runs.
+Browser Use is three parts. An agent, the Browser Use CLI it runs, and a browser. You can take all three, or only the parts you need.
 
-| You want | Use | What runs where |
+<img src="/cloud/images/which-product-light.svg" alt="Your agent, the Browser Use CLI, and a browser; all three hosted is Cloud v4" noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="Your agent, the Browser Use CLI, and a browser; all three hosted is Cloud v4" noZoom className="hidden dark:block" />
+
+| You bring | You take from us | That is |
 |---|---|---|
-| Your own agent, running locally, driving your own browser | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent (Claude Code, Codex, Gemini CLI) writes Python over CDP against your Chrome |
-| A deployed agent you call through an API | [Browser Use Cloud v4](https://docs.browser-use.com/cloud/quickstart) | Our agent and our browsers, hosted; one API call in, a result out |
-| Only a browser: you bring your own agent, or you just need browser automation | [Browser infrastructure](https://docs.browser-use.com/cloud/browser/stealth) | Our stealth browsers with proxies, profiles and CAPTCHA handling, reachable over CDP from any agent |
+| Nothing. Send a task, get a result | Agent, CLI and browser, hosted | [Cloud v4](https://docs.browser-use.com/cloud/quickstart) |
+| Your agent: Codex, Claude Code, Hermes | The CLI, plus your Chrome or one of our cloud browsers | [Browser Use CLI](/open-source/browser-use-cli) |
+| Your agent and your own harness | Only the browser, over CDP | [Browser API](https://docs.browser-use.com/cloud/browser/stealth) |
+
+## Cloud v4
+
+The whole stack on our side. One API call or the chat at [cloud.browser-use.com](https://cloud.browser-use.com); the agent, the CLI, the browsers, proxies and live preview are hosted.
 
 ## Browser Use CLI
 
-For an agent that runs on your machine. The coding agent you already use gets a skill that talks to a browser over CDP: your running Chrome with its tabs, cookies and logins, or one of our cloud browsers. Setup is one prompt; see [Browser Use CLI](/open-source/browser-use-cli).
+Your coding agent gets the CLI as a skill and drives a browser over CDP. Your running Chrome, with its tabs and logins, or a cloud browser from us with `browser-use auth login`. Hermes ships with it by default. Setup is one prompt, see [Browser Use CLI](/open-source/browser-use-cli).
 
-## Browser Use Cloud v4
+## Browser API
 
-For an agent that runs on our side. Send a task through the API or the chat at [cloud.browser-use.com](https://cloud.browser-use.com) and get the result back. The agent, the browsers, the proxies and the live preview are all hosted. This is the CLI and our browser together, as a service.
+You have an agent and a harness and only need the browser. Create a stealth browser with residential proxies, persistent profiles and CAPTCHA handling, connect over CDP from anything.
 
-## Browser infrastructure
-
-For teams that have an agent and only need the browser. Create a stealth browser with residential proxies, persistent profiles and CAPTCHA handling, connect over CDP, and drive it from any framework or your own code.
-
-## They share one account
-
-One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) authenticates the CLI's cloud browsers (`browser-use auth login`), the v4 API, and the browser API. Credits and profiles live in the same project.
+One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.
 
 # Choosing an Agent
 Source: https://docs.browser-use.com/cloud/choosing-an-agent

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -128,24 +128,24 @@ Source: https://docs.browser-use.com/cloud/which-product
 
 Pick where your agent and browser should run.
 
-<img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex use Browser Use CLI with real Chrome or connect to the browser in our cloud. In our cloud, OpenCode, Browser Use CLI, and Cloud Browser form the fully hosted stack. Your own agent can also connect directly through the Browser API." noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex use Browser Use CLI with real Chrome or connect to the browser in our cloud. In our cloud, OpenCode, Browser Use CLI, and Cloud Browser form the fully hosted stack. Your own agent can also connect directly through the Browser API." noZoom className="hidden dark:block" />
+<img src="/cloud/images/which-product-light.svg" alt="On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other local agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI together above that Cloud Browser. Browser API is the browser-only route." noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other local agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI together above that Cloud Browser. Browser API is the browser-only route." noZoom className="hidden dark:block" />
 
-## On your machine
+## On your computer
 
-Claude Code, Codex, or another coding agent runs the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli) on your machine. The CLI either drives your real Chrome, with its tabs and logins, or connects to the hosted browser shown in our cloud.
+Claude Code, Codex, OpenCode, Hermes Agent, or another local agent can run the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli) on your computer. Local computer-use CLIs such as Playwright CLI and Agent Browser fit the same shape. They can control real Chrome, with its tabs and logins, or use the single hosted browser shown in our cloud.
 
 Start with real Chrome. Connect to our cloud when a site blocks you or you need many browsers at once. Run `browser-use auth login` once before the first cloud connection.
 
 ## In our cloud
 
-[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs OpenCode, Browser Use CLI, and Cloud Browser together. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
+[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs OpenCode and Browser Use CLI at the same level, with Cloud Browser underneath. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your computer.
 
 Use the full hosted stack for scheduled work, tasks your users trigger, and work that should keep running without your computer.
 
 ## Only the browser
 
-Bring your own agent and connect directly to the same hosted browser through the [Browser API](https://docs.browser-use.com/cloud/browser/stealth). Your agent can run on your machine or in your own cloud.
+Use the [Browser API](https://docs.browser-use.com/cloud/browser/stealth) when you only need the hosted browser. Browser Use CLI or a custom computer-use CLI can connect to the same Cloud Browser from your computer or your own cloud; Browser API does not add a hosted agent.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -126,31 +126,31 @@ curl -X PATCH \
 Source: https://docs.browser-use.com/cloud/which-product
 
 
-Three ways to use Browser Use. Run our CLI next to your own agent, hand the whole task to a hosted agent, or take only a browser.
+Three products. The difference is where your agent runs and whether you want us to provide the agent, the browser, or both.
 
 <img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="block dark:hidden" />
 <img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="hidden dark:block" />
 
 ## Browser Use CLI
 
-Your agent stays yours. Claude Code, Codex or anything else picks up the [Browser Use CLI](/open-source/browser-use-cli) as a skill and drives a browser over CDP. Hermes ships with it by default.
+Claude Code, Codex or another agent runs on your machine with the [Browser Use CLI](/open-source/browser-use-cli). The CLI drives a browser over CDP.
 
 You get two browsers to choose from:
 
 - **Your own Chrome**, with the tabs and logins you already have.
 - **Our cloud browser**, with stealth, residential proxies and CAPTCHA handling. Run `browser-use auth login` once.
 
-Same CLI either way. Start local, switch to the cloud when a site blocks you or you need many browsers at once.
+Same agent and CLI either way. Start with your Chrome. Switch to our cloud browser when a site blocks you or you need many browsers at once.
 
 ## Fully hosted agent
 
-[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs the whole thing on our side: the agent, the CLI and the browser. You send a prompt, you get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
+[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs the agent and browser for you. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
 
 Use it for scheduled work, for tasks your users trigger, and anywhere you do not want to babysit a browser.
 
 ## Only the browser
 
-You already have an agent and a harness and just need a browser that does not get blocked. Create one from the [Browser API](https://docs.browser-use.com/cloud/browser/stealth) and connect over CDP from anything.
+You already have an agent and only want our browser. Your agent can run on your machine or in your own cloud. Create a browser from the [Browser API](https://docs.browser-use.com/cloud/browser/stealth) and connect over CDP.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -128,8 +128,14 @@ Source: https://docs.browser-use.com/cloud/which-product
 
 Pick where your agent and browser should run.
 
-<img src="/cloud/images/which-product-light.svg" alt="On your computer, Claude Code, Codex, OpenCode, and Hermes Agent sit above Browser Use CLI and Playwright CLI. The CLIs use either real Chrome locally or the Cloud Browser directly. In Cloud v4, OpenCode and Browser Use CLI run above that Cloud Browser." noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="On your computer, Claude Code, Codex, OpenCode, and Hermes Agent sit above Browser Use CLI and Playwright CLI. The CLIs use either real Chrome locally or the Cloud Browser directly. In Cloud v4, OpenCode and Browser Use CLI run above that Cloud Browser." noZoom className="hidden dark:block" />
+<picture className="block dark:hidden">
+  <source media="(max-width: 600px)" srcSet="/cloud/images/which-product-light-mobile.svg" />
+  <img src="/cloud/images/which-product-light.svg" alt="On your computer, choose Claude Code, Codex, OpenCode or Hermes Agent, then Playwright CLI or Browser Use CLI. Either CLI can use real Chrome or the single Cloud Browser. A separate Profile Sync step copies selected cookies from real Chrome to a cloud profile. Hosted V4 runs OpenCode, Browser Use CLI and Cloud Browser: send a prompt, get a result." noZoom />
+</picture>
+<picture className="hidden dark:block">
+  <source media="(max-width: 600px)" srcSet="/cloud/images/which-product-dark-mobile.svg" />
+  <img src="/cloud/images/which-product-dark.svg" alt="On your computer, choose Claude Code, Codex, OpenCode or Hermes Agent, then Playwright CLI or Browser Use CLI. Either CLI can use real Chrome or the single Cloud Browser. A separate Profile Sync step copies selected cookies from real Chrome to a cloud profile. Hosted V4 runs OpenCode, Browser Use CLI and Cloud Browser: send a prompt, get a result." noZoom />
+</picture>
 
 ## On your computer
 
@@ -137,9 +143,11 @@ Claude Code, Codex, OpenCode, Hermes Agent, or another local agent can run the [
 
 Start with real Chrome. Connect to our cloud when a site blocks you or you need many browsers at once. Run `browser-use auth login` once before the first cloud connection.
 
+[Profile Sync](https://docs.browser-use.com/cloud/guides/profile-sync) copies selected cookies from real Chrome into a cloud profile. Run it explicitly for the accounts you want to use in the cloud; the dashed line does not mean automatic synchronization.
+
 ## In our cloud
 
-[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs OpenCode and Browser Use CLI at the same level, with Cloud Browser underneath. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your computer.
+[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs OpenCode, Browser Use CLI and Cloud Browser. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your computer.
 
 Use the full hosted stack for scheduled work, tasks your users trigger, and work that should keep running without your computer.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -126,45 +126,29 @@ curl -X PATCH \
 Source: https://docs.browser-use.com/cloud/which-product
 
 
-Browser Use is one API key and five ways to use it. Start from what you want to happen, not from the product name.
+Browser Use is one API key and three ways to use it. Start from where your agent runs.
 
 | You want | Use | What runs where |
 |---|---|---|
-| A result from a browser task, by API or chat, without running anything yourself | [Browser Use Cloud](https://docs.browser-use.com/cloud/quickstart) | Our agent and our stealth browsers, in our cloud |
-| Your coding agent (Claude Code, Codex, Gemini CLI) to drive a browser you are logged into | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent, your Chrome or a cloud browser, Python over CDP |
-| To build your own agent in Python with any LLM | [Browser Use library](/open-source/quickstart) | Your code, your model, a local or self-hosted browser |
-| A desktop app instead of a terminal | [Browser Use Desktop](https://github.com/browser-use/desktop) | The CLI with a window around it, on your machine |
-| An always-on agent you text from your phone | [Browser Use Box](https://github.com/browser-use/bux) | Claude Code plus a real browser on a VPS you own, via Telegram |
+| Your own agent, running locally, driving your own browser | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent (Claude Code, Codex, Gemini CLI) writes Python over CDP against your Chrome |
+| A deployed agent you call through an API | [Browser Use Cloud v4](https://docs.browser-use.com/cloud/quickstart) | Our agent and our browsers, hosted; one API call in, a result out |
+| Only a browser: you bring your own agent, or you just need browser automation | [Browser infrastructure](https://docs.browser-use.com/cloud/guides/browser-api) | Our stealth browsers with proxies, profiles and CAPTCHA handling, reachable over CDP from any agent |
 
-## Cloud
+## Browser Use CLI
 
-Send a task, get a result. The v4 API and the chat UI at [cloud.browser-use.com](https://cloud.browser-use.com) run the agent on hosted stealth browsers with residential proxies, CAPTCHA solving, persistent profiles, and a live preview. Nothing to install; the SDK is optional.
+For an agent that runs on your machine. The coding agent you already use gets a skill that talks to a browser over CDP: your running Chrome with its tabs, cookies and logins, or one of our cloud browsers. Setup is one prompt; see [Browser Use CLI](/open-source/browser-use-cli).
 
-Pick this when you need stealth or proxies, when the task runs on a server, or when you want to scale to many sessions.
+## Browser Use Cloud v4
 
-## Browser Use CLI (`browser-use`)
+For an agent that runs on our side. Send a task through the API or the chat at [cloud.browser-use.com](https://cloud.browser-use.com) and get the result back. The agent, the browsers, the proxies and the live preview are all hosted. This is the CLI and our browser together, as a service.
 
-A skill for coding agents, backed by the open-source [browser-harness](https://github.com/browser-use/browser-harness) project. The agent writes Python that talks to a browser over CDP: your running Chrome with its tabs, cookies, and logins, a Browser Use cloud browser, or any CDP endpoint.
+## Browser infrastructure
 
-Pick this when you are already inside Claude Code or Codex and want it to click, type, and read pages in a browser you control. Setup is a single prompt; see [Browser Use CLI](/open-source/browser-use-cli).
-
-## Browser Use library (`pip install browser-use`)
-
-The Python framework the company started with. Bring your own LLM, run the agent in your own process, and customize tools, prompts, and the browser session. Works with a local browser or with cloud browsers through the same API key.
-
-Pick this when you are building your own agent product or need full control over the loop.
-
-## Browser Use Desktop
-
-An open-source desktop app for people who do not live in a terminal. It gives the CLI a window: type a goal, watch the browser, approve steps. Same local-browser model as the CLI.
-
-## Browser Use Box (BUX)
-
-One install script turns any Ubuntu box into a 24/7 agent with Claude Code, the CLI, and a real browser preinstalled. You talk to it over Telegram. Pick this when you want an agent that keeps working while your laptop is closed.
+For teams that have an agent and only need the browser. Create a stealth browser with residential proxies, persistent profiles and CAPTCHA handling, connect over CDP, and drive it from any framework or your own code.
 
 ## They share one account
 
-The same API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) authenticates the SDK, the CLI's cloud browsers (`browser-use auth login`), the library's `ChatBrowserUse` model, and Browser Use Box. Credits and profiles live in the same project.
+One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) authenticates the CLI's cloud browsers (`browser-use auth login`), the v4 API, and the browser API. Credits and profiles live in the same project.
 
 # Choosing an Agent
 Source: https://docs.browser-use.com/cloud/choosing-an-agent

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -128,8 +128,8 @@ Source: https://docs.browser-use.com/cloud/which-product
 
 Pick where your agent and browser should run.
 
-<img src="/cloud/images/which-product-light.svg" alt="On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other local agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI together above that Cloud Browser. Browser API is the browser-only route." noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other local agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI together above that Cloud Browser. Browser API is the browser-only route." noZoom className="hidden dark:block" />
+<img src="/cloud/images/which-product-light.svg" alt="On your computer, Claude Code, Codex, OpenCode, and Hermes Agent sit above Browser Use CLI and Playwright CLI. The CLIs use either real Chrome locally or the Cloud Browser directly. In Cloud v4, OpenCode and Browser Use CLI run above that Cloud Browser." noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="On your computer, Claude Code, Codex, OpenCode, and Hermes Agent sit above Browser Use CLI and Playwright CLI. The CLIs use either real Chrome locally or the Cloud Browser directly. In Cloud v4, OpenCode and Browser Use CLI run above that Cloud Browser." noZoom className="hidden dark:block" />
 
 ## On your computer
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -126,28 +126,31 @@ curl -X PATCH \
 Source: https://docs.browser-use.com/cloud/which-product
 
 
-Browser Use is three parts. An agent, the Browser Use CLI it runs, and a browser. You can take all three, or only the parts you need.
+Three ways to use Browser Use. Run our CLI next to your own agent, hand the whole task to a hosted agent, or take only a browser.
 
-<img src="/cloud/images/which-product-light.svg" alt="Your agent, the Browser Use CLI, and a browser; all three hosted is Cloud v4" noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="Your agent, the Browser Use CLI, and a browser; all three hosted is Cloud v4" noZoom className="hidden dark:block" />
-
-| You bring | You take from us | That is |
-|---|---|---|
-| Nothing. Send a task, get a result | Agent, CLI and browser, hosted | [Cloud v4](https://docs.browser-use.com/cloud/quickstart) |
-| Your agent: Codex, Claude Code, Hermes | The CLI, plus your Chrome or one of our cloud browsers | [Browser Use CLI](/open-source/browser-use-cli) |
-| Your agent and your own harness | Only the browser, over CDP | [Browser API](https://docs.browser-use.com/cloud/browser/stealth) |
-
-## Cloud v4
-
-The whole stack on our side. One API call or the chat at [cloud.browser-use.com](https://cloud.browser-use.com); the agent, the CLI, the browsers, proxies and live preview are hosted.
+<img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="hidden dark:block" />
 
 ## Browser Use CLI
 
-Your coding agent gets the CLI as a skill and drives a browser over CDP. Your running Chrome, with its tabs and logins, or a cloud browser from us with `browser-use auth login`. Hermes ships with it by default. Setup is one prompt, see [Browser Use CLI](/open-source/browser-use-cli).
+Your agent stays yours. Claude Code, Codex or anything else picks up the [Browser Use CLI](/open-source/browser-use-cli) as a skill and drives a browser over CDP. Hermes ships with it by default.
 
-## Browser API
+You get two browsers to choose from:
 
-You have an agent and a harness and only need the browser. Create a stealth browser with residential proxies, persistent profiles and CAPTCHA handling, connect over CDP from anything.
+- **Your own Chrome**, with the tabs and logins you already have.
+- **Our cloud browser**, with stealth, residential proxies and CAPTCHA handling. Run `browser-use auth login` once.
+
+Same CLI either way. Start local, switch to the cloud when a site blocks you or you need many browsers at once.
+
+## Fully hosted agent
+
+[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs the whole thing on our side: the agent, the CLI and the browser. You send a prompt, you get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
+
+Use it for scheduled work, for tasks your users trigger, and anywhere you do not want to babysit a browser.
+
+## Only the browser
+
+You already have an agent and a harness and just need a browser that does not get blocked. Create one from the [Browser API](https://docs.browser-use.com/cloud/browser/stealth) and connect over CDP from anything.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -126,31 +126,26 @@ curl -X PATCH \
 Source: https://docs.browser-use.com/cloud/which-product
 
 
-Three products. The difference is where your agent runs and whether you want us to provide the agent, the browser, or both.
+Pick where your agent and browser should run.
 
-<img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="hidden dark:block" />
+<img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex use Browser Use CLI with real Chrome or connect to the browser in our cloud. In our cloud, OpenCode, Browser Use CLI, and Cloud Browser form the fully hosted stack. Your own agent can also connect directly through the Browser API." noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex use Browser Use CLI with real Chrome or connect to the browser in our cloud. In our cloud, OpenCode, Browser Use CLI, and Cloud Browser form the fully hosted stack. Your own agent can also connect directly through the Browser API." noZoom className="hidden dark:block" />
 
-## Browser Use CLI
+## On your machine
 
-Claude Code, Codex or another agent runs on your machine with the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli). The CLI drives a browser over CDP.
+Claude Code, Codex, or another coding agent runs the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli) on your machine. The CLI either drives your real Chrome, with its tabs and logins, or connects to the hosted browser shown in our cloud.
 
-You get two browsers to choose from:
+Start with real Chrome. Connect to our cloud when a site blocks you or you need many browsers at once. Run `browser-use auth login` once before the first cloud connection.
 
-- **Your own Chrome**, with the tabs and logins you already have.
-- **Our cloud browser**, with stealth, residential proxies and CAPTCHA handling. Run `browser-use auth login` once.
+## In our cloud
 
-Same agent and CLI either way. Start with your Chrome. Switch to our cloud browser when a site blocks you or you need many browsers at once.
+[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs OpenCode, Browser Use CLI, and Cloud Browser together. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
 
-## Fully hosted agent
-
-[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs the agent and browser for you. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
-
-Use it for scheduled work, for tasks your users trigger, and anywhere you do not want to babysit a browser.
+Use the full hosted stack for scheduled work, tasks your users trigger, and work that should keep running without your computer.
 
 ## Only the browser
 
-You already have an agent and only want our browser. Your agent can run on your machine or in your own cloud. Create a browser from the [Browser API](https://docs.browser-use.com/cloud/browser/stealth) and connect over CDP.
+Bring your own agent and connect directly to the same hosted browser through the [Browser API](https://docs.browser-use.com/cloud/browser/stealth). Your agent can run on your machine or in your own cloud.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -132,7 +132,7 @@ Browser Use is one API key and three ways to use it. Start from where your agent
 |---|---|---|
 | Your own agent, running locally, driving your own browser | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent (Claude Code, Codex, Gemini CLI) writes Python over CDP against your Chrome |
 | A deployed agent you call through an API | [Browser Use Cloud v4](https://docs.browser-use.com/cloud/quickstart) | Our agent and our browsers, hosted; one API call in, a result out |
-| Only a browser: you bring your own agent, or you just need browser automation | [Browser infrastructure](https://docs.browser-use.com/cloud/guides/browser-api) | Our stealth browsers with proxies, profiles and CAPTCHA handling, reachable over CDP from any agent |
+| Only a browser: you bring your own agent, or you just need browser automation | [Browser infrastructure](https://docs.browser-use.com/cloud/browser/stealth) | Our stealth browsers with proxies, profiles and CAPTCHA handling, reachable over CDP from any agent |
 
 ## Browser Use CLI
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -133,7 +133,7 @@ Three products. The difference is where your agent runs and whether you want us 
 
 ## Browser Use CLI
 
-Claude Code, Codex or another agent runs on your machine with the [Browser Use CLI](/open-source/browser-use-cli). The CLI drives a browser over CDP.
+Claude Code, Codex or another agent runs on your machine with the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli). The CLI drives a browser over CDP.
 
 You get two browsers to choose from:
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -122,6 +122,50 @@ curl -X PATCH \
 [Copy for an LLM](https://docs.browser-use.com/cloud/llms.txt)
   Give your coding agent the compact API V4 context.
 
+# Which Browser Use do I need?
+Source: https://docs.browser-use.com/cloud/which-product
+
+
+Browser Use is one API key and five ways to use it. Start from what you want to happen, not from the product name.
+
+| You want | Use | What runs where |
+|---|---|---|
+| A result from a browser task, by API or chat, without running anything yourself | [Browser Use Cloud](https://docs.browser-use.com/cloud/quickstart) | Our agent and our stealth browsers, in our cloud |
+| Your coding agent (Claude Code, Codex, Gemini CLI) to drive a browser you are logged into | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent, your Chrome or a cloud browser, Python over CDP |
+| To build your own agent in Python with any LLM | [Browser Use library](/open-source/quickstart) | Your code, your model, a local or self-hosted browser |
+| A desktop app instead of a terminal | [Browser Use Desktop](https://github.com/browser-use/desktop) | The CLI with a window around it, on your machine |
+| An always-on agent you text from your phone | [Browser Use Box](https://github.com/browser-use/bux) | Claude Code plus a real browser on a VPS you own, via Telegram |
+
+## Cloud
+
+Send a task, get a result. The v4 API and the chat UI at [cloud.browser-use.com](https://cloud.browser-use.com) run the agent on hosted stealth browsers with residential proxies, CAPTCHA solving, persistent profiles, and a live preview. Nothing to install; the SDK is optional.
+
+Pick this when you need stealth or proxies, when the task runs on a server, or when you want to scale to many sessions.
+
+## Browser Use CLI (`browser-use`)
+
+A skill for coding agents, backed by the open-source [browser-harness](https://github.com/browser-use/browser-harness) project. The agent writes Python that talks to a browser over CDP: your running Chrome with its tabs, cookies, and logins, a Browser Use cloud browser, or any CDP endpoint.
+
+Pick this when you are already inside Claude Code or Codex and want it to click, type, and read pages in a browser you control. Setup is a single prompt; see [Browser Use CLI](/open-source/browser-use-cli).
+
+## Browser Use library (`pip install browser-use`)
+
+The Python framework the company started with. Bring your own LLM, run the agent in your own process, and customize tools, prompts, and the browser session. Works with a local browser or with cloud browsers through the same API key.
+
+Pick this when you are building your own agent product or need full control over the loop.
+
+## Browser Use Desktop
+
+An open-source desktop app for people who do not live in a terminal. It gives the CLI a window: type a goal, watch the browser, approve steps. Same local-browser model as the CLI.
+
+## Browser Use Box (BUX)
+
+One install script turns any Ubuntu box into a 24/7 agent with Claude Code, the CLI, and a real browser preinstalled. You talk to it over Telegram. Pick this when you want an agent that keeps working while your laptop is closed.
+
+## They share one account
+
+The same API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) authenticates the SDK, the CLI's cloud browsers (`browser-use auth login`), the library's `ChatBrowserUse` model, and Browser Use Box. Credits and profiles live in the same project.
+
 # Choosing an Agent
 Source: https://docs.browser-use.com/cloud/choosing-an-agent
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -67,7 +67,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): Run a hosted agent or launch a cloud browser.
-- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Our browser, our CLI, or both together hosted as v4: pick by where your agent runs.
+- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Three parts: your agent, our CLI, a browser. Take all three hosted, or only what you need.
 - [Choosing an Agent](https://docs.browser-use.com/cloud/choosing-an-agent): Compare Browser Use Cloud agents on accuracy, speed and price, and pick the right one for your task.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -67,7 +67,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): Run a hosted agent or launch a cloud browser.
-- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Three parts: your agent, our CLI, a browser. Take all three hosted, or only what you need.
+- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Run our CLI on your machine with your Chrome or our cloud browser, send a prompt to the fully hosted agent, or take only the browser.
 - [Choosing an Agent](https://docs.browser-use.com/cloud/choosing-an-agent): Compare Browser Use Cloud agents on accuracy, speed and price, and pick the right one for your task.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -67,7 +67,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): Run a hosted agent or launch a cloud browser.
-- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Cloud, the open-source library, the CLI for coding agents, the desktop app, or Browser Use Box: pick by where you want the browser and the agent to run.
+- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Our browser, our CLI, or both together hosted as v4: pick by where your agent runs.
 - [Choosing an Agent](https://docs.browser-use.com/cloud/choosing-an-agent): Compare Browser Use Cloud agents on accuracy, speed and price, and pick the right one for your task.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -67,7 +67,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): Run a hosted agent or launch a cloud browser.
-- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Run our CLI on your machine with your Chrome or our cloud browser, send a prompt to the fully hosted agent, or take only the browser.
+- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Keep Claude Code or Codex on your machine, send the whole task to our cloud, or take only our browser.
 - [Choosing an Agent](https://docs.browser-use.com/cloud/choosing-an-agent): Compare Browser Use Cloud agents on accuracy, speed and price, and pick the right one for your task.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -67,6 +67,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): Run a hosted agent or launch a cloud browser.
+- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Cloud, the open-source library, the CLI for coding agents, the desktop app, or Browser Use Box: pick by where you want the browser and the agent to run.
 - [Choosing an Agent](https://docs.browser-use.com/cloud/choosing-an-agent): Compare Browser Use Cloud agents on accuracy, speed and price, and pick the right one for your task.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -67,7 +67,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 
 ## Get Started
 - [Quick start](https://docs.browser-use.com/cloud/quickstart): Run a hosted agent or launch a cloud browser.
-- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Keep Claude Code or Codex on your machine, send the whole task to our cloud, or take only our browser.
+- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Run Browser Use on your machine, run the full stack in our cloud, or bring your own agent and use only the hosted browser.
 - [Choosing an Agent](https://docs.browser-use.com/cloud/choosing-an-agent): Compare Browser Use Cloud agents on accuracy, speed and price, and pick the right one for your task.
 - [Prompt for Vibecoders](https://docs.browser-use.com/cloud/vibecoding): Complete Cloud SDK reference for AI coding agents.
 

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -19,31 +19,31 @@ Full SDK reference in a single page.
 Source: https://docs.browser-use.com/cloud/which-product
 
 
-Three ways to use Browser Use. Run our CLI next to your own agent, hand the whole task to a hosted agent, or take only a browser.
+Three products. The difference is where your agent runs and whether you want us to provide the agent, the browser, or both.
 
 <img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="block dark:hidden" />
 <img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="hidden dark:block" />
 
 ## Browser Use CLI
 
-Your agent stays yours. Claude Code, Codex or anything else picks up the [Browser Use CLI](/open-source/browser-use-cli) as a skill and drives a browser over CDP. Hermes ships with it by default.
+Claude Code, Codex or another agent runs on your machine with the [Browser Use CLI](/open-source/browser-use-cli). The CLI drives a browser over CDP.
 
 You get two browsers to choose from:
 
 - **Your own Chrome**, with the tabs and logins you already have.
 - **Our cloud browser**, with stealth, residential proxies and CAPTCHA handling. Run `browser-use auth login` once.
 
-Same CLI either way. Start local, switch to the cloud when a site blocks you or you need many browsers at once.
+Same agent and CLI either way. Start with your Chrome. Switch to our cloud browser when a site blocks you or you need many browsers at once.
 
 ## Fully hosted agent
 
-[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs the whole thing on our side: the agent, the CLI and the browser. You send a prompt, you get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
+[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs the agent and browser for you. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
 
 Use it for scheduled work, for tasks your users trigger, and anywhere you do not want to babysit a browser.
 
 ## Only the browser
 
-You already have an agent and a harness and just need a browser that does not get blocked. Create one from the [Browser API](https://docs.browser-use.com/cloud/browser/stealth) and connect over CDP from anything.
+You already have an agent and only want our browser. Your agent can run on your machine or in your own cloud. Create a browser from the [Browser API](https://docs.browser-use.com/cloud/browser/stealth) and connect over CDP.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.
 

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -21,24 +21,24 @@ Source: https://docs.browser-use.com/cloud/which-product
 
 Pick where your agent and browser should run.
 
-<img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex use Browser Use CLI with real Chrome or connect to the browser in our cloud. In our cloud, OpenCode, Browser Use CLI, and Cloud Browser form the fully hosted stack. Your own agent can also connect directly through the Browser API." noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex use Browser Use CLI with real Chrome or connect to the browser in our cloud. In our cloud, OpenCode, Browser Use CLI, and Cloud Browser form the fully hosted stack. Your own agent can also connect directly through the Browser API." noZoom className="hidden dark:block" />
+<img src="/cloud/images/which-product-light.svg" alt="On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other local agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI together above that Cloud Browser. Browser API is the browser-only route." noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other local agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI together above that Cloud Browser. Browser API is the browser-only route." noZoom className="hidden dark:block" />
 
-## On your machine
+## On your computer
 
-Claude Code, Codex, or another coding agent runs the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli) on your machine. The CLI either drives your real Chrome, with its tabs and logins, or connects to the hosted browser shown in our cloud.
+Claude Code, Codex, OpenCode, Hermes Agent, or another local agent can run the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli) on your computer. Local computer-use CLIs such as Playwright CLI and Agent Browser fit the same shape. They can control real Chrome, with its tabs and logins, or use the single hosted browser shown in our cloud.
 
 Start with real Chrome. Connect to our cloud when a site blocks you or you need many browsers at once. Run `browser-use auth login` once before the first cloud connection.
 
 ## In our cloud
 
-[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs OpenCode, Browser Use CLI, and Cloud Browser together. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
+[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs OpenCode and Browser Use CLI at the same level, with Cloud Browser underneath. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your computer.
 
 Use the full hosted stack for scheduled work, tasks your users trigger, and work that should keep running without your computer.
 
 ## Only the browser
 
-Bring your own agent and connect directly to the same hosted browser through the [Browser API](https://docs.browser-use.com/cloud/browser/stealth). Your agent can run on your machine or in your own cloud.
+Use the [Browser API](https://docs.browser-use.com/cloud/browser/stealth) when you only need the hosted browser. Browser Use CLI or a custom computer-use CLI can connect to the same Cloud Browser from your computer or your own cloud; Browser API does not add a hosted agent.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.
 

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -25,7 +25,7 @@ Browser Use is one API key and three ways to use it. Start from where your agent
 |---|---|---|
 | Your own agent, running locally, driving your own browser | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent (Claude Code, Codex, Gemini CLI) writes Python over CDP against your Chrome |
 | A deployed agent you call through an API | [Browser Use Cloud v4](https://docs.browser-use.com/cloud/quickstart) | Our agent and our browsers, hosted; one API call in, a result out |
-| Only a browser: you bring your own agent, or you just need browser automation | [Browser infrastructure](https://docs.browser-use.com/cloud/guides/browser-api) | Our stealth browsers with proxies, profiles and CAPTCHA handling, reachable over CDP from any agent |
+| Only a browser: you bring your own agent, or you just need browser automation | [Browser infrastructure](https://docs.browser-use.com/cloud/browser/stealth) | Our stealth browsers with proxies, profiles and CAPTCHA handling, reachable over CDP from any agent |
 
 ## Browser Use CLI
 

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -19,45 +19,29 @@ Full SDK reference in a single page.
 Source: https://docs.browser-use.com/cloud/which-product
 
 
-Browser Use is one API key and five ways to use it. Start from what you want to happen, not from the product name.
+Browser Use is one API key and three ways to use it. Start from where your agent runs.
 
 | You want | Use | What runs where |
 |---|---|---|
-| A result from a browser task, by API or chat, without running anything yourself | [Browser Use Cloud](https://docs.browser-use.com/cloud/quickstart) | Our agent and our stealth browsers, in our cloud |
-| Your coding agent (Claude Code, Codex, Gemini CLI) to drive a browser you are logged into | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent, your Chrome or a cloud browser, Python over CDP |
-| To build your own agent in Python with any LLM | [Browser Use library](/open-source/quickstart) | Your code, your model, a local or self-hosted browser |
-| A desktop app instead of a terminal | [Browser Use Desktop](https://github.com/browser-use/desktop) | The CLI with a window around it, on your machine |
-| An always-on agent you text from your phone | [Browser Use Box](https://github.com/browser-use/bux) | Claude Code plus a real browser on a VPS you own, via Telegram |
+| Your own agent, running locally, driving your own browser | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent (Claude Code, Codex, Gemini CLI) writes Python over CDP against your Chrome |
+| A deployed agent you call through an API | [Browser Use Cloud v4](https://docs.browser-use.com/cloud/quickstart) | Our agent and our browsers, hosted; one API call in, a result out |
+| Only a browser: you bring your own agent, or you just need browser automation | [Browser infrastructure](https://docs.browser-use.com/cloud/guides/browser-api) | Our stealth browsers with proxies, profiles and CAPTCHA handling, reachable over CDP from any agent |
 
-## Cloud
+## Browser Use CLI
 
-Send a task, get a result. The v4 API and the chat UI at [cloud.browser-use.com](https://cloud.browser-use.com) run the agent on hosted stealth browsers with residential proxies, CAPTCHA solving, persistent profiles, and a live preview. Nothing to install; the SDK is optional.
+For an agent that runs on your machine. The coding agent you already use gets a skill that talks to a browser over CDP: your running Chrome with its tabs, cookies and logins, or one of our cloud browsers. Setup is one prompt; see [Browser Use CLI](/open-source/browser-use-cli).
 
-Pick this when you need stealth or proxies, when the task runs on a server, or when you want to scale to many sessions.
+## Browser Use Cloud v4
 
-## Browser Use CLI (`browser-use`)
+For an agent that runs on our side. Send a task through the API or the chat at [cloud.browser-use.com](https://cloud.browser-use.com) and get the result back. The agent, the browsers, the proxies and the live preview are all hosted. This is the CLI and our browser together, as a service.
 
-A skill for coding agents, backed by the open-source [browser-harness](https://github.com/browser-use/browser-harness) project. The agent writes Python that talks to a browser over CDP: your running Chrome with its tabs, cookies, and logins, a Browser Use cloud browser, or any CDP endpoint.
+## Browser infrastructure
 
-Pick this when you are already inside Claude Code or Codex and want it to click, type, and read pages in a browser you control. Setup is a single prompt; see [Browser Use CLI](/open-source/browser-use-cli).
-
-## Browser Use library (`pip install browser-use`)
-
-The Python framework the company started with. Bring your own LLM, run the agent in your own process, and customize tools, prompts, and the browser session. Works with a local browser or with cloud browsers through the same API key.
-
-Pick this when you are building your own agent product or need full control over the loop.
-
-## Browser Use Desktop
-
-An open-source desktop app for people who do not live in a terminal. It gives the CLI a window: type a goal, watch the browser, approve steps. Same local-browser model as the CLI.
-
-## Browser Use Box (BUX)
-
-One install script turns any Ubuntu box into a 24/7 agent with Claude Code, the CLI, and a real browser preinstalled. You talk to it over Telegram. Pick this when you want an agent that keeps working while your laptop is closed.
+For teams that have an agent and only need the browser. Create a stealth browser with residential proxies, persistent profiles and CAPTCHA handling, connect over CDP, and drive it from any framework or your own code.
 
 ## They share one account
 
-The same API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) authenticates the SDK, the CLI's cloud browsers (`browser-use auth login`), the library's `ChatBrowserUse` model, and Browser Use Box. Credits and profiles live in the same project.
+One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) authenticates the CLI's cloud browsers (`browser-use auth login`), the v4 API, and the browser API. Credits and profiles live in the same project.
 
 # Human Quickstart
 Source: https://docs.browser-use.com/open-source/quickstart

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -19,31 +19,26 @@ Full SDK reference in a single page.
 Source: https://docs.browser-use.com/cloud/which-product
 
 
-Three products. The difference is where your agent runs and whether you want us to provide the agent, the browser, or both.
+Pick where your agent and browser should run.
 
-<img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="hidden dark:block" />
+<img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex use Browser Use CLI with real Chrome or connect to the browser in our cloud. In our cloud, OpenCode, Browser Use CLI, and Cloud Browser form the fully hosted stack. Your own agent can also connect directly through the Browser API." noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex use Browser Use CLI with real Chrome or connect to the browser in our cloud. In our cloud, OpenCode, Browser Use CLI, and Cloud Browser form the fully hosted stack. Your own agent can also connect directly through the Browser API." noZoom className="hidden dark:block" />
 
-## Browser Use CLI
+## On your machine
 
-Claude Code, Codex or another agent runs on your machine with the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli). The CLI drives a browser over CDP.
+Claude Code, Codex, or another coding agent runs the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli) on your machine. The CLI either drives your real Chrome, with its tabs and logins, or connects to the hosted browser shown in our cloud.
 
-You get two browsers to choose from:
+Start with real Chrome. Connect to our cloud when a site blocks you or you need many browsers at once. Run `browser-use auth login` once before the first cloud connection.
 
-- **Your own Chrome**, with the tabs and logins you already have.
-- **Our cloud browser**, with stealth, residential proxies and CAPTCHA handling. Run `browser-use auth login` once.
+## In our cloud
 
-Same agent and CLI either way. Start with your Chrome. Switch to our cloud browser when a site blocks you or you need many browsers at once.
+[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs OpenCode, Browser Use CLI, and Cloud Browser together. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
 
-## Fully hosted agent
-
-[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs the agent and browser for you. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
-
-Use it for scheduled work, for tasks your users trigger, and anywhere you do not want to babysit a browser.
+Use the full hosted stack for scheduled work, tasks your users trigger, and work that should keep running without your computer.
 
 ## Only the browser
 
-You already have an agent and only want our browser. Your agent can run on your machine or in your own cloud. Create a browser from the [Browser API](https://docs.browser-use.com/cloud/browser/stealth) and connect over CDP.
+Bring your own agent and connect directly to the same hosted browser through the [Browser API](https://docs.browser-use.com/cloud/browser/stealth). Your agent can run on your machine or in your own cloud.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.
 

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -19,28 +19,31 @@ Full SDK reference in a single page.
 Source: https://docs.browser-use.com/cloud/which-product
 
 
-Browser Use is three parts. An agent, the Browser Use CLI it runs, and a browser. You can take all three, or only the parts you need.
+Three ways to use Browser Use. Run our CLI next to your own agent, hand the whole task to a hosted agent, or take only a browser.
 
-<img src="/cloud/images/which-product-light.svg" alt="Your agent, the Browser Use CLI, and a browser; all three hosted is Cloud v4" noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="Your agent, the Browser Use CLI, and a browser; all three hosted is Cloud v4" noZoom className="hidden dark:block" />
-
-| You bring | You take from us | That is |
-|---|---|---|
-| Nothing. Send a task, get a result | Agent, CLI and browser, hosted | [Cloud v4](https://docs.browser-use.com/cloud/quickstart) |
-| Your agent: Codex, Claude Code, Hermes | The CLI, plus your Chrome or one of our cloud browsers | [Browser Use CLI](/open-source/browser-use-cli) |
-| Your agent and your own harness | Only the browser, over CDP | [Browser API](https://docs.browser-use.com/cloud/browser/stealth) |
-
-## Cloud v4
-
-The whole stack on our side. One API call or the chat at [cloud.browser-use.com](https://cloud.browser-use.com); the agent, the CLI, the browsers, proxies and live preview are hosted.
+<img src="/cloud/images/which-product-light.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="On your machine, Claude Code or Codex run the Browser Use CLI against your Chrome or our cloud browser. In our cloud, the fully hosted agent, or only a browser for your own agent." noZoom className="hidden dark:block" />
 
 ## Browser Use CLI
 
-Your coding agent gets the CLI as a skill and drives a browser over CDP. Your running Chrome, with its tabs and logins, or a cloud browser from us with `browser-use auth login`. Hermes ships with it by default. Setup is one prompt, see [Browser Use CLI](/open-source/browser-use-cli).
+Your agent stays yours. Claude Code, Codex or anything else picks up the [Browser Use CLI](/open-source/browser-use-cli) as a skill and drives a browser over CDP. Hermes ships with it by default.
 
-## Browser API
+You get two browsers to choose from:
 
-You have an agent and a harness and only need the browser. Create a stealth browser with residential proxies, persistent profiles and CAPTCHA handling, connect over CDP from anything.
+- **Your own Chrome**, with the tabs and logins you already have.
+- **Our cloud browser**, with stealth, residential proxies and CAPTCHA handling. Run `browser-use auth login` once.
+
+Same CLI either way. Start local, switch to the cloud when a site blocks you or you need many browsers at once.
+
+## Fully hosted agent
+
+[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs the whole thing on our side: the agent, the CLI and the browser. You send a prompt, you get the result back, plus a live preview and any files it produced. Nothing runs on your machine.
+
+Use it for scheduled work, for tasks your users trigger, and anywhere you do not want to babysit a browser.
+
+## Only the browser
+
+You already have an agent and a harness and just need a browser that does not get blocked. Create one from the [Browser API](https://docs.browser-use.com/cloud/browser/stealth) and connect over CDP from anything.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.
 

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -26,7 +26,7 @@ Three products. The difference is where your agent runs and whether you want us 
 
 ## Browser Use CLI
 
-Claude Code, Codex or another agent runs on your machine with the [Browser Use CLI](/open-source/browser-use-cli). The CLI drives a browser over CDP.
+Claude Code, Codex or another agent runs on your machine with the [Browser Use CLI](https://docs.browser-use.com/open-source/browser-use-cli). The CLI drives a browser over CDP.
 
 You get two browsers to choose from:
 

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -21,8 +21,14 @@ Source: https://docs.browser-use.com/cloud/which-product
 
 Pick where your agent and browser should run.
 
-<img src="/cloud/images/which-product-light.svg" alt="On your computer, Claude Code, Codex, OpenCode, and Hermes Agent sit above Browser Use CLI and Playwright CLI. The CLIs use either real Chrome locally or the Cloud Browser directly. In Cloud v4, OpenCode and Browser Use CLI run above that Cloud Browser." noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="On your computer, Claude Code, Codex, OpenCode, and Hermes Agent sit above Browser Use CLI and Playwright CLI. The CLIs use either real Chrome locally or the Cloud Browser directly. In Cloud v4, OpenCode and Browser Use CLI run above that Cloud Browser." noZoom className="hidden dark:block" />
+<picture className="block dark:hidden">
+  <source media="(max-width: 600px)" srcSet="/cloud/images/which-product-light-mobile.svg" />
+  <img src="/cloud/images/which-product-light.svg" alt="On your computer, choose Claude Code, Codex, OpenCode or Hermes Agent, then Playwright CLI or Browser Use CLI. Either CLI can use real Chrome or the single Cloud Browser. A separate Profile Sync step copies selected cookies from real Chrome to a cloud profile. Hosted V4 runs OpenCode, Browser Use CLI and Cloud Browser: send a prompt, get a result." noZoom />
+</picture>
+<picture className="hidden dark:block">
+  <source media="(max-width: 600px)" srcSet="/cloud/images/which-product-dark-mobile.svg" />
+  <img src="/cloud/images/which-product-dark.svg" alt="On your computer, choose Claude Code, Codex, OpenCode or Hermes Agent, then Playwright CLI or Browser Use CLI. Either CLI can use real Chrome or the single Cloud Browser. A separate Profile Sync step copies selected cookies from real Chrome to a cloud profile. Hosted V4 runs OpenCode, Browser Use CLI and Cloud Browser: send a prompt, get a result." noZoom />
+</picture>
 
 ## On your computer
 
@@ -30,9 +36,11 @@ Claude Code, Codex, OpenCode, Hermes Agent, or another local agent can run the [
 
 Start with real Chrome. Connect to our cloud when a site blocks you or you need many browsers at once. Run `browser-use auth login` once before the first cloud connection.
 
+[Profile Sync](https://docs.browser-use.com/cloud/guides/profile-sync) copies selected cookies from real Chrome into a cloud profile. Run it explicitly for the accounts you want to use in the cloud; the dashed line does not mean automatic synchronization.
+
 ## In our cloud
 
-[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs OpenCode and Browser Use CLI at the same level, with Cloud Browser underneath. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your computer.
+[Cloud v4](https://docs.browser-use.com/cloud/quickstart) runs OpenCode, Browser Use CLI and Cloud Browser. You send a prompt to our API and get the result back, plus a live preview and any files it produced. Nothing runs on your computer.
 
 Use the full hosted stack for scheduled work, tasks your users trigger, and work that should keep running without your computer.
 

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -19,29 +19,30 @@ Full SDK reference in a single page.
 Source: https://docs.browser-use.com/cloud/which-product
 
 
-Browser Use is one API key and three ways to use it. Start from where your agent runs.
+Browser Use is three parts. An agent, the Browser Use CLI it runs, and a browser. You can take all three, or only the parts you need.
 
-| You want | Use | What runs where |
+<img src="/cloud/images/which-product-light.svg" alt="Your agent, the Browser Use CLI, and a browser; all three hosted is Cloud v4" noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="Your agent, the Browser Use CLI, and a browser; all three hosted is Cloud v4" noZoom className="hidden dark:block" />
+
+| You bring | You take from us | That is |
 |---|---|---|
-| Your own agent, running locally, driving your own browser | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent (Claude Code, Codex, Gemini CLI) writes Python over CDP against your Chrome |
-| A deployed agent you call through an API | [Browser Use Cloud v4](https://docs.browser-use.com/cloud/quickstart) | Our agent and our browsers, hosted; one API call in, a result out |
-| Only a browser: you bring your own agent, or you just need browser automation | [Browser infrastructure](https://docs.browser-use.com/cloud/browser/stealth) | Our stealth browsers with proxies, profiles and CAPTCHA handling, reachable over CDP from any agent |
+| Nothing. Send a task, get a result | Agent, CLI and browser, hosted | [Cloud v4](https://docs.browser-use.com/cloud/quickstart) |
+| Your agent: Codex, Claude Code, Hermes | The CLI, plus your Chrome or one of our cloud browsers | [Browser Use CLI](/open-source/browser-use-cli) |
+| Your agent and your own harness | Only the browser, over CDP | [Browser API](https://docs.browser-use.com/cloud/browser/stealth) |
+
+## Cloud v4
+
+The whole stack on our side. One API call or the chat at [cloud.browser-use.com](https://cloud.browser-use.com); the agent, the CLI, the browsers, proxies and live preview are hosted.
 
 ## Browser Use CLI
 
-For an agent that runs on your machine. The coding agent you already use gets a skill that talks to a browser over CDP: your running Chrome with its tabs, cookies and logins, or one of our cloud browsers. Setup is one prompt; see [Browser Use CLI](/open-source/browser-use-cli).
+Your coding agent gets the CLI as a skill and drives a browser over CDP. Your running Chrome, with its tabs and logins, or a cloud browser from us with `browser-use auth login`. Hermes ships with it by default. Setup is one prompt, see [Browser Use CLI](/open-source/browser-use-cli).
 
-## Browser Use Cloud v4
+## Browser API
 
-For an agent that runs on our side. Send a task through the API or the chat at [cloud.browser-use.com](https://cloud.browser-use.com) and get the result back. The agent, the browsers, the proxies and the live preview are all hosted. This is the CLI and our browser together, as a service.
+You have an agent and a harness and only need the browser. Create a stealth browser with residential proxies, persistent profiles and CAPTCHA handling, connect over CDP from anything.
 
-## Browser infrastructure
-
-For teams that have an agent and only need the browser. Create a stealth browser with residential proxies, persistent profiles and CAPTCHA handling, connect over CDP, and drive it from any framework or your own code.
-
-## They share one account
-
-One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) authenticates the CLI's cloud browsers (`browser-use auth login`), the v4 API, and the browser API. Credits and profiles live in the same project.
+One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.
 
 # Human Quickstart
 Source: https://docs.browser-use.com/open-source/quickstart

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -46,7 +46,7 @@ Use the full hosted stack for scheduled work, tasks your users trigger, and work
 
 ## Only the browser
 
-Use the [Browser API](https://docs.browser-use.com/cloud/browser/stealth) when you only need the hosted browser. Browser Use CLI or a custom computer-use CLI can connect to the same Cloud Browser from your computer or your own cloud; Browser API does not add a hosted agent.
+Use the [Browser API](https://docs.browser-use.com/cloud/browser/quickstart) when you only need the hosted browser. Browser Use CLI or a custom computer-use CLI can connect to the same Cloud Browser from your computer or your own cloud; Browser API does not add a hosted agent.
 
 One API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) works for all three. Credits and profiles live in the same project.
 

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -21,8 +21,8 @@ Source: https://docs.browser-use.com/cloud/which-product
 
 Pick where your agent and browser should run.
 
-<img src="/cloud/images/which-product-light.svg" alt="On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other local agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI together above that Cloud Browser. Browser API is the browser-only route." noZoom className="block dark:hidden" />
-<img src="/cloud/images/which-product-dark.svg" alt="On your computer, Claude Code, Codex, OpenCode, Hermes Agent, and other local agents can use Browser Use CLI or another computer-use CLI. Those CLIs can control real Chrome or the single Cloud Browser. Cloud v4 runs OpenCode and Browser Use CLI together above that Cloud Browser. Browser API is the browser-only route." noZoom className="hidden dark:block" />
+<img src="/cloud/images/which-product-light.svg" alt="On your computer, Claude Code, Codex, OpenCode, and Hermes Agent sit above Browser Use CLI and Playwright CLI. The CLIs use either real Chrome locally or the Cloud Browser directly. In Cloud v4, OpenCode and Browser Use CLI run above that Cloud Browser." noZoom className="block dark:hidden" />
+<img src="/cloud/images/which-product-dark.svg" alt="On your computer, Claude Code, Codex, OpenCode, and Hermes Agent sit above Browser Use CLI and Playwright CLI. The CLIs use either real Chrome locally or the Cloud Browser directly. In Cloud v4, OpenCode and Browser Use CLI run above that Cloud Browser." noZoom className="hidden dark:block" />
 
 ## On your computer
 

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -15,6 +15,50 @@ Full SDK reference in a single page.
 
   Try [Browser Use Cloud](https://docs.browser-use.com/cloud/introduction) for our SOTA model, stealth browsers, CAPTCHA solving, and managed infrastructure.
 
+# Which Browser Use do I need?
+Source: https://docs.browser-use.com/cloud/which-product
+
+
+Browser Use is one API key and five ways to use it. Start from what you want to happen, not from the product name.
+
+| You want | Use | What runs where |
+|---|---|---|
+| A result from a browser task, by API or chat, without running anything yourself | [Browser Use Cloud](https://docs.browser-use.com/cloud/quickstart) | Our agent and our stealth browsers, in our cloud |
+| Your coding agent (Claude Code, Codex, Gemini CLI) to drive a browser you are logged into | [Browser Use CLI](/open-source/browser-use-cli) | Your coding agent, your Chrome or a cloud browser, Python over CDP |
+| To build your own agent in Python with any LLM | [Browser Use library](/open-source/quickstart) | Your code, your model, a local or self-hosted browser |
+| A desktop app instead of a terminal | [Browser Use Desktop](https://github.com/browser-use/desktop) | The CLI with a window around it, on your machine |
+| An always-on agent you text from your phone | [Browser Use Box](https://github.com/browser-use/bux) | Claude Code plus a real browser on a VPS you own, via Telegram |
+
+## Cloud
+
+Send a task, get a result. The v4 API and the chat UI at [cloud.browser-use.com](https://cloud.browser-use.com) run the agent on hosted stealth browsers with residential proxies, CAPTCHA solving, persistent profiles, and a live preview. Nothing to install; the SDK is optional.
+
+Pick this when you need stealth or proxies, when the task runs on a server, or when you want to scale to many sessions.
+
+## Browser Use CLI (`browser-use`)
+
+A skill for coding agents, backed by the open-source [browser-harness](https://github.com/browser-use/browser-harness) project. The agent writes Python that talks to a browser over CDP: your running Chrome with its tabs, cookies, and logins, a Browser Use cloud browser, or any CDP endpoint.
+
+Pick this when you are already inside Claude Code or Codex and want it to click, type, and read pages in a browser you control. Setup is a single prompt; see [Browser Use CLI](/open-source/browser-use-cli).
+
+## Browser Use library (`pip install browser-use`)
+
+The Python framework the company started with. Bring your own LLM, run the agent in your own process, and customize tools, prompts, and the browser session. Works with a local browser or with cloud browsers through the same API key.
+
+Pick this when you are building your own agent product or need full control over the loop.
+
+## Browser Use Desktop
+
+An open-source desktop app for people who do not live in a terminal. It gives the CLI a window: type a goal, watch the browser, approve steps. Same local-browser model as the CLI.
+
+## Browser Use Box (BUX)
+
+One install script turns any Ubuntu box into a 24/7 agent with Claude Code, the CLI, and a real browser preinstalled. You talk to it over Telegram. Pick this when you want an agent that keeps working while your laptop is closed.
+
+## They share one account
+
+The same API key from [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1) authenticates the SDK, the CLI's cloud browsers (`browser-use auth login`), the library's `ChatBrowserUse` model, and Browser Use Box. Credits and profiles live in the same project.
+
 # Human Quickstart
 Source: https://docs.browser-use.com/open-source/quickstart
 

--- a/docs/open-source/llms.txt
+++ b/docs/open-source/llms.txt
@@ -11,7 +11,7 @@ Install: `pip install browser-use`
 
 ## Get Started
 - [Browser Use Open Source](https://docs.browser-use.com/open-source/introduction): Python library for AI browser automation with 79k+ GitHub stars. Connect any LLM and run locally or self-hosted.
-- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Three parts: your agent, our CLI, a browser. Take all three hosted, or only what you need.
+- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Run our CLI on your machine with your Chrome or our cloud browser, send a prompt to the fully hosted agent, or take only the browser.
 - [Human Quickstart](https://docs.browser-use.com/open-source/quickstart): Install and run your first AI browser agent in minutes. Python setup with pip, environment variables, and a working example.
 - [Prompts for Vibecoders](https://docs.browser-use.com/open-source/vibecoding): Complete Python SDK reference for AI coding agents. Paste into Claude Code, Cursor, or Copilot for instant integration.
 - [Supported Models](https://docs.browser-use.com/open-source/supported-models): Choose between Claude, Gemini, Llama, DeepSeek, and more. Configuration examples for each provider.

--- a/docs/open-source/llms.txt
+++ b/docs/open-source/llms.txt
@@ -11,7 +11,7 @@ Install: `pip install browser-use`
 
 ## Get Started
 - [Browser Use Open Source](https://docs.browser-use.com/open-source/introduction): Python library for AI browser automation with 79k+ GitHub stars. Connect any LLM and run locally or self-hosted.
-- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Keep Claude Code or Codex on your machine, send the whole task to our cloud, or take only our browser.
+- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Run Browser Use on your machine, run the full stack in our cloud, or bring your own agent and use only the hosted browser.
 - [Human Quickstart](https://docs.browser-use.com/open-source/quickstart): Install and run your first AI browser agent in minutes. Python setup with pip, environment variables, and a working example.
 - [Prompts for Vibecoders](https://docs.browser-use.com/open-source/vibecoding): Complete Python SDK reference for AI coding agents. Paste into Claude Code, Cursor, or Copilot for instant integration.
 - [Supported Models](https://docs.browser-use.com/open-source/supported-models): Choose between Claude, Gemini, Llama, DeepSeek, and more. Configuration examples for each provider.

--- a/docs/open-source/llms.txt
+++ b/docs/open-source/llms.txt
@@ -11,7 +11,7 @@ Install: `pip install browser-use`
 
 ## Get Started
 - [Browser Use Open Source](https://docs.browser-use.com/open-source/introduction): Python library for AI browser automation with 79k+ GitHub stars. Connect any LLM and run locally or self-hosted.
-- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Run our CLI on your machine with your Chrome or our cloud browser, send a prompt to the fully hosted agent, or take only the browser.
+- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Keep Claude Code or Codex on your machine, send the whole task to our cloud, or take only our browser.
 - [Human Quickstart](https://docs.browser-use.com/open-source/quickstart): Install and run your first AI browser agent in minutes. Python setup with pip, environment variables, and a working example.
 - [Prompts for Vibecoders](https://docs.browser-use.com/open-source/vibecoding): Complete Python SDK reference for AI coding agents. Paste into Claude Code, Cursor, or Copilot for instant integration.
 - [Supported Models](https://docs.browser-use.com/open-source/supported-models): Choose between Claude, Gemini, Llama, DeepSeek, and more. Configuration examples for each provider.

--- a/docs/open-source/llms.txt
+++ b/docs/open-source/llms.txt
@@ -11,7 +11,7 @@ Install: `pip install browser-use`
 
 ## Get Started
 - [Browser Use Open Source](https://docs.browser-use.com/open-source/introduction): Python library for AI browser automation with 79k+ GitHub stars. Connect any LLM and run locally or self-hosted.
-- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Cloud, the open-source library, the CLI for coding agents, the desktop app, or Browser Use Box: pick by where you want the browser and the agent to run.
+- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Our browser, our CLI, or both together hosted as v4: pick by where your agent runs.
 - [Human Quickstart](https://docs.browser-use.com/open-source/quickstart): Install and run your first AI browser agent in minutes. Python setup with pip, environment variables, and a working example.
 - [Prompts for Vibecoders](https://docs.browser-use.com/open-source/vibecoding): Complete Python SDK reference for AI coding agents. Paste into Claude Code, Cursor, or Copilot for instant integration.
 - [Supported Models](https://docs.browser-use.com/open-source/supported-models): Choose between Claude, Gemini, Llama, DeepSeek, and more. Configuration examples for each provider.

--- a/docs/open-source/llms.txt
+++ b/docs/open-source/llms.txt
@@ -11,6 +11,7 @@ Install: `pip install browser-use`
 
 ## Get Started
 - [Browser Use Open Source](https://docs.browser-use.com/open-source/introduction): Python library for AI browser automation with 79k+ GitHub stars. Connect any LLM and run locally or self-hosted.
+- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Cloud, the open-source library, the CLI for coding agents, the desktop app, or Browser Use Box: pick by where you want the browser and the agent to run.
 - [Human Quickstart](https://docs.browser-use.com/open-source/quickstart): Install and run your first AI browser agent in minutes. Python setup with pip, environment variables, and a working example.
 - [Prompts for Vibecoders](https://docs.browser-use.com/open-source/vibecoding): Complete Python SDK reference for AI coding agents. Paste into Claude Code, Cursor, or Copilot for instant integration.
 - [Supported Models](https://docs.browser-use.com/open-source/supported-models): Choose between Claude, Gemini, Llama, DeepSeek, and more. Configuration examples for each provider.

--- a/docs/open-source/llms.txt
+++ b/docs/open-source/llms.txt
@@ -11,7 +11,7 @@ Install: `pip install browser-use`
 
 ## Get Started
 - [Browser Use Open Source](https://docs.browser-use.com/open-source/introduction): Python library for AI browser automation with 79k+ GitHub stars. Connect any LLM and run locally or self-hosted.
-- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Our browser, our CLI, or both together hosted as v4: pick by where your agent runs.
+- [Which Browser Use do I need?](https://docs.browser-use.com/cloud/which-product): Three parts: your agent, our CLI, a browser. Take all three hosted, or only what you need.
 - [Human Quickstart](https://docs.browser-use.com/open-source/quickstart): Install and run your first AI browser agent in minutes. Python setup with pip, environment variables, and a working example.
 - [Prompts for Vibecoders](https://docs.browser-use.com/open-source/vibecoding): Complete Python SDK reference for AI coding agents. Paste into Claude Code, Cursor, or Copilot for instant integration.
 - [Supported Models](https://docs.browser-use.com/open-source/supported-models): Choose between Claude, Gemini, Llama, DeepSeek, and more. Configuration examples for each provider.


### PR DESCRIPTION
Adds a product map with local agent and CLI choices beside the hosted V4 stack. Playwright CLI and Browser Use CLI share routes to real Chrome or Cloud Browser. A separate dashed Profile Sync path shows explicit cookie copying from real Chrome into a cloud profile. Includes light/dark and narrow-screen SVGs, page links, and regenerated LLM docs.
