### PR TITLE
Document 1Password for v4 runs and move the guide out of Legacy

### DIFF
--- a/docs/cloud/guides/1password.mdx
+++ b/docs/cloud/guides/1password.mdx
@@ -1,6 +1,6 @@
 ---
 title: 1Password & 2FA
-description: "Auto-fill passwords and TOTP codes from 1Password during agent tasks."
+description: "Auto-fill passwords and TOTP codes from 1Password in API tasks: v4 runs with secret bindings, v2 and v3 tasks with a vault id."
 icon: lock
 ---
 
@@ -23,7 +23,65 @@ Create a new vault in 1Password for Browser Use. Add the credentials you want th
 2. Click **Create Integration**
 3. Paste your service account token
 
-## Run tasks with 1Password
+## Use a vault in a v4 run
+
+A v4 run does not take a vault id. It takes **secret bindings**: each binding names one field of one 1Password item, gives it an alias the agent can ask for, and lists the hosts it may be typed into. The value never reaches the model; the server types it into the focused field when the agent asks for the alias on an allowed domain. Bindings are run-scoped, so a follow-up run that needs the same login must send them again.
+
+<CodeGroup>
+```python Python
+from browser_use_sdk.v4 import BrowserUse
+
+with BrowserUse() as client:
+    run = client.runs.create(
+        "Log into Jira and create a ticket for the Q4 release",
+        secret_bindings=[
+            {
+                "alias": "jira_password",
+                "source": {
+                    "type": "onepassword",
+                    "integrationId": "<integration id from Settings → Secrets>",
+                    "vaultId": "<vault id>",
+                    "itemId": "<item id>",
+                    "fieldId": "password",
+                },
+                "allowedDomains": ["atlassian.net"],
+            }
+        ],
+    )
+    print(client.runs.wait_for_completion(run.id).result)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v4";
+
+const client = new BrowserUse();
+const run = await client.runs.create({
+  task: "Log into Jira and create a ticket for the Q4 release",
+  secretBindings: [
+    {
+      alias: "jira_password",
+      source: {
+        type: "onepassword",
+        integrationId: "<integration id from Settings → Secrets>",
+        vaultId: "<vault id>",
+        itemId: "<item id>",
+        fieldId: "password",
+      },
+      allowedDomains: ["atlassian.net"],
+    },
+  ],
+});
+```
+</CodeGroup>
+
+- `integrationId` is the 1Password integration you connected under **Settings → Secrets**.
+- `vaultId` and `itemId` are the 1Password UUIDs of the vault and item (copy them from 1Password).
+- `fieldId` is the field's id, not its label: `username`, `password`, or `one-time-password` for a TOTP field, which resolves to the current code.
+- `allowedDomains` are bare hostnames; a host covers its subdomains.
+
+In the chat UI at cloud.browser-use.com the same picker lives under **Run settings → Credentials**: choose the vault, the item, and the field, give it an alias, and list the domains.
+
+## Use a vault in a v2 or v3 task
+
 
 <CodeGroup>
 ```python Python

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1580,6 +1580,198 @@ See [Human in the loop](https://docs.browser-use.com/cloud/agent/human-in-the-lo
 embedding the live browser URL. Never put passwords or TOTP secrets directly
 in a prompt.
 
+# 1Password & 2FA
+Source: https://docs.browser-use.com/cloud/guides/1password
+
+
+## Setup
+
+### 1. Create a dedicated vault
+
+Create a new vault in 1Password for Browser Use. Add the credentials you want the agent to access (usernames, passwords, and 2FA/TOTP codes).
+
+### 2. Create a service account token
+
+1. Go to [1Password Developer Tools - Service Accounts](https://my.1password.eu/developer-tools/active/service-accounts)
+2. Click **New Service Account**, name it "Browser Use Cloud"
+3. Grant **read access** to the dedicated vault
+4. Copy the generated token
+
+### 3. Connect to Browser Use Cloud
+
+1. Go to [Browser Use Cloud Settings - Secrets](https://cloud.browser-use.com/settings?tab=secrets)
+2. Click **Create Integration**
+3. Paste your service account token
+
+## Use a vault in a v4 run
+
+A v4 run does not take a vault id. It takes **secret bindings**: each binding names one field of one 1Password item, gives it an alias the agent can ask for, and lists the hosts it may be typed into. The value never reaches the model; the server types it into the focused field when the agent asks for the alias on an allowed domain. Bindings are run-scoped, so a follow-up run that needs the same login must send them again.
+
+```python Python
+from browser_use_sdk.v4 import BrowserUse
+
+with BrowserUse() as client:
+    run = client.runs.create(
+        "Log into Jira and create a ticket for the Q4 release",
+        secret_bindings=[
+            {
+                "alias": "jira_password",
+                "source": {
+                    "type": "onepassword",
+                    "integrationId": "<integration id from Settings → Secrets>",
+                    "vaultId": "<vault id>",
+                    "itemId": "<item id>",
+                    "fieldId": "password",
+                },
+                "allowedDomains": ["atlassian.net"],
+            }
+        ],
+    )
+    print(client.runs.wait_for_completion(run.id).result)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v4";
+
+const client = new BrowserUse();
+const run = await client.runs.create({
+  task: "Log into Jira and create a ticket for the Q4 release",
+  secretBindings: [
+    {
+      alias: "jira_password",
+      source: {
+        type: "onepassword",
+        integrationId: "<integration id from Settings → Secrets>",
+        vaultId: "<vault id>",
+        itemId: "<item id>",
+        fieldId: "password",
+      },
+      allowedDomains: ["atlassian.net"],
+    },
+  ],
+});
+```
+
+- `integrationId` is the 1Password integration you connected under **Settings → Secrets**.
+- `vaultId` and `itemId` are the 1Password UUIDs of the vault and item (copy them from 1Password).
+- `fieldId` is the field's id, not its label: `username`, `password`, or `one-time-password` for a TOTP field, which resolves to the current code.
+- `allowedDomains` are bare hostnames; a host covers its subdomains.
+
+In the chat UI at cloud.browser-use.com the same picker lives under **Run settings → Credentials**: choose the vault, the item, and the field, give it an alias, and list the domains.
+
+## Use a vault in a v2 or v3 task
+
+
+```python Python
+from browser_use_sdk import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+result = await client.run(
+    "Log into my Jira account and create a new ticket",
+    op_vault_id="your-vault-id",
+    allowed_domains=["*.atlassian.net"],
+)
+print(result.output)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk";
+
+const client = new BrowserUse();
+const result = await client.run(
+  "Log into my Jira account and create a new ticket",
+  {
+    opVaultId: "your-vault-id",
+    allowedDomains: ["*.atlassian.net"],
+  },
+);
+console.log(result.output);
+```
+
+For SSO/OAuth redirects, include all required domains:
+
+```python Python
+result = await client.run(
+    "Log into Jira and create a ticket for the Q4 release",
+    op_vault_id="your-vault-id",
+    allowed_domains=["*.atlassian.net", "*.okta.com"],
+)
+```
+```typescript TypeScript
+const result = await client.run(
+  "Log into Jira and create a ticket for the Q4 release",
+  {
+    opVaultId: "your-vault-id",
+    allowedDomains: ["*.atlassian.net", "*.okta.com"],
+  },
+);
+```
+
+## How it works
+
+When the agent encounters a login form:
+
+1. It identifies the service (e.g., Twitter, GitHub, LinkedIn)
+2. Retrieves matching credentials from your 1Password vault
+3. Fills in the username and password
+4. If 2FA is required and a TOTP code is stored, it generates and enters the code automatically
+
+  The agent never sees your actual credentials. The actual username, password, and 2FA codes are filled in programmatically — keeping your secrets hidden from the AI model.
+
+# Secrets
+Source: https://docs.browser-use.com/cloud/guides/secrets
+
+
+Pass credentials to the agent scoped by domain. The agent uses them only on matching domains.
+
+```python Python
+from browser_use_sdk import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+result = await client.run(
+    "Log into GitHub and star the browser-use/browser-use repo",
+    secrets={"github.com": "username:password123"},
+    allowed_domains=["github.com"],
+)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk";
+
+const client = new BrowserUse();
+const result = await client.run(
+  "Log into GitHub and star the browser-use/browser-use repo",
+  {
+    secrets: { "github.com": "username:password123" },
+    allowedDomains: ["github.com"],
+  },
+);
+```
+
+Use `allowed_domains` to restrict the agent to specific domains. Supports wildcards: `example.com`, `*.example.com`.
+
+For SSO/OAuth redirects, include all domains in the auth flow:
+
+```python Python
+result = await client.run(
+    "Log into the company portal and download the Q4 report",
+    secrets={
+        "portal.example.com": "user@company.com:password123",
+        "okta.com": "user@company.com:password123",
+    },
+    allowed_domains=["portal.example.com", "*.okta.com"],
+)
+```
+```typescript TypeScript
+const result = await client.run(
+  "Log into the company portal and download the Q4 report",
+  {
+    secrets: {
+      "portal.example.com": "user@company.com:password123",
+      "okta.com": "user@company.com:password123",
+    },
+    allowedDomains: ["portal.example.com", "*.okta.com"],
+  },
+);
+```
+
 # Claude Code
 Source: https://docs.browser-use.com/cloud/tutorials/integrations/claude-code
 
@@ -2224,142 +2416,6 @@ const result = await client.marketplace.execute(skillId, { parameters: { ... } }
 ```
 
 See [Pricing](https://browser-use.com/pricing) for skill costs.
-
-# 1Password & 2FA
-Source: https://docs.browser-use.com/cloud/guides/1password
-
-
-## Setup
-
-### 1. Create a dedicated vault
-
-Create a new vault in 1Password for Browser Use. Add the credentials you want the agent to access (usernames, passwords, and 2FA/TOTP codes).
-
-### 2. Create a service account token
-
-1. Go to [1Password Developer Tools - Service Accounts](https://my.1password.eu/developer-tools/active/service-accounts)
-2. Click **New Service Account**, name it "Browser Use Cloud"
-3. Grant **read access** to the dedicated vault
-4. Copy the generated token
-
-### 3. Connect to Browser Use Cloud
-
-1. Go to [Browser Use Cloud Settings - Secrets](https://cloud.browser-use.com/settings?tab=secrets)
-2. Click **Create Integration**
-3. Paste your service account token
-
-## Run tasks with 1Password
-
-```python Python
-from browser_use_sdk import AsyncBrowserUse
-
-client = AsyncBrowserUse()
-result = await client.run(
-    "Log into my Jira account and create a new ticket",
-    op_vault_id="your-vault-id",
-    allowed_domains=["*.atlassian.net"],
-)
-print(result.output)
-```
-```typescript TypeScript
-import { BrowserUse } from "browser-use-sdk";
-
-const client = new BrowserUse();
-const result = await client.run(
-  "Log into my Jira account and create a new ticket",
-  {
-    opVaultId: "your-vault-id",
-    allowedDomains: ["*.atlassian.net"],
-  },
-);
-console.log(result.output);
-```
-
-For SSO/OAuth redirects, include all required domains:
-
-```python Python
-result = await client.run(
-    "Log into Jira and create a ticket for the Q4 release",
-    op_vault_id="your-vault-id",
-    allowed_domains=["*.atlassian.net", "*.okta.com"],
-)
-```
-```typescript TypeScript
-const result = await client.run(
-  "Log into Jira and create a ticket for the Q4 release",
-  {
-    opVaultId: "your-vault-id",
-    allowedDomains: ["*.atlassian.net", "*.okta.com"],
-  },
-);
-```
-
-## How it works
-
-When the agent encounters a login form:
-
-1. It identifies the service (e.g., Twitter, GitHub, LinkedIn)
-2. Retrieves matching credentials from your 1Password vault
-3. Fills in the username and password
-4. If 2FA is required and a TOTP code is stored, it generates and enters the code automatically
-
-  The agent never sees your actual credentials. The actual username, password, and 2FA codes are filled in programmatically — keeping your secrets hidden from the AI model.
-
-# Secrets
-Source: https://docs.browser-use.com/cloud/guides/secrets
-
-
-Pass credentials to the agent scoped by domain. The agent uses them only on matching domains.
-
-```python Python
-from browser_use_sdk import AsyncBrowserUse
-
-client = AsyncBrowserUse()
-result = await client.run(
-    "Log into GitHub and star the browser-use/browser-use repo",
-    secrets={"github.com": "username:password123"},
-    allowed_domains=["github.com"],
-)
-```
-```typescript TypeScript
-import { BrowserUse } from "browser-use-sdk";
-
-const client = new BrowserUse();
-const result = await client.run(
-  "Log into GitHub and star the browser-use/browser-use repo",
-  {
-    secrets: { "github.com": "username:password123" },
-    allowedDomains: ["github.com"],
-  },
-);
-```
-
-Use `allowed_domains` to restrict the agent to specific domains. Supports wildcards: `example.com`, `*.example.com`.
-
-For SSO/OAuth redirects, include all domains in the auth flow:
-
-```python Python
-result = await client.run(
-    "Log into the company portal and download the Q4 report",
-    secrets={
-        "portal.example.com": "user@company.com:password123",
-        "okta.com": "user@company.com:password123",
-    },
-    allowed_domains=["portal.example.com", "*.okta.com"],
-)
-```
-```typescript TypeScript
-const result = await client.run(
-  "Log into the company portal and download the Q4 report",
-  {
-    secrets: {
-      "portal.example.com": "user@company.com:password123",
-      "okta.com": "user@company.com:password123",
-    },
-    allowedDomains: ["portal.example.com", "*.okta.com"],
-  },
-);
-```
 
 # API Reference
 Source: https://docs.browser-use.com/cloud/api-v4-overview

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -93,6 +93,8 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 - [Profiles](https://docs.browser-use.com/cloud/guides/authentication): Reuse cookies and browser state in API V4 runs.
 - [Sync local and cloud cookies](https://docs.browser-use.com/cloud/guides/profile-sync): Sync a local login, then use it in an API V4 run.
 - [2FA](https://docs.browser-use.com/cloud/guides/2fa): Handle two-factor authentication in API V4 runs.
+- [1Password & 2FA](https://docs.browser-use.com/cloud/guides/1password): Auto-fill passwords and TOTP codes from 1Password in API tasks: v4 runs with secret bindings, v2 and v3 tasks with a vault id.
+- [Secrets](https://docs.browser-use.com/cloud/guides/secrets): Pass domain-scoped credentials to the agent securely.
 
 ## More
 - [FAQ](https://docs.browser-use.com/cloud/faq): Common questions and solutions.
@@ -112,8 +114,6 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 - [Agent (v2)](https://docs.browser-use.com/cloud/legacy/agent): V2 agent models and file handling.
 - [Public share links (v2)](https://docs.browser-use.com/cloud/legacy/public-share): Generate shareable URLs for agent sessions using the v2 API.
 - [Skills](https://docs.browser-use.com/cloud/legacy/skills): Turn any website into a deterministic API endpoint. Create once, call repeatedly.
-- [1Password & 2FA](https://docs.browser-use.com/cloud/guides/1password): Auto-fill passwords and TOTP codes from 1Password during agent tasks.
-- [Secrets](https://docs.browser-use.com/cloud/guides/secrets): Pass domain-scoped credentials to the agent securely.
 
 ## API v4
 - [API Reference](https://docs.browser-use.com/cloud/api-v4-overview): Authenticate and start using the Browser Use API v4 — the current REST API for long-horizon agents.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -105,7 +105,9 @@
                         "pages": [
                           "cloud/guides/authentication",
                           "cloud/guides/profile-sync",
-                          "cloud/guides/2fa"
+                          "cloud/guides/2fa",
+                          "cloud/guides/1password",
+                          "cloud/guides/secrets"
                         ]
                       }
                     ]
@@ -145,9 +147,7 @@
                     "pages": [
                       "cloud/legacy/agent",
                       "cloud/legacy/public-share",
-                      "cloud/legacy/skills",
-                      "cloud/guides/1password",
-                      "cloud/guides/secrets"
+                      "cloud/legacy/skills"
                     ]
                   }
                 ]

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1580,6 +1580,198 @@ See [Human in the loop](https://docs.browser-use.com/cloud/agent/human-in-the-lo
 embedding the live browser URL. Never put passwords or TOTP secrets directly
 in a prompt.
 
+# 1Password & 2FA
+Source: https://docs.browser-use.com/cloud/guides/1password
+
+
+## Setup
+
+### 1. Create a dedicated vault
+
+Create a new vault in 1Password for Browser Use. Add the credentials you want the agent to access (usernames, passwords, and 2FA/TOTP codes).
+
+### 2. Create a service account token
+
+1. Go to [1Password Developer Tools - Service Accounts](https://my.1password.eu/developer-tools/active/service-accounts)
+2. Click **New Service Account**, name it "Browser Use Cloud"
+3. Grant **read access** to the dedicated vault
+4. Copy the generated token
+
+### 3. Connect to Browser Use Cloud
+
+1. Go to [Browser Use Cloud Settings - Secrets](https://cloud.browser-use.com/settings?tab=secrets)
+2. Click **Create Integration**
+3. Paste your service account token
+
+## Use a vault in a v4 run
+
+A v4 run does not take a vault id. It takes **secret bindings**: each binding names one field of one 1Password item, gives it an alias the agent can ask for, and lists the hosts it may be typed into. The value never reaches the model; the server types it into the focused field when the agent asks for the alias on an allowed domain. Bindings are run-scoped, so a follow-up run that needs the same login must send them again.
+
+```python Python
+from browser_use_sdk.v4 import BrowserUse
+
+with BrowserUse() as client:
+    run = client.runs.create(
+        "Log into Jira and create a ticket for the Q4 release",
+        secret_bindings=[
+            {
+                "alias": "jira_password",
+                "source": {
+                    "type": "onepassword",
+                    "integrationId": "<integration id from Settings → Secrets>",
+                    "vaultId": "<vault id>",
+                    "itemId": "<item id>",
+                    "fieldId": "password",
+                },
+                "allowedDomains": ["atlassian.net"],
+            }
+        ],
+    )
+    print(client.runs.wait_for_completion(run.id).result)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v4";
+
+const client = new BrowserUse();
+const run = await client.runs.create({
+  task: "Log into Jira and create a ticket for the Q4 release",
+  secretBindings: [
+    {
+      alias: "jira_password",
+      source: {
+        type: "onepassword",
+        integrationId: "<integration id from Settings → Secrets>",
+        vaultId: "<vault id>",
+        itemId: "<item id>",
+        fieldId: "password",
+      },
+      allowedDomains: ["atlassian.net"],
+    },
+  ],
+});
+```
+
+- `integrationId` is the 1Password integration you connected under **Settings → Secrets**.
+- `vaultId` and `itemId` are the 1Password UUIDs of the vault and item (copy them from 1Password).
+- `fieldId` is the field's id, not its label: `username`, `password`, or `one-time-password` for a TOTP field, which resolves to the current code.
+- `allowedDomains` are bare hostnames; a host covers its subdomains.
+
+In the chat UI at cloud.browser-use.com the same picker lives under **Run settings → Credentials**: choose the vault, the item, and the field, give it an alias, and list the domains.
+
+## Use a vault in a v2 or v3 task
+
+
+```python Python
+from browser_use_sdk import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+result = await client.run(
+    "Log into my Jira account and create a new ticket",
+    op_vault_id="your-vault-id",
+    allowed_domains=["*.atlassian.net"],
+)
+print(result.output)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk";
+
+const client = new BrowserUse();
+const result = await client.run(
+  "Log into my Jira account and create a new ticket",
+  {
+    opVaultId: "your-vault-id",
+    allowedDomains: ["*.atlassian.net"],
+  },
+);
+console.log(result.output);
+```
+
+For SSO/OAuth redirects, include all required domains:
+
+```python Python
+result = await client.run(
+    "Log into Jira and create a ticket for the Q4 release",
+    op_vault_id="your-vault-id",
+    allowed_domains=["*.atlassian.net", "*.okta.com"],
+)
+```
+```typescript TypeScript
+const result = await client.run(
+  "Log into Jira and create a ticket for the Q4 release",
+  {
+    opVaultId: "your-vault-id",
+    allowedDomains: ["*.atlassian.net", "*.okta.com"],
+  },
+);
+```
+
+## How it works
+
+When the agent encounters a login form:
+
+1. It identifies the service (e.g., Twitter, GitHub, LinkedIn)
+2. Retrieves matching credentials from your 1Password vault
+3. Fills in the username and password
+4. If 2FA is required and a TOTP code is stored, it generates and enters the code automatically
+
+  The agent never sees your actual credentials. The actual username, password, and 2FA codes are filled in programmatically — keeping your secrets hidden from the AI model.
+
+# Secrets
+Source: https://docs.browser-use.com/cloud/guides/secrets
+
+
+Pass credentials to the agent scoped by domain. The agent uses them only on matching domains.
+
+```python Python
+from browser_use_sdk import AsyncBrowserUse
+
+client = AsyncBrowserUse()
+result = await client.run(
+    "Log into GitHub and star the browser-use/browser-use repo",
+    secrets={"github.com": "username:password123"},
+    allowed_domains=["github.com"],
+)
+```
+```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk";
+
+const client = new BrowserUse();
+const result = await client.run(
+  "Log into GitHub and star the browser-use/browser-use repo",
+  {
+    secrets: { "github.com": "username:password123" },
+    allowedDomains: ["github.com"],
+  },
+);
+```
+
+Use `allowed_domains` to restrict the agent to specific domains. Supports wildcards: `example.com`, `*.example.com`.
+
+For SSO/OAuth redirects, include all domains in the auth flow:
+
+```python Python
+result = await client.run(
+    "Log into the company portal and download the Q4 report",
+    secrets={
+        "portal.example.com": "user@company.com:password123",
+        "okta.com": "user@company.com:password123",
+    },
+    allowed_domains=["portal.example.com", "*.okta.com"],
+)
+```
+```typescript TypeScript
+const result = await client.run(
+  "Log into the company portal and download the Q4 report",
+  {
+    secrets: {
+      "portal.example.com": "user@company.com:password123",
+      "okta.com": "user@company.com:password123",
+    },
+    allowedDomains: ["portal.example.com", "*.okta.com"],
+  },
+);
+```
+
 # Claude Code
 Source: https://docs.browser-use.com/cloud/tutorials/integrations/claude-code
 
@@ -2224,142 +2416,6 @@ const result = await client.marketplace.execute(skillId, { parameters: { ... } }
 ```
 
 See [Pricing](https://browser-use.com/pricing) for skill costs.
-
-# 1Password & 2FA
-Source: https://docs.browser-use.com/cloud/guides/1password
-
-
-## Setup
-
-### 1. Create a dedicated vault
-
-Create a new vault in 1Password for Browser Use. Add the credentials you want the agent to access (usernames, passwords, and 2FA/TOTP codes).
-
-### 2. Create a service account token
-
-1. Go to [1Password Developer Tools - Service Accounts](https://my.1password.eu/developer-tools/active/service-accounts)
-2. Click **New Service Account**, name it "Browser Use Cloud"
-3. Grant **read access** to the dedicated vault
-4. Copy the generated token
-
-### 3. Connect to Browser Use Cloud
-
-1. Go to [Browser Use Cloud Settings - Secrets](https://cloud.browser-use.com/settings?tab=secrets)
-2. Click **Create Integration**
-3. Paste your service account token
-
-## Run tasks with 1Password
-
-```python Python
-from browser_use_sdk import AsyncBrowserUse
-
-client = AsyncBrowserUse()
-result = await client.run(
-    "Log into my Jira account and create a new ticket",
-    op_vault_id="your-vault-id",
-    allowed_domains=["*.atlassian.net"],
-)
-print(result.output)
-```
-```typescript TypeScript
-import { BrowserUse } from "browser-use-sdk";
-
-const client = new BrowserUse();
-const result = await client.run(
-  "Log into my Jira account and create a new ticket",
-  {
-    opVaultId: "your-vault-id",
-    allowedDomains: ["*.atlassian.net"],
-  },
-);
-console.log(result.output);
-```
-
-For SSO/OAuth redirects, include all required domains:
-
-```python Python
-result = await client.run(
-    "Log into Jira and create a ticket for the Q4 release",
-    op_vault_id="your-vault-id",
-    allowed_domains=["*.atlassian.net", "*.okta.com"],
-)
-```
-```typescript TypeScript
-const result = await client.run(
-  "Log into Jira and create a ticket for the Q4 release",
-  {
-    opVaultId: "your-vault-id",
-    allowedDomains: ["*.atlassian.net", "*.okta.com"],
-  },
-);
-```
-
-## How it works
-
-When the agent encounters a login form:
-
-1. It identifies the service (e.g., Twitter, GitHub, LinkedIn)
-2. Retrieves matching credentials from your 1Password vault
-3. Fills in the username and password
-4. If 2FA is required and a TOTP code is stored, it generates and enters the code automatically
-
-  The agent never sees your actual credentials. The actual username, password, and 2FA codes are filled in programmatically — keeping your secrets hidden from the AI model.
-
-# Secrets
-Source: https://docs.browser-use.com/cloud/guides/secrets
-
-
-Pass credentials to the agent scoped by domain. The agent uses them only on matching domains.
-
-```python Python
-from browser_use_sdk import AsyncBrowserUse
-
-client = AsyncBrowserUse()
-result = await client.run(
-    "Log into GitHub and star the browser-use/browser-use repo",
-    secrets={"github.com": "username:password123"},
-    allowed_domains=["github.com"],
-)
-```
-```typescript TypeScript
-import { BrowserUse } from "browser-use-sdk";
-
-const client = new BrowserUse();
-const result = await client.run(
-  "Log into GitHub and star the browser-use/browser-use repo",
-  {
-    secrets: { "github.com": "username:password123" },
-    allowedDomains: ["github.com"],
-  },
-);
-```
-
-Use `allowed_domains` to restrict the agent to specific domains. Supports wildcards: `example.com`, `*.example.com`.
-
-For SSO/OAuth redirects, include all domains in the auth flow:
-
-```python Python
-result = await client.run(
-    "Log into the company portal and download the Q4 report",
-    secrets={
-        "portal.example.com": "user@company.com:password123",
-        "okta.com": "user@company.com:password123",
-    },
-    allowed_domains=["portal.example.com", "*.okta.com"],
-)
-```
-```typescript TypeScript
-const result = await client.run(
-  "Log into the company portal and download the Q4 report",
-  {
-    secrets: {
-      "portal.example.com": "user@company.com:password123",
-      "okta.com": "user@company.com:password123",
-    },
-    allowedDomains: ["portal.example.com", "*.okta.com"],
-  },
-);
-```
 
 # API Reference
 Source: https://docs.browser-use.com/cloud/api-v4-overview

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -93,6 +93,8 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 - [Profiles](https://docs.browser-use.com/cloud/guides/authentication): Reuse cookies and browser state in API V4 runs.
 - [Sync local and cloud cookies](https://docs.browser-use.com/cloud/guides/profile-sync): Sync a local login, then use it in an API V4 run.
 - [2FA](https://docs.browser-use.com/cloud/guides/2fa): Handle two-factor authentication in API V4 runs.
+- [1Password & 2FA](https://docs.browser-use.com/cloud/guides/1password): Auto-fill passwords and TOTP codes from 1Password in API tasks: v4 runs with secret bindings, v2 and v3 tasks with a vault id.
+- [Secrets](https://docs.browser-use.com/cloud/guides/secrets): Pass domain-scoped credentials to the agent securely.
 
 ## More
 - [FAQ](https://docs.browser-use.com/cloud/faq): Common questions and solutions.
@@ -112,8 +114,6 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 - [Agent (v2)](https://docs.browser-use.com/cloud/legacy/agent): V2 agent models and file handling.
 - [Public share links (v2)](https://docs.browser-use.com/cloud/legacy/public-share): Generate shareable URLs for agent sessions using the v2 API.
 - [Skills](https://docs.browser-use.com/cloud/legacy/skills): Turn any website into a deterministic API endpoint. Create once, call repeatedly.
-- [1Password & 2FA](https://docs.browser-use.com/cloud/guides/1password): Auto-fill passwords and TOTP codes from 1Password during agent tasks.
-- [Secrets](https://docs.browser-use.com/cloud/guides/secrets): Pass domain-scoped credentials to the agent securely.
 
 ## API v4
 - [API Reference](https://docs.browser-use.com/cloud/api-v4-overview): Authenticate and start using the Browser Use API v4 — the current REST API for long-horizon agents.


### PR DESCRIPTION
## Why

People connect a 1Password vault in Settings → Secrets and expect the agent to use it. The guide only documented the v2 `op_vault_id` path and was filed under **Legacy (v2)**, although the live v4 API (`GET /api/v4/openapi.json`) accepts a `onepassword` secret source inside `secretBindings`, and the v4 chat picks vault items under Run settings → Credentials since #5620 (prod-2026-09-02-1). One real user ticket and two agent-filed tickets since Aug 17 (ENG-5790) came from that gap.

## What changes

- `cloud/guides/1password.mdx`: new **Use a vault in a v4 run** section (Python and TypeScript, `secret_bindings` / `secretBindings` with a `onepassword` source), what each id is, and where the same picker lives in the chat UI. The v2 section is kept and labelled.
- `docs.json`: the 1Password and Secrets guides move from **Legacy (v2)** to **Browser → Authentication**.
- `llms.txt` / `llms-full.txt` regenerated.

Pairs with browser-use/cloud#5778 (Secrets tab copy).