### PR TITLE
Document V4 inbox verification codes

### DIFF
--- a/docs/cloud/agent/quickstart.mdx
+++ b/docs/cloud/agent/quickstart.mdx
@@ -77,7 +77,7 @@ curl https://api.browser-use.com/api/v4/runs \
 </CodeGroup>
 
 See [2FA](/cloud/guides/2fa) for existing accounts, SMS forwarding, saved
-profiles, and human checkpoints.
+profiles, and human takeovers.
 
 <img
   src="/cloud/images/v4-agent-overview-light.svg"

--- a/docs/cloud/agent/quickstart.mdx
+++ b/docs/cloud/agent/quickstart.mdx
@@ -44,6 +44,35 @@ Every new run implicitly creates a [session](/cloud/agent/sessions) for its
 conversation and live browser, plus a [workspace](/cloud/agent/workspaces) for
 persistent files.
 
+## Verify an account by email
+
+Set `agentmail` to give the V4 agent its own inbox. The agent can use that
+address for a signup, read the verification email, and enter the code:
+
+<CodeGroup>
+```python Python
+run = client.runs.create(
+    "Create an account at example.com with your inbox. Read the verification email and enter its code.",
+    agentmail=True,
+)
+```
+```typescript TypeScript
+const run = await client.runs.create({
+  task: "Create an account at example.com with your inbox. Read the verification email and enter its code.",
+  agentmail: true,
+});
+```
+```bash curl
+curl https://api.browser-use.com/api/v4/runs \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"task":"Create an account at example.com with your inbox. Read the verification email and enter its code.","agentmail":true}'
+```
+</CodeGroup>
+
+See [2FA](/cloud/guides/2fa) for existing accounts, SMS forwarding, saved
+profiles, and human checkpoints.
+
 <img
   src="/cloud/images/v4-agent-overview-light.svg"
   alt="A task starts a run inside a session and the run reads and writes persistent workspace files"

--- a/docs/cloud/agent/quickstart.mdx
+++ b/docs/cloud/agent/quickstart.mdx
@@ -51,12 +51,18 @@ address for a signup, read the verification email, and enter the code:
 
 <CodeGroup>
 ```python Python
-run = client.runs.create(
-    "Create an account at example.com with your inbox. Read the verification email and enter its code.",
-    agentmail=True,
-)
+from browser_use_sdk.v4 import BrowserUse
+
+with BrowserUse() as client:
+    run = client.runs.create(
+        "Create an account at example.com with your inbox. Read the verification email and enter its code.",
+        agentmail=True,
+    )
 ```
 ```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v4";
+
+const client = new BrowserUse();
 const run = await client.runs.create({
   task: "Create an account at example.com with your inbox. Read the verification email and enter its code.",
   agentmail: true,

--- a/docs/cloud/guides/2fa.mdx
+++ b/docs/cloud/guides/2fa.mdx
@@ -4,7 +4,56 @@ description: "Handle two-factor authentication in API V4 runs."
 icon: shield-halved
 ---
 
-The most reliable options are a saved profile or a human checkpoint.
+Use the agent's inbox for email codes, reuse a logged-in profile, or pause for
+a human. These paths do not require Browser Use to store a TOTP seed.
+
+## Let the agent read email codes
+
+Set `agentmail` on an API V4 run to provision an inbox for its workspace. The
+inbox address and email skill are added to the agent's context, so it can
+receive the message, read the code, and finish the browser flow:
+
+<CodeGroup>
+```python Python
+run = client.runs.create(
+    "Create an account at example.com with your inbox. Read the verification email and enter its code.",
+    agentmail=True,
+)
+result = client.runs.wait_for_completion(run.id)
+```
+```typescript TypeScript
+const run = await client.runs.create({
+  task: "Create an account at example.com with your inbox. Read the verification email and enter its code.",
+  agentmail: true,
+});
+const result = await client.runs.waitForCompletion(run.id);
+```
+```bash curl
+curl https://api.browser-use.com/api/v4/runs \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"task":"Create an account at example.com with your inbox. Read the verification email and enter its code.","agentmail":true}'
+```
+</CodeGroup>
+
+The inbox persists with the workspace. For each API follow-up that needs inbox
+access, pass `agentmail=true` again and reuse the same session. Its address is
+also shown under [Settings → Workspaces](https://cloud.browser-use.com/settings?tab=workspaces).
+For an existing account, start one AgentMail-enabled run, copy that address,
+configure email forwarding, then continue the same session with AgentMail
+enabled.
+
+## Forward SMS codes to the inbox
+
+If a site only sends codes by SMS, you can use your own phone automation or
+forwarding provider to email those messages to the workspace inbox. Then tell
+the agent to read the forwarded message and enter its code.
+
+<Warning>
+  SMS forwarding is a customer-managed pattern, not a built-in Browser Use
+  integration. Browser Use does not read your phone or mobile account. Limit
+  forwarding to the intended sender and treat verification codes as sensitive.
+</Warning>
 
 ## Reuse a logged-in profile
 

--- a/docs/cloud/guides/2fa.mdx
+++ b/docs/cloud/guides/2fa.mdx
@@ -43,6 +43,23 @@ For an existing account, start one AgentMail-enabled run, copy that address,
 configure email forwarding, then continue the same session with AgentMail
 enabled.
 
+<CodeGroup>
+```python Python
+follow_up = client.runs.create(
+    "Check the inbox again and finish verification",
+    session_id=run.session_id,
+    agentmail=True,
+)
+```
+```typescript TypeScript
+const followUp = await client.runs.create({
+  task: "Check the inbox again and finish verification",
+  sessionId: run.sessionId,
+  agentmail: true,
+});
+```
+</CodeGroup>
+
 ## Forward SMS codes to the inbox
 
 If a site only sends codes by SMS, you can use your own phone automation or

--- a/docs/cloud/guides/2fa.mdx
+++ b/docs/cloud/guides/2fa.mdx
@@ -45,16 +45,28 @@ enabled.
 
 <CodeGroup>
 ```python Python
+inbox_run = client.runs.create(
+    "Open example.com and stop while I configure email forwarding to your inbox.",
+    agentmail=True,
+)
+client.runs.wait_for_completion(inbox_run.id)
+
 follow_up = client.runs.create(
     "Check the inbox again and finish verification",
-    session_id=run.session_id,
+    session_id=inbox_run.session_id,
     agentmail=True,
 )
 ```
 ```typescript TypeScript
+const inboxRun = await client.runs.create({
+  task: "Open example.com and stop while I configure email forwarding to your inbox.",
+  agentmail: true,
+});
+await client.runs.waitForCompletion(inboxRun.id);
+
 const followUp = await client.runs.create({
   task: "Check the inbox again and finish verification",
-  sessionId: run.sessionId,
+  sessionId: inboxRun.sessionId,
   agentmail: true,
 });
 ```

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -261,12 +261,18 @@ Set `agentmail` to give the V4 agent its own inbox. The agent can use that
 address for a signup, read the verification email, and enter the code:
 
 ```python Python
-run = client.runs.create(
-    "Create an account at example.com with your inbox. Read the verification email and enter its code.",
-    agentmail=True,
-)
+from browser_use_sdk.v4 import BrowserUse
+
+with BrowserUse() as client:
+    run = client.runs.create(
+        "Create an account at example.com with your inbox. Read the verification email and enter its code.",
+        agentmail=True,
+    )
 ```
 ```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v4";
+
+const client = new BrowserUse();
 const run = await client.runs.create({
   task: "Create an account at example.com with your inbox. Read the verification email and enter its code.",
   agentmail: true,

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1632,16 +1632,28 @@ configure email forwarding, then continue the same session with AgentMail
 enabled.
 
 ```python Python
+inbox_run = client.runs.create(
+    "Open example.com and stop while I configure email forwarding to your inbox.",
+    agentmail=True,
+)
+client.runs.wait_for_completion(inbox_run.id)
+
 follow_up = client.runs.create(
     "Check the inbox again and finish verification",
-    session_id=run.session_id,
+    session_id=inbox_run.session_id,
     agentmail=True,
 )
 ```
 ```typescript TypeScript
+const inboxRun = await client.runs.create({
+  task: "Open example.com and stop while I configure email forwarding to your inbox.",
+  agentmail: true,
+});
+await client.runs.waitForCompletion(inboxRun.id);
+
 const followUp = await client.runs.create({
   task: "Check the inbox again and finish verification",
-  sessionId: run.sessionId,
+  sessionId: inboxRun.sessionId,
   agentmail: true,
 });
 ```

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -255,6 +255,33 @@ Every new run implicitly creates a [session](https://docs.browser-use.com/cloud/
 conversation and live browser, plus a [workspace](https://docs.browser-use.com/cloud/agent/workspaces) for
 persistent files.
 
+## Verify an account by email
+
+Set `agentmail` to give the V4 agent its own inbox. The agent can use that
+address for a signup, read the verification email, and enter the code:
+
+```python Python
+run = client.runs.create(
+    "Create an account at example.com with your inbox. Read the verification email and enter its code.",
+    agentmail=True,
+)
+```
+```typescript TypeScript
+const run = await client.runs.create({
+  task: "Create an account at example.com with your inbox. Read the verification email and enter its code.",
+  agentmail: true,
+});
+```
+```bash curl
+curl https://api.browser-use.com/api/v4/runs \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"task":"Create an account at example.com with your inbox. Read the verification email and enter its code.","agentmail":true}'
+```
+
+See [2FA](https://docs.browser-use.com/cloud/guides/2fa) for existing accounts, SMS forwarding, saved
+profiles, and human checkpoints.
+
 <img
   src="/cloud/images/v4-agent-overview-light.svg"
   alt="A task starts a run inside a session and the run reads and writes persistent workspace files"
@@ -1561,7 +1588,52 @@ the prompt. Re-sync when the site's login expires.
 Source: https://docs.browser-use.com/cloud/guides/2fa
 
 
-The most reliable options are a saved profile or a human checkpoint.
+Use the agent's inbox for email codes, reuse a logged-in profile, or pause for
+a human. These paths do not require Browser Use to store a TOTP seed.
+
+## Let the agent read email codes
+
+Set `agentmail` on an API V4 run to provision an inbox for its workspace. The
+inbox address and email skill are added to the agent's context, so it can
+receive the message, read the code, and finish the browser flow:
+
+```python Python
+run = client.runs.create(
+    "Create an account at example.com with your inbox. Read the verification email and enter its code.",
+    agentmail=True,
+)
+result = client.runs.wait_for_completion(run.id)
+```
+```typescript TypeScript
+const run = await client.runs.create({
+  task: "Create an account at example.com with your inbox. Read the verification email and enter its code.",
+  agentmail: true,
+});
+const result = await client.runs.waitForCompletion(run.id);
+```
+```bash curl
+curl https://api.browser-use.com/api/v4/runs \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"task":"Create an account at example.com with your inbox. Read the verification email and enter its code.","agentmail":true}'
+```
+
+The inbox persists with the workspace. For each API follow-up that needs inbox
+access, pass `agentmail=true` again and reuse the same session. Its address is
+also shown under [Settings → Workspaces](https://cloud.browser-use.com/settings?tab=workspaces).
+For an existing account, start one AgentMail-enabled run, copy that address,
+configure email forwarding, then continue the same session with AgentMail
+enabled.
+
+## Forward SMS codes to the inbox
+
+If a site only sends codes by SMS, you can use your own phone automation or
+forwarding provider to email those messages to the workspace inbox. Then tell
+the agent to read the forwarded message and enter its code.
+
+  SMS forwarding is a customer-managed pattern, not a built-in Browser Use
+  integration. Browser Use does not read your phone or mobile account. Limit
+  forwarding to the intended sender and treat verification codes as sensitive.
 
 ## Reuse a logged-in profile
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -286,7 +286,7 @@ curl https://api.browser-use.com/api/v4/runs \
 ```
 
 See [2FA](https://docs.browser-use.com/cloud/guides/2fa) for existing accounts, SMS forwarding, saved
-profiles, and human checkpoints.
+profiles, and human takeovers.
 
 <img
   src="/cloud/images/v4-agent-overview-light.svg"

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1625,6 +1625,21 @@ For an existing account, start one AgentMail-enabled run, copy that address,
 configure email forwarding, then continue the same session with AgentMail
 enabled.
 
+```python Python
+follow_up = client.runs.create(
+    "Check the inbox again and finish verification",
+    session_id=run.session_id,
+    agentmail=True,
+)
+```
+```typescript TypeScript
+const followUp = await client.runs.create({
+  task: "Check the inbox again and finish verification",
+  sessionId: run.sessionId,
+  agentmail: true,
+});
+```
+
 ## Forward SMS codes to the inbox
 
 If a site only sends codes by SMS, you can use your own phone automation or

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -261,12 +261,18 @@ Set `agentmail` to give the V4 agent its own inbox. The agent can use that
 address for a signup, read the verification email, and enter the code:
 
 ```python Python
-run = client.runs.create(
-    "Create an account at example.com with your inbox. Read the verification email and enter its code.",
-    agentmail=True,
-)
+from browser_use_sdk.v4 import BrowserUse
+
+with BrowserUse() as client:
+    run = client.runs.create(
+        "Create an account at example.com with your inbox. Read the verification email and enter its code.",
+        agentmail=True,
+    )
 ```
 ```typescript TypeScript
+import { BrowserUse } from "browser-use-sdk/v4";
+
+const client = new BrowserUse();
 const run = await client.runs.create({
   task: "Create an account at example.com with your inbox. Read the verification email and enter its code.",
   agentmail: true,

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1632,16 +1632,28 @@ configure email forwarding, then continue the same session with AgentMail
 enabled.
 
 ```python Python
+inbox_run = client.runs.create(
+    "Open example.com and stop while I configure email forwarding to your inbox.",
+    agentmail=True,
+)
+client.runs.wait_for_completion(inbox_run.id)
+
 follow_up = client.runs.create(
     "Check the inbox again and finish verification",
-    session_id=run.session_id,
+    session_id=inbox_run.session_id,
     agentmail=True,
 )
 ```
 ```typescript TypeScript
+const inboxRun = await client.runs.create({
+  task: "Open example.com and stop while I configure email forwarding to your inbox.",
+  agentmail: true,
+});
+await client.runs.waitForCompletion(inboxRun.id);
+
 const followUp = await client.runs.create({
   task: "Check the inbox again and finish verification",
-  sessionId: run.sessionId,
+  sessionId: inboxRun.sessionId,
   agentmail: true,
 });
 ```

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -255,6 +255,33 @@ Every new run implicitly creates a [session](https://docs.browser-use.com/cloud/
 conversation and live browser, plus a [workspace](https://docs.browser-use.com/cloud/agent/workspaces) for
 persistent files.
 
+## Verify an account by email
+
+Set `agentmail` to give the V4 agent its own inbox. The agent can use that
+address for a signup, read the verification email, and enter the code:
+
+```python Python
+run = client.runs.create(
+    "Create an account at example.com with your inbox. Read the verification email and enter its code.",
+    agentmail=True,
+)
+```
+```typescript TypeScript
+const run = await client.runs.create({
+  task: "Create an account at example.com with your inbox. Read the verification email and enter its code.",
+  agentmail: true,
+});
+```
+```bash curl
+curl https://api.browser-use.com/api/v4/runs \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"task":"Create an account at example.com with your inbox. Read the verification email and enter its code.","agentmail":true}'
+```
+
+See [2FA](https://docs.browser-use.com/cloud/guides/2fa) for existing accounts, SMS forwarding, saved
+profiles, and human checkpoints.
+
 <img
   src="/cloud/images/v4-agent-overview-light.svg"
   alt="A task starts a run inside a session and the run reads and writes persistent workspace files"
@@ -1561,7 +1588,52 @@ the prompt. Re-sync when the site's login expires.
 Source: https://docs.browser-use.com/cloud/guides/2fa
 
 
-The most reliable options are a saved profile or a human checkpoint.
+Use the agent's inbox for email codes, reuse a logged-in profile, or pause for
+a human. These paths do not require Browser Use to store a TOTP seed.
+
+## Let the agent read email codes
+
+Set `agentmail` on an API V4 run to provision an inbox for its workspace. The
+inbox address and email skill are added to the agent's context, so it can
+receive the message, read the code, and finish the browser flow:
+
+```python Python
+run = client.runs.create(
+    "Create an account at example.com with your inbox. Read the verification email and enter its code.",
+    agentmail=True,
+)
+result = client.runs.wait_for_completion(run.id)
+```
+```typescript TypeScript
+const run = await client.runs.create({
+  task: "Create an account at example.com with your inbox. Read the verification email and enter its code.",
+  agentmail: true,
+});
+const result = await client.runs.waitForCompletion(run.id);
+```
+```bash curl
+curl https://api.browser-use.com/api/v4/runs \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"task":"Create an account at example.com with your inbox. Read the verification email and enter its code.","agentmail":true}'
+```
+
+The inbox persists with the workspace. For each API follow-up that needs inbox
+access, pass `agentmail=true` again and reuse the same session. Its address is
+also shown under [Settings → Workspaces](https://cloud.browser-use.com/settings?tab=workspaces).
+For an existing account, start one AgentMail-enabled run, copy that address,
+configure email forwarding, then continue the same session with AgentMail
+enabled.
+
+## Forward SMS codes to the inbox
+
+If a site only sends codes by SMS, you can use your own phone automation or
+forwarding provider to email those messages to the workspace inbox. Then tell
+the agent to read the forwarded message and enter its code.
+
+  SMS forwarding is a customer-managed pattern, not a built-in Browser Use
+  integration. Browser Use does not read your phone or mobile account. Limit
+  forwarding to the intended sender and treat verification codes as sensitive.
 
 ## Reuse a logged-in profile
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -286,7 +286,7 @@ curl https://api.browser-use.com/api/v4/runs \
 ```
 
 See [2FA](https://docs.browser-use.com/cloud/guides/2fa) for existing accounts, SMS forwarding, saved
-profiles, and human checkpoints.
+profiles, and human takeovers.
 
 <img
   src="/cloud/images/v4-agent-overview-light.svg"

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1625,6 +1625,21 @@ For an existing account, start one AgentMail-enabled run, copy that address,
 configure email forwarding, then continue the same session with AgentMail
 enabled.
 
+```python Python
+follow_up = client.runs.create(
+    "Check the inbox again and finish verification",
+    session_id=run.session_id,
+    agentmail=True,
+)
+```
+```typescript TypeScript
+const followUp = await client.runs.create({
+  task: "Check the inbox again and finish verification",
+  sessionId: run.sessionId,
+  agentmail: true,
+});
+```
+
 ## Forward SMS codes to the inbox
 
 If a site only sends codes by SMS, you can use your own phone automation or


### PR DESCRIPTION
API V4 already provisions a workspace inbox for an opted-in run, but the 2FA guide only mentioned saved profiles and human takeover. This adds the email-code flow to the quickstart and 2FA guide, and shows direct API follow-ups reusing the same session while opting into `agentmail: true` again. SMS forwarding is explicitly customer-managed, and no TOTP storage is added. Cloud PR browser-use/cloud#5807 must land first so API agents can discover the email skill. Generated llms artifacts are refreshed, and Mintlify validation plus broken-link checks pass.