### PR TITLE
docs(skills): mark Skills retired and point to rerunnable scripts

### DIFF
--- a/docs/cloud/legacy/skills.mdx
+++ b/docs/cloud/legacy/skills.mdx
@@ -10,7 +10,7 @@ icon: wand-magic-sparkles
   be viewed and run, and Marketplace skills can still be cloned and executed.
 
   For new work, use [rerunnable scripts](/cloud/agent/scripts). A Cloud agent learns the
-  task once, saves the working code in its workspace, and later runs reuse that script.
+  task once and saves the working code in its workspace, so every later run reuses it.
 </Warning>
 
 ## Run an existing skill

--- a/docs/cloud/legacy/skills.mdx
+++ b/docs/cloud/legacy/skills.mdx
@@ -1,86 +1,39 @@
 ---
 title: Skills
-description: "Turn any website into a deterministic API endpoint. Create once, call repeatedly."
+description: "Retired. Existing skills still run; new skills are no longer created."
 icon: wand-magic-sparkles
 ---
 
-A skill turns a website interaction into a reusable, reliable API. Describe what you need, Browser Use builds the automation, you call it like a function.
+<Warning>
+  Skills are retired. You can no longer create or refine a skill: `skills.create`,
+  `skills.refine`, and manual recording return `410 Gone`. Existing skills can still
+  be viewed and run, and Marketplace skills can still be cloned and executed.
 
-## How skills work
+  For new work, use [rerunnable scripts](/cloud/agent/scripts). A Cloud agent learns the
+  task once, saves the working code in its workspace, and later runs reuse that script.
+</Warning>
 
-Every skill has two parts:
-
-- **Goal** — the full specification: what parameters it accepts, what data it returns, and the complete scope of work. If you want to extract data from 100 listings, the goal describes extracting from *all* of them.
-
-- **Demonstration** (`agent_prompt`) — shows *how* to perform the task, but only once. Think of it like onboarding a new colleague: you would not walk them through all 100 listings. You would show the first one or two and say "keep going like this for the rest." The demonstration navigates the site, triggers the necessary network requests, and the system builds the actual endpoint logic from that recording.
-
-<Tip>
-  The demonstration only needs to trigger the right network requests — it does not need to complete the full task. If extracting from many pages, open the first item and maybe paginate once. The system handles the rest.
-</Tip>
-
-## Create a skill
-
-<CodeGroup>
-```python Python
-from browser_use_sdk import AsyncBrowserUse
-
-client = AsyncBrowserUse()
-skill = await client.skills.create(
-    goal="Extract the top X posts from HackerNews. For each post return: title, URL, score, author, comment count, and rank. X is an input parameter.",
-    agent_prompt="Go to https://news.ycombinator.com, click on the first post to load its content, go back to the list, and scroll down to trigger loading of additional posts.",
-)
-print(skill.id)
-```
-```typescript TypeScript
-import { BrowserUse } from "browser-use-sdk";
-
-const client = new BrowserUse();
-const skill = await client.skills.create({
-  goal: "Extract the top X posts from HackerNews. For each post return: title, URL, score, author, comment count, and rank. X is an input parameter.",
-  agentPrompt: "Go to https://news.ycombinator.com, click on the first post to load its content, go back to the list, and scroll down to trigger loading of additional posts.",
-});
-console.log(skill.id);
-```
-</CodeGroup>
-
-Skill creation takes ~30 seconds. You can also create skills visually from the [Cloud Dashboard](https://cloud.browser-use.com/skills) — record yourself performing the task, or let the agent demonstrate it.
-
-## Execute a skill
+## Run an existing skill
 
 <CodeGroup>
 ```python Python
 result = await client.skills.execute(
-    skill.id,
+    skill_id,
     parameters={"X": 10},
 )
 print(result)
 ```
 ```typescript TypeScript
-const result = await client.skills.execute(skill.id, {
+const result = await client.skills.execute(skillId, {
   parameters: { X: 10 },
 });
 console.log(result);
 ```
 </CodeGroup>
 
-## Refine with feedback
-
-If execution is not quite right, iterate for free:
-
-<CodeGroup>
-```python Python
-await client.skills.refine(skill.id, feedback="Also extract the product description and available colors")
-```
-```typescript TypeScript
-await client.skills.refine(skill.id, {
-  feedback: "Also extract the product description and available colors",
-});
-```
-</CodeGroup>
-
 ## Marketplace
 
-Browse and use community-created skills.
+Browse, clone, and run community-created skills. Creating new skills is no longer available.
 
 <CodeGroup>
 ```python Python

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -2915,7 +2915,7 @@ Source: https://docs.browser-use.com/cloud/legacy/skills
   be viewed and run, and Marketplace skills can still be cloned and executed.
 
   For new work, use [rerunnable scripts](https://docs.browser-use.com/cloud/agent/scripts). A Cloud agent learns the
-  task once, saves the working code in its workspace, and later runs reuse that script.
+  task once and saves the working code in its workspace, so every later run reuses it.
 
 ## Run an existing skill
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -2910,75 +2910,32 @@ console.log(share.shareUrl);
 Source: https://docs.browser-use.com/cloud/legacy/skills
 
 
-A skill turns a website interaction into a reusable, reliable API. Describe what you need, Browser Use builds the automation, you call it like a function.
+  Skills are retired. You can no longer create or refine a skill: `skills.create`,
+  `skills.refine`, and manual recording return `410 Gone`. Existing skills can still
+  be viewed and run, and Marketplace skills can still be cloned and executed.
 
-## How skills work
+  For new work, use [rerunnable scripts](https://docs.browser-use.com/cloud/agent/scripts). A Cloud agent learns the
+  task once, saves the working code in its workspace, and later runs reuse that script.
 
-Every skill has two parts:
-
-- **Goal** — the full specification: what parameters it accepts, what data it returns, and the complete scope of work. If you want to extract data from 100 listings, the goal describes extracting from *all* of them.
-
-- **Demonstration** (`agent_prompt`) — shows *how* to perform the task, but only once. Think of it like onboarding a new colleague: you would not walk them through all 100 listings. You would show the first one or two and say "keep going like this for the rest." The demonstration navigates the site, triggers the necessary network requests, and the system builds the actual endpoint logic from that recording.
-
-  The demonstration only needs to trigger the right network requests — it does not need to complete the full task. If extracting from many pages, open the first item and maybe paginate once. The system handles the rest.
-
-## Create a skill
-
-```python Python
-from browser_use_sdk import AsyncBrowserUse
-
-client = AsyncBrowserUse()
-skill = await client.skills.create(
-    goal="Extract the top X posts from HackerNews. For each post return: title, URL, score, author, comment count, and rank. X is an input parameter.",
-    agent_prompt="Go to https://news.ycombinator.com, click on the first post to load its content, go back to the list, and scroll down to trigger loading of additional posts.",
-)
-print(skill.id)
-```
-```typescript TypeScript
-import { BrowserUse } from "browser-use-sdk";
-
-const client = new BrowserUse();
-const skill = await client.skills.create({
-  goal: "Extract the top X posts from HackerNews. For each post return: title, URL, score, author, comment count, and rank. X is an input parameter.",
-  agentPrompt: "Go to https://news.ycombinator.com, click on the first post to load its content, go back to the list, and scroll down to trigger loading of additional posts.",
-});
-console.log(skill.id);
-```
-
-Skill creation takes ~30 seconds. You can also create skills visually from the [Cloud Dashboard](https://cloud.browser-use.com/skills) — record yourself performing the task, or let the agent demonstrate it.
-
-## Execute a skill
+## Run an existing skill
 
 ```python Python
 result = await client.skills.execute(
-    skill.id,
+    skill_id,
     parameters={"X": 10},
 )
 print(result)
 ```
 ```typescript TypeScript
-const result = await client.skills.execute(skill.id, {
+const result = await client.skills.execute(skillId, {
   parameters: { X: 10 },
 });
 console.log(result);
 ```
 
-## Refine with feedback
-
-If execution is not quite right, iterate for free:
-
-```python Python
-await client.skills.refine(skill.id, feedback="Also extract the product description and available colors")
-```
-```typescript TypeScript
-await client.skills.refine(skill.id, {
-  feedback: "Also extract the product description and available colors",
-});
-```
-
 ## Marketplace
 
-Browse and use community-created skills.
+Browse, clone, and run community-created skills. Creating new skills is no longer available.
 
 ```python Python
 skills = await client.marketplace.list()

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -115,7 +115,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 ## Legacy (v2)
 - [Agent (v2)](https://docs.browser-use.com/cloud/legacy/agent): V2 agent models and file handling.
 - [Public share links (v2)](https://docs.browser-use.com/cloud/legacy/public-share): Generate shareable URLs for agent sessions using the v2 API.
-- [Skills](https://docs.browser-use.com/cloud/legacy/skills): Turn any website into a deterministic API endpoint. Create once, call repeatedly.
+- [Skills](https://docs.browser-use.com/cloud/legacy/skills): Retired. Existing skills still run; new skills are no longer created.
 - [1Password & 2FA](https://docs.browser-use.com/cloud/guides/1password): Auto-fill passwords and TOTP codes from 1Password during agent tasks.
 - [Secrets](https://docs.browser-use.com/cloud/guides/secrets): Pass domain-scoped credentials to the agent securely.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2915,7 +2915,7 @@ Source: https://docs.browser-use.com/cloud/legacy/skills
   be viewed and run, and Marketplace skills can still be cloned and executed.
 
   For new work, use [rerunnable scripts](https://docs.browser-use.com/cloud/agent/scripts). A Cloud agent learns the
-  task once, saves the working code in its workspace, and later runs reuse that script.
+  task once and saves the working code in its workspace, so every later run reuses it.
 
 ## Run an existing skill
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2910,75 +2910,32 @@ console.log(share.shareUrl);
 Source: https://docs.browser-use.com/cloud/legacy/skills
 
 
-A skill turns a website interaction into a reusable, reliable API. Describe what you need, Browser Use builds the automation, you call it like a function.
+  Skills are retired. You can no longer create or refine a skill: `skills.create`,
+  `skills.refine`, and manual recording return `410 Gone`. Existing skills can still
+  be viewed and run, and Marketplace skills can still be cloned and executed.
 
-## How skills work
+  For new work, use [rerunnable scripts](https://docs.browser-use.com/cloud/agent/scripts). A Cloud agent learns the
+  task once, saves the working code in its workspace, and later runs reuse that script.
 
-Every skill has two parts:
-
-- **Goal** — the full specification: what parameters it accepts, what data it returns, and the complete scope of work. If you want to extract data from 100 listings, the goal describes extracting from *all* of them.
-
-- **Demonstration** (`agent_prompt`) — shows *how* to perform the task, but only once. Think of it like onboarding a new colleague: you would not walk them through all 100 listings. You would show the first one or two and say "keep going like this for the rest." The demonstration navigates the site, triggers the necessary network requests, and the system builds the actual endpoint logic from that recording.
-
-  The demonstration only needs to trigger the right network requests — it does not need to complete the full task. If extracting from many pages, open the first item and maybe paginate once. The system handles the rest.
-
-## Create a skill
-
-```python Python
-from browser_use_sdk import AsyncBrowserUse
-
-client = AsyncBrowserUse()
-skill = await client.skills.create(
-    goal="Extract the top X posts from HackerNews. For each post return: title, URL, score, author, comment count, and rank. X is an input parameter.",
-    agent_prompt="Go to https://news.ycombinator.com, click on the first post to load its content, go back to the list, and scroll down to trigger loading of additional posts.",
-)
-print(skill.id)
-```
-```typescript TypeScript
-import { BrowserUse } from "browser-use-sdk";
-
-const client = new BrowserUse();
-const skill = await client.skills.create({
-  goal: "Extract the top X posts from HackerNews. For each post return: title, URL, score, author, comment count, and rank. X is an input parameter.",
-  agentPrompt: "Go to https://news.ycombinator.com, click on the first post to load its content, go back to the list, and scroll down to trigger loading of additional posts.",
-});
-console.log(skill.id);
-```
-
-Skill creation takes ~30 seconds. You can also create skills visually from the [Cloud Dashboard](https://cloud.browser-use.com/skills) — record yourself performing the task, or let the agent demonstrate it.
-
-## Execute a skill
+## Run an existing skill
 
 ```python Python
 result = await client.skills.execute(
-    skill.id,
+    skill_id,
     parameters={"X": 10},
 )
 print(result)
 ```
 ```typescript TypeScript
-const result = await client.skills.execute(skill.id, {
+const result = await client.skills.execute(skillId, {
   parameters: { X: 10 },
 });
 console.log(result);
 ```
 
-## Refine with feedback
-
-If execution is not quite right, iterate for free:
-
-```python Python
-await client.skills.refine(skill.id, feedback="Also extract the product description and available colors")
-```
-```typescript TypeScript
-await client.skills.refine(skill.id, {
-  feedback: "Also extract the product description and available colors",
-});
-```
-
 ## Marketplace
 
-Browse and use community-created skills.
+Browse, clone, and run community-created skills. Creating new skills is no longer available.
 
 ```python Python
 skills = await client.marketplace.list()

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -115,7 +115,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 ## Legacy (v2)
 - [Agent (v2)](https://docs.browser-use.com/cloud/legacy/agent): V2 agent models and file handling.
 - [Public share links (v2)](https://docs.browser-use.com/cloud/legacy/public-share): Generate shareable URLs for agent sessions using the v2 API.
-- [Skills](https://docs.browser-use.com/cloud/legacy/skills): Turn any website into a deterministic API endpoint. Create once, call repeatedly.
+- [Skills](https://docs.browser-use.com/cloud/legacy/skills): Retired. Existing skills still run; new skills are no longer created.
 - [1Password & 2FA](https://docs.browser-use.com/cloud/guides/1password): Auto-fill passwords and TOTP codes from 1Password during agent tasks.
 - [Secrets](https://docs.browser-use.com/cloud/guides/secrets): Pass domain-scoped credentials to the agent securely.
 

--- a/docs/open-source/customize/skills/basics.mdx
+++ b/docs/open-source/customize/skills/basics.mdx
@@ -4,7 +4,7 @@ description: "Skills are your API for anything. Describe what you need in plain 
 icon: "wand-magic"
 ---
 
-To learn more visit [Skills - Concepts](/cloud/guides/skills).
+To learn more visit [Skills - Concepts](/cloud/guides/skills). Skills are retired: existing skills still run, but new ones can no longer be created.
 
 
 ## Quick Example
@@ -85,4 +85,4 @@ async def main():
 asyncio.run(main())
 ```
 
-Browse and create skills at [cloud.browser-use.com/skills](https://cloud.browser-use.com/skills).
+Browse your existing skills at [cloud.browser-use.com/skills](https://cloud.browser-use.com/skills). Creating new skills is no longer available; for new work use [rerunnable scripts](/cloud/agent/scripts).


### PR DESCRIPTION
## Why

Cloud PR [#5666](https://github.com/browser-use/cloud/pull/5666) makes skill creation, `refine`, and manual recording return `410 Gone`:

> Skill creation is no longer available. Existing skills can still be viewed and run.

The docs still taught `skills.create(...)` and `skills.refine(...)`, and told people to "create skills visually from the Cloud Dashboard". Anyone following the docs after that PR merges hits a 410. A paying customer already opened a support ticket after hitting the retired backend.

## What changed

`docs/cloud/legacy/skills.mdx`
- Retirement warning at the top, naming exactly what returns 410 and what still works, linking to [rerunnable scripts](https://docs.browser-use.com/cloud/agent/scripts).
- Removed **Create a skill** and **Refine with feedback**.
- Kept **Execute** and **Marketplace**: existing skills still run, and marketplace skills can still be cloned and executed.

`docs/open-source/customize/skills/basics.mdx`
- Still accurate about loading existing skills by id, so the examples stay.
- Dropped "Browse and create skills at ..."; creation is gone.

`llms.txt` / `llms-full.txt` regenerated with `docs/generate-llms-txt.sh`.

## Verified against the code, not assumed

Read the PR #5666 diff rather than trusting the summary:
- `create` and `refine` → 410 (`backend/app/endpoints/cloud/skills/router.py`, `api/v2/skills/router.py`)
- `start_manual_recording` gated
- `/skills` list page **still exists** and still lists skills; only the Create button is removed, so links to `cloud.browser-use.com/skills` stay valid
- Marketplace keeps clone and execute; only its creation prompt changes

The only remaining `skills.create` string in the generated llms files is inside the new warning, which is intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UV3AvcViJQzAV75u67XZCF

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Skills docs to match the retired backend: `skills.create`, `skills.refine`, and manual recording now return `410 Gone`, and the docs no longer teach them. Existing skills and Marketplace skills still work, and new work now points to rerunnable scripts.

- Adds a retirement warning to `docs/cloud/legacy/skills.mdx` and removes the Create and Refine sections.
- Updates `docs/open-source/customize/skills/basics.mdx` to stop advertising skill creation.
- Regenerates `llms.txt` and `llms-full.txt`.

<sup>Written for commit 4b6f560fb8d967ca0fa8fe7a8a16ee8c05c9d494. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

