### PR TITLE
release: v3.11.3

### DIFF
--- a/browser-use-node/package.json
+++ b/browser-use-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-use-sdk",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "description": "Official TypeScript SDK for the Browser Use API",
   "repository": {
     "type": "git",

--- a/browser-use-node/src/core/http.ts
+++ b/browser-use-node/src/core/http.ts
@@ -48,6 +48,7 @@ export class HttpClient {
     options?: {
       body?: unknown;
       query?: Record<string, unknown>;
+      headers?: Record<string, string>;
       signal?: AbortSignal;
     },
   ): Promise<T> {
@@ -66,7 +67,7 @@ export class HttpClient {
       }
     }
 
-    const headers: Record<string, string> = {};
+    const headers: Record<string, string> = { ...options?.headers };
     if (this.useApiKeyHeader) {
       headers["X-Browser-Use-API-Key"] = this.apiKey;
     }
@@ -148,8 +149,13 @@ export class HttpClient {
     return this.request<T>("GET", path, { query });
   }
 
-  post<T>(path: string, body?: unknown, query?: Record<string, unknown>): Promise<T> {
-    return this.request<T>("POST", path, { body, query });
+  post<T>(
+    path: string,
+    body?: unknown,
+    query?: Record<string, unknown>,
+    headers?: Record<string, string>,
+  ): Promise<T> {
+    return this.request<T>("POST", path, { body, query, headers });
   }
 
   patch<T>(path: string, body?: unknown, query?: Record<string, unknown>): Promise<T> {

--- a/browser-use-node/src/generated/v2/types.ts
+++ b/browser-use-node/src/generated/v2/types.ts
@@ -1118,6 +1118,18 @@ export interface components {
              */
             allowResizing: boolean;
             /**
+             * PDF Renderer Enabled
+             * @description Whether Chrome renders PDFs in a tab. Set to false to stop the in-tab render; the file is saved to the session's download directory either way.
+             * @default true
+             */
+            pdfRendererEnabled: boolean;
+            /**
+             * Solve Captchas
+             * @description Whether the browser detects and solves CAPTCHAs on its own. Set to false to handle CAPTCHAs yourself. Defaults to true.
+             * @default true
+             */
+            solveCaptchas: boolean;
+            /**
              * Custom Proxy
              * @description Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription.
              */
@@ -1308,7 +1320,7 @@ export interface components {
             thinking: boolean;
             /**
              * Thinking Level
-             * @description Optional model reasoning depth. Omit this field to preserve the provider default. API V2 accepts disabled/low/medium/high for browser-use-llm, browser-use-2.0, gemini-2.5-flash, gemini-3-flash-preview, gemini-3.5-flash, gemini-flash-latest, gemini-flash-lite-latest, gpt-5.5, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, claude-sonnet-5, claude-opus-4-7, claude-opus-4-8, and claude-opus-5; low/medium/high for gemini-2.5-pro, o3, and o4-mini; low/high for gemini-3-pro-preview and gemini-3.1-pro-preview; and disabled only for claude-sonnet-4-20250514, claude-sonnet-4-5-20250929, and claude-opus-4-5-20251101. For browser-use-llm, browser-use-2.0, Gemini 3 Flash, and Gemini 3.5 Flash, disabled maps to Google's minimal thinking level. For Gemini 2.5 Flash and the gemini-flash-latest variants, disabled maps to a zero thinking budget. bu-2-0-mini-preview does not support configurable thinking, so omit thinkingLevel for that model. Other V2 models reject an explicit level. API V2 cannot configure GLM thinking or enable fixed-budget Claude thinking; use API V3 or V4 for those combinations.
+             * @description Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected. API V2 cannot configure GLM or fixed-budget Claude thinking; use API V3 or V4 for those combinations.
              */
             thinkingLevel?: components["schemas"]["ThinkingLevel"] | null;
             /**
@@ -2412,7 +2424,7 @@ export interface components {
          * SupportedLLMs
          * @enum {string}
          */
-        SupportedLLMs: "browser-use-llm" | "browser-use-2.0" | "bu-2-0-mini-preview" | "gpt-4.1" | "gpt-4.1-mini" | "o4-mini" | "o3" | "gpt-5.5" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna" | "gemini-2.5-flash" | "gemini-2.5-pro" | "gemini-3-pro-preview" | "gemini-3.1-pro-preview" | "gemini-3-flash-preview" | "gemini-3.5-flash" | "gemini-flash-latest" | "gemini-flash-lite-latest" | "claude-sonnet-4-20250514" | "claude-sonnet-4-5-20250929" | "claude-sonnet-5" | "claude-opus-4-5-20251101" | "claude-opus-4-7" | "claude-opus-4-8" | "claude-opus-5" | "glm-5.2" | "minimax-m3" | "llama-4-maverick-17b-128e-instruct" | "claude-3-7-sonnet-20250219";
+        SupportedLLMs: "browser-use-llm" | "browser-use-2.0" | "bu-2-0-mini-preview" | "gpt-4.1" | "gpt-4.1-mini" | "o4-mini" | "o3" | "gpt-5.5" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna" | "gemini-2.5-flash" | "gemini-2.5-pro" | "gemini-3-pro-preview" | "gemini-3.1-pro-preview" | "gemini-3-flash-preview" | "gemini-3.5-flash" | "gemini-flash-latest" | "gemini-flash-lite-latest" | "claude-sonnet-4-20250514" | "claude-sonnet-4-5-20250929" | "claude-sonnet-5" | "claude-opus-4-5-20251101" | "claude-opus-4-7" | "claude-opus-4-8" | "claude-opus-5" | "glm-5.2" | "minimax-m3" | "grok-4.6" | "glm-5.3-flash" | "deepseek-v4-flash-vision" | "llama-4-maverick-17b-128e-instruct" | "claude-3-7-sonnet-20250219";
         /**
          * TaskCreatedResponse
          * @description Response model for creating a task

--- a/browser-use-node/src/generated/v2/types.ts
+++ b/browser-use-node/src/generated/v2/types.ts
@@ -1320,7 +1320,7 @@ export interface components {
             thinking: boolean;
             /**
              * Thinking Level
-             * @description Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected. API V2 cannot configure GLM or fixed-budget Claude thinking; use API V3 or V4 for those combinations.
+             * @description Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level for Gemini 3 Flash and 3.5 Flash, and to a zero thinking budget for Gemini 2.5 Flash and the gemini-flash-latest variants); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected. API V2 cannot configure GLM or fixed-budget Claude thinking; use API V3 or V4 for those combinations.
              */
             thinkingLevel?: components["schemas"]["ThinkingLevel"] | null;
             /**

--- a/browser-use-node/src/generated/v3/types.ts
+++ b/browser-use-node/src/generated/v3/types.ts
@@ -781,6 +781,9 @@ export interface components {
          *     - `gpt-5.4-mini`: GPT-5.4 mini — OpenAI's fast and efficient model. Best for tasks that benefit from OpenAI's capabilities.
          *     - `glm-5.2`: Z.ai GLM 5.2 — capable, low-cost open model. Best for cost-sensitive agentic tasks.
          *     - `minimax-m3`: MiniMax M3 — fast, very low-cost model. Best for simple, high-volume tasks.
+         *     - `grok-4.6`: xAI Grok 4.6. Fast frontier model with a large context window.
+         *     - `glm-5.3-flash`: Z.ai GLM 5.3 Flash. Multimodal, very low cost, served by Fireworks.
+         *     - `deepseek-v4-flash-vision`: DeepSeek V4 Flash Vision. Experimental, very low cost.
          *
          *     Additional provider models (e.g. `gemini-3.5-flash`, `gpt-5.2`, and `gpt-5-mini`)
          *     are selectable only with `use_own_key=true`, where your own provider key serves
@@ -789,7 +792,7 @@ export interface components {
          *     Bedrock rollout.
          * @enum {string}
          */
-        BuModel: "bu-mini" | "bu-max" | "bu-ultra" | "gemini-3-flash" | "claude-opus-4.6" | "claude-opus-4.7" | "claude-sonnet-5" | "claude-opus-4.8" | "gpt-5.4-mini" | "glm-5.2" | "minimax-m3" | "claude-haiku-4.5" | "gpt-5.2" | "gpt-5-mini" | "gpt-5.5" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna" | "gemini-3-pro" | "gemini-3.1-pro" | "gemini-3.5-flash";
+        BuModel: "bu-mini" | "bu-max" | "bu-ultra" | "gemini-3-flash" | "claude-opus-4.6" | "claude-opus-4.7" | "claude-sonnet-5" | "claude-opus-4.8" | "gpt-5.4-mini" | "glm-5.2" | "minimax-m3" | "grok-4.6" | "glm-5.3-flash" | "deepseek-v4-flash-vision" | "claude-haiku-4.5" | "gpt-5.2" | "gpt-5-mini" | "gpt-5.5" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna" | "gemini-3-pro" | "gemini-3.1-pro" | "gemini-3.5-flash";
         /**
          * CreateBrowserSessionRequest
          * @description Request model for creating a browser session.
@@ -835,6 +838,18 @@ export interface components {
              * @default false
              */
             allowResizing: boolean;
+            /**
+             * PDF Renderer Enabled
+             * @description Whether Chrome renders PDFs in a tab. Set to false to stop the in-tab render; the file is saved to the session's download directory either way.
+             * @default true
+             */
+            pdfRendererEnabled: boolean;
+            /**
+             * Solve Captchas
+             * @description Whether the browser detects and solves CAPTCHAs on its own. Set to false to handle CAPTCHAs yourself. Defaults to true.
+             * @default true
+             */
+            solveCaptchas: boolean;
             /**
              * Custom Proxy
              * @description Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription.

--- a/browser-use-node/src/generated/v3/types.ts
+++ b/browser-use-node/src/generated/v3/types.ts
@@ -1264,7 +1264,7 @@ export interface components {
              * @default claude-opus-4.7
              */
             model: components["schemas"]["BuModel"];
-            /** @description Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected. */
+            /** @description Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level for Gemini 3 Flash and 3.5 Flash, and to a zero thinking budget for Gemini 2.5 Flash and the gemini-flash-latest variants); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected. */
             thinkingLevel?: components["schemas"]["ThinkingLevel"] | null;
             /**
              * Sessionid

--- a/browser-use-node/src/generated/v4/types.ts
+++ b/browser-use-node/src/generated/v4/types.ts
@@ -844,6 +844,18 @@ export interface components {
              */
             allowResizing: boolean;
             /**
+             * PDF Renderer Enabled
+             * @description Whether Chrome renders PDFs in a tab. Set to false to stop the in-tab render; the file is saved to the session's download directory either way.
+             * @default true
+             */
+            pdfRendererEnabled: boolean;
+            /**
+             * Solve Captchas
+             * @description Whether the browser detects and solves CAPTCHAs on its own. Set to false to handle CAPTCHAs yourself. Defaults to true.
+             * @default true
+             */
+            solveCaptchas: boolean;
+            /**
              * Custom Proxy
              * @description Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription.
              */
@@ -919,8 +931,8 @@ export interface components {
          */
         InlineSecretSource: {
             /**
-             * Type
-             * @constant
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
              */
             type: "inline";
             /**
@@ -940,6 +952,39 @@ export interface components {
              * @default Insufficient credits
              */
             detail: string;
+        };
+        /**
+         * OnePasswordSecretSource
+         * @description One field of a 1Password item, resolved only when the agent asks for it.
+         *
+         *     Nothing here is a secret: the quadruple NAMES a credential without carrying
+         *     it. Creating the binding makes no call to 1Password — a provider outage must
+         *     not stop a run from being dispatched, and no vault is ever enumerated.
+         *
+         *     A one-time-password field resolves to its current code; its seed is never
+         *     read, so there is no flag to ask for one.
+         */
+        OnePasswordSecretSource: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "onepassword";
+            /**
+             * Integrationid
+             * Format: uuid
+             * @description 1Password integration to resolve through. Must belong to this project.
+             */
+            integrationId: string;
+            /** Vaultid */
+            vaultId: string;
+            /** Itemid */
+            itemId: string;
+            /**
+             * Fieldid
+             * @description Field id from the item-fields endpoint, e.g. "password".
+             */
+            fieldId: string;
         };
         /**
          * ProfileCreateRequest
@@ -1200,7 +1245,7 @@ export interface components {
              * @default gpt-5.6-luna
              * @enum {string}
              */
-            model: "glm-5.2" | "grok-4.5" | "kimi-k3" | "minimax-m3" | "claude-opus-4.7" | "claude-opus-4.8" | "claude-opus-5" | "claude-fable-5" | "claude-sonnet-5" | "gpt-5.5" | "gpt-5.6" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna" | "gemini-3.6-flash" | "gemini-3.5-flash" | "gemini-3.1-pro" | "gemini-3-flash";
+            model: "glm-5.2" | "grok-4.5" | "grok-4.6" | "glm-5.3-flash" | "deepseek-v4-flash-vision" | "kimi-k3" | "minimax-m3" | "claude-opus-4.7" | "claude-opus-4.8" | "claude-opus-5" | "claude-fable-5" | "claude-sonnet-5" | "gpt-5.5" | "gpt-5.6" | "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna" | "gemini-3.6-flash" | "gemini-3.5-flash" | "gemini-3.1-pro" | "gemini-3-flash";
             /**
              * Modelparams
              * @description Optional provider-native request parameters for the selected model, written with the provider's own field names and values and forwarded unchanged (e.g. {"reasoning": {"effort": "high"}} for OpenAI, {"thinking": {"type": "adaptive"}} for Anthropic, {"thinkingConfig": {"thinkingLevel": "high"}} for Google). Supported paths and values are per-model; an unsupported path, value, or a model that accepts no parameters at all is rejected with 422. Omitting this field applies the model's default parameters (gpt-5.6-luna defaults to {"reasoning": {"effort": "xhigh"}}); passing {} opts out of that default and leaves the provider's own defaults in place.
@@ -1401,7 +1446,8 @@ export interface components {
              * @description Name the agent refers to this secret by, e.g. "github_password".
              */
             alias: string;
-            source: components["schemas"]["InlineSecretSource"];
+            /** Source */
+            source: components["schemas"]["InlineSecretSource"] | components["schemas"]["OnePasswordSecretSource"];
             /**
              * Alloweddomains
              * @description Hosts the secret may be typed into, e.g. ["github.com"]. A host covers its subdomains. Bare hostnames only — no scheme, port, path, or wildcard.
@@ -2241,7 +2287,9 @@ export interface operations {
     queue_session_message_sessions__session_id__queue_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "X-V4-Queue-Deduplicate"?: string | null;
+            };
             path: {
                 session_id: string;
             };

--- a/browser-use-node/src/v4.ts
+++ b/browser-use-node/src/v4.ts
@@ -15,7 +15,7 @@ export type {
 } from "./v4/resources/runs.js";
 
 export { Sessions } from "./v4/resources/sessions.js";
-export type { SessionListParams } from "./v4/resources/sessions.js";
+export type { SendMessageOptions, SessionListParams } from "./v4/resources/sessions.js";
 
 export { Workspaces } from "./v4/resources/workspaces.js";
 export type { WorkspaceFilesParams } from "./v4/resources/workspaces.js";

--- a/browser-use-node/src/v4.ts
+++ b/browser-use-node/src/v4.ts
@@ -39,6 +39,7 @@ export type RunAttachmentsResponse = S["RunAttachmentsResponse"];
 export type RunBrowserSettings = S["RunBrowserSettings"];
 export type RunJudgeSettings = S["RunJudgeSettings"];
 export type InlineSecretSource = S["InlineSecretSource"];
+export type OnePasswordSecretSource = S["OnePasswordSecretSource"];
 export type SecretBinding = S["SecretBinding"];
 
 // Session models

--- a/browser-use-node/src/v4/resources/sessions.ts
+++ b/browser-use-node/src/v4/resources/sessions.ts
@@ -12,6 +12,11 @@ export interface SessionListParams {
   limit?: number;
 }
 
+export interface SendMessageOptions {
+  /** Optional server-side deduplication strategy, such as `exact-text-v1`. */
+  deduplicate?: string | null;
+}
+
 export class Sessions {
   constructor(private readonly http: HttpClient) {}
 
@@ -35,7 +40,19 @@ export class Sessions {
    * busy; set `interrupt: true` to cancel the active run so the message runs
    * immediately.
    */
-  sendMessage(sessionId: string, body: QueueMessageRequest): Promise<QueuedMessage> {
+  sendMessage(
+    sessionId: string,
+    body: QueueMessageRequest,
+    options?: SendMessageOptions,
+  ): Promise<QueuedMessage> {
+    if (options?.deduplicate != null) {
+      return this.http.post<QueuedMessage>(
+        `/sessions/${sessionId}/queue`,
+        body,
+        undefined,
+        { "X-V4-Queue-Deduplicate": options.deduplicate },
+      );
+    }
     return this.http.post<QueuedMessage>(`/sessions/${sessionId}/queue`, body);
   }
 

--- a/browser-use-node/tests/browsers.test.ts
+++ b/browser-use-node/tests/browsers.test.ts
@@ -14,11 +14,17 @@ describe.each([
     };
     const browsers = new Browsers(http as any);
 
-    await browsers.create({ metadata: { team: "sdk", env: "test" } });
+    await browsers.create({
+      metadata: { team: "sdk", env: "test" },
+      pdfRendererEnabled: false,
+      solveCaptchas: false,
+    });
     await browsers.list({ metadata: ["team", "env=test"] });
 
     expect(http.post).toHaveBeenCalledWith("/browsers", {
       metadata: { team: "sdk", env: "test" },
+      pdfRendererEnabled: false,
+      solveCaptchas: false,
     });
     expect(http.get).toHaveBeenCalledWith("/browsers", {
       metadata: ["team", "env=test"],

--- a/browser-use-node/tests/http.test.ts
+++ b/browser-use-node/tests/http.test.ts
@@ -26,4 +26,29 @@ describe("HttpClient query serialization", () => {
     expect(url.searchParams.getAll("metadata")).toEqual(["team", "env=prod"]);
     expect(url.searchParams.get("pageSize")).toBe("10");
   });
+
+  it("forwards per-request headers alongside authentication", async () => {
+    let requestedHeaders = new Headers();
+    const http = new HttpClient({
+      apiKey: "test",
+      baseUrl: "https://api.example.com",
+      fetch: async (_input, init) => {
+        requestedHeaders = new Headers(init?.headers);
+        return new Response("{}", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    });
+
+    await http.post(
+      "/sessions/id/queue",
+      { text: "hello" },
+      undefined,
+      { "X-V4-Queue-Deduplicate": "exact-text-v1" },
+    );
+
+    expect(requestedHeaders.get("X-V4-Queue-Deduplicate")).toBe("exact-text-v1");
+    expect(requestedHeaders.get("X-Browser-Use-API-Key")).toBe("test");
+  });
 });

--- a/browser-use-node/tests/v4.test.ts
+++ b/browser-use-node/tests/v4.test.ts
@@ -48,10 +48,16 @@ describe("v4 browsers", () => {
     const http = { post: vi.fn(async () => active) };
     const browsers = new Browsers(http as any);
 
-    const browser = await browsers.create({ proxyCountryCode: "us" });
+    const browser = await browsers.create({
+      proxyCountryCode: "us",
+      pdfRendererEnabled: false,
+      solveCaptchas: false,
+    });
 
     expect(http.post).toHaveBeenCalledWith("/browsers", {
       proxyCountryCode: "us",
+      pdfRendererEnabled: false,
+      solveCaptchas: false,
     });
     expect(browser.cdpUrl).toContain("devtools/browser/test");
   });
@@ -182,6 +188,17 @@ describe("v4 runs pagination + events", () => {
           source: { type: "inline", value: "not-masked" },
           allowedDomains: ["github.com"],
         },
+        {
+          alias: "onepassword_github_password",
+          source: {
+            type: "onepassword",
+            integrationId: "00000000-0000-0000-0000-000000000004",
+            vaultId: "vault-id",
+            itemId: "item-id",
+            fieldId: "password",
+          },
+          allowedDomains: ["github.com"],
+        },
       ],
     });
 
@@ -192,6 +209,17 @@ describe("v4 runs pagination + events", () => {
         {
           alias: "github_password",
           source: { type: "inline", value: "not-masked" },
+          allowedDomains: ["github.com"],
+        },
+        {
+          alias: "onepassword_github_password",
+          source: {
+            type: "onepassword",
+            integrationId: "00000000-0000-0000-0000-000000000004",
+            vaultId: "vault-id",
+            itemId: "item-id",
+            fieldId: "password",
+          },
           allowedDomains: ["github.com"],
         },
       ],

--- a/browser-use-node/tests/v4.test.ts
+++ b/browser-use-node/tests/v4.test.ts
@@ -306,6 +306,26 @@ describe("v4 sessions queue", () => {
     expect(msg.status).toBe("pending");
   });
 
+  it("can request server-side queue deduplication", async () => {
+    const http = {
+      post: vi.fn(async () => queuedMessage),
+    };
+    const sessions = new Sessions(http as any);
+
+    await sessions.sendMessage(
+      SESSION_ID,
+      { text: "also check the careers page" },
+      { deduplicate: "exact-text-v1" },
+    );
+
+    expect(http.post).toHaveBeenCalledWith(
+      `/sessions/${SESSION_ID}/queue`,
+      { text: "also check the careers page" },
+      undefined,
+      { "X-V4-Queue-Deduplicate": "exact-text-v1" },
+    );
+  });
+
   it("lists pending queued messages", async () => {
     const http = {
       get: vi.fn(async () => ({ queue: [queuedMessage] })),

--- a/browser-use-python/pyproject.toml
+++ b/browser-use-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "browser-use-sdk"
-version = "3.11.2"
+version = "3.11.3"
 description = "Python SDK for the Browser Use cloud API"
 readme = "README.md"
 license = "MIT"

--- a/browser-use-python/src/browser_use_sdk/_core/http.py
+++ b/browser-use-python/src/browser_use_sdk/_core/http.py
@@ -84,6 +84,7 @@ class SyncHttpClient:
         *,
         json: Any = None,
         params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Any:
         json = _clean_json(json) if json is not None else None
         cleaned_params = _clean_params(params)
@@ -91,7 +92,7 @@ class SyncHttpClient:
             if attempt > 0:
                 time.sleep(min(_BACKOFF_BASE * (2 ** attempt), 10))
             response = self._client.request(
-                method, path, json=json, params=cleaned_params
+                method, path, json=json, params=cleaned_params, headers=headers
             )
 
             if _should_retry(response.status_code) and attempt < self._max_retries:
@@ -147,6 +148,7 @@ class AsyncHttpClient:
         *,
         json: Any = None,
         params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Any:
         json = _clean_json(json) if json is not None else None
         cleaned_params = _clean_params(params)
@@ -154,7 +156,7 @@ class AsyncHttpClient:
             if attempt > 0:
                 await asyncio.sleep(min(_BACKOFF_BASE * (2 ** attempt), 10))
             response = await self._client.request(
-                method, path, json=json, params=cleaned_params
+                method, path, json=json, params=cleaned_params, headers=headers
             )
 
             if _should_retry(response.status_code) and attempt < self._max_retries:

--- a/browser-use-python/src/browser_use_sdk/generated/v2/models.py
+++ b/browser-use-python/src/browser_use_sdk/generated/v2/models.py
@@ -965,6 +965,9 @@ class SupportedLLMs(Enum):
     claude_opus_5 = 'claude-opus-5'
     glm_5_2 = 'glm-5.2'
     minimax_m3 = 'minimax-m3'
+    grok_4_6 = 'grok-4.6'
+    glm_5_3_flash = 'glm-5.3-flash'
+    deepseek_v4_flash_vision = 'deepseek-v4-flash-vision'
     llama_4_maverick_17b_128e_instruct = 'llama-4-maverick-17b-128e-instruct'
     claude_3_7_sonnet_20250219 = 'claude-3-7-sonnet-20250219'
 
@@ -1535,6 +1538,18 @@ class CreateBrowserSessionRequest(BaseModel):
         description='Whether to allow the browser to be resized during the session (not recommended since it reduces stealthiness).',
         title='Allow Resizing',
     )
+    pdf_renderer_enabled: bool | None = Field(
+        True,
+        alias='pdfRendererEnabled',
+        description="Whether Chrome renders PDFs in a tab. Set to false to stop the in-tab render; the file is saved to the session's download directory either way.",
+        title='PDF Renderer Enabled',
+    )
+    solve_captchas: bool | None = Field(
+        True,
+        alias='solveCaptchas',
+        description='Whether the browser detects and solves CAPTCHAs on its own. Set to false to handle CAPTCHAs yourself. Defaults to true.',
+        title='Solve Captchas',
+    )
     custom_proxy: CustomProxy | None = Field(
         None,
         alias='customProxy',
@@ -1691,7 +1706,7 @@ class CreateTaskRequest(BaseModel):
     thinking_level: ThinkingLevel | None = Field(
         None,
         alias='thinkingLevel',
-        description="Optional model reasoning depth. Omit this field to preserve the provider default. API V2 accepts disabled/low/medium/high for browser-use-llm, browser-use-2.0, gemini-2.5-flash, gemini-3-flash-preview, gemini-3.5-flash, gemini-flash-latest, gemini-flash-lite-latest, gpt-5.5, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, claude-sonnet-5, claude-opus-4-7, claude-opus-4-8, and claude-opus-5; low/medium/high for gemini-2.5-pro, o3, and o4-mini; low/high for gemini-3-pro-preview and gemini-3.1-pro-preview; and disabled only for claude-sonnet-4-20250514, claude-sonnet-4-5-20250929, and claude-opus-4-5-20251101. For browser-use-llm, browser-use-2.0, Gemini 3 Flash, and Gemini 3.5 Flash, disabled maps to Google's minimal thinking level. For Gemini 2.5 Flash and the gemini-flash-latest variants, disabled maps to a zero thinking budget. bu-2-0-mini-preview does not support configurable thinking, so omit thinkingLevel for that model. Other V2 models reject an explicit level. API V2 cannot configure GLM thinking or enable fixed-budget Claude thinking; use API V3 or V4 for those combinations.",
+        description="Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected. API V2 cannot configure GLM or fixed-budget Claude thinking; use API V3 or V4 for those combinations.",
         title='Thinking Level',
     )
     vision: bool | str | None = Field(

--- a/browser-use-python/src/browser_use_sdk/generated/v2/models.py
+++ b/browser-use-python/src/browser_use_sdk/generated/v2/models.py
@@ -1706,7 +1706,7 @@ class CreateTaskRequest(BaseModel):
     thinking_level: ThinkingLevel | None = Field(
         None,
         alias='thinkingLevel',
-        description="Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected. API V2 cannot configure GLM or fixed-budget Claude thinking; use API V3 or V4 for those combinations.",
+        description="Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level for Gemini 3 Flash and 3.5 Flash, and to a zero thinking budget for Gemini 2.5 Flash and the gemini-flash-latest variants); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected. API V2 cannot configure GLM or fixed-budget Claude thinking; use API V3 or V4 for those combinations.",
         title='Thinking Level',
     )
     vision: bool | str | None = Field(

--- a/browser-use-python/src/browser_use_sdk/generated/v3/models.py
+++ b/browser-use-python/src/browser_use_sdk/generated/v3/models.py
@@ -168,6 +168,9 @@ class BuModel(Enum):
     gpt_5_4_mini = 'gpt-5.4-mini'
     glm_5_2 = 'glm-5.2'
     minimax_m3 = 'minimax-m3'
+    grok_4_6 = 'grok-4.6'
+    glm_5_3_flash = 'glm-5.3-flash'
+    deepseek_v4_flash_vision = 'deepseek-v4-flash-vision'
     claude_haiku_4_5 = 'claude-haiku-4.5'
     gpt_5_2 = 'gpt-5.2'
     gpt_5_mini = 'gpt-5-mini'
@@ -1102,6 +1105,18 @@ class CreateBrowserSessionRequest(BaseModel):
         alias='allowResizing',
         description='Whether to allow the browser to be resized during the session (not recommended since it reduces stealthiness).',
         title='Allow Resizing',
+    )
+    pdf_renderer_enabled: bool | None = Field(
+        True,
+        alias='pdfRendererEnabled',
+        description="Whether Chrome renders PDFs in a tab. Set to false to stop the in-tab render; the file is saved to the session's download directory either way.",
+        title='PDF Renderer Enabled',
+    )
+    solve_captchas: bool | None = Field(
+        True,
+        alias='solveCaptchas',
+        description='Whether the browser detects and solves CAPTCHAs on its own. Set to false to handle CAPTCHAs yourself. Defaults to true.',
+        title='Solve Captchas',
     )
     custom_proxy: CustomProxy | None = Field(
         None,

--- a/browser-use-python/src/browser_use_sdk/generated/v3/models.py
+++ b/browser-use-python/src/browser_use_sdk/generated/v3/models.py
@@ -1183,7 +1183,7 @@ class RunTaskRequest(BaseModel):
     thinking_level: ThinkingLevel | None = Field(
         None,
         alias='thinkingLevel',
-        description="Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected.",
+        description="Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level for Gemini 3 Flash and 3.5 Flash, and to a zero thinking budget for Gemini 2.5 Flash and the gemini-flash-latest variants); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected.",
     )
     session_id: UUID | None = Field(
         None,

--- a/browser-use-python/src/browser_use_sdk/generated/v4/models.py
+++ b/browser-use-python/src/browser_use_sdk/generated/v4/models.py
@@ -239,6 +239,33 @@ class InsufficientCreditsError(BaseModel):
     detail: str | None = Field('Insufficient credits', title='Detail')
 
 
+class OnePasswordSecretSource(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    type: Literal['onepassword'] = Field(..., title='Type')
+    integration_id: UUID = Field(
+        ...,
+        alias='integrationId',
+        description='1Password integration to resolve through. Must belong to this project.',
+        title='Integrationid',
+    )
+    vault_id: str = Field(
+        ..., alias='vaultId', max_length=64, min_length=1, title='Vaultid'
+    )
+    item_id: str = Field(
+        ..., alias='itemId', max_length=64, min_length=1, title='Itemid'
+    )
+    field_id: str = Field(
+        ...,
+        alias='fieldId',
+        description='Field id from the item-fields endpoint, e.g. "password".',
+        max_length=64,
+        min_length=1,
+        title='Fieldid',
+    )
+
+
 class Name(RootModel[str]):
     root: str = Field(
         ..., description='Optional name for the profile', max_length=100, title='Name'
@@ -693,6 +720,9 @@ class RunBrowserSettings(BaseModel):
 class Model(Enum):
     glm_5_2 = 'glm-5.2'
     grok_4_5 = 'grok-4.5'
+    grok_4_6 = 'grok-4.6'
+    glm_5_3_flash = 'glm-5.3-flash'
+    deepseek_v4_flash_vision = 'deepseek-v4-flash-vision'
     kimi_k3 = 'kimi-k3'
     minimax_m3 = 'minimax-m3'
     claude_opus_4_7 = 'claude-opus-4.7'
@@ -809,7 +839,9 @@ class SecretBinding(BaseModel):
         description='Name the agent refers to this secret by, e.g. "github_password".',
         title='Alias',
     )
-    source: InlineSecretSource
+    source: InlineSecretSource | OnePasswordSecretSource = Field(
+        ..., discriminator='type', title='Source'
+    )
     allowed_domains: List[str] = Field(
         ...,
         alias='allowedDomains',
@@ -1137,6 +1169,18 @@ class CreateBrowserSessionRequest(BaseModel):
         alias='allowResizing',
         description='Whether to allow the browser to be resized during the session (not recommended since it reduces stealthiness).',
         title='Allow Resizing',
+    )
+    pdf_renderer_enabled: bool | None = Field(
+        True,
+        alias='pdfRendererEnabled',
+        description="Whether Chrome renders PDFs in a tab. Set to false to stop the in-tab render; the file is saved to the session's download directory either way.",
+        title='PDF Renderer Enabled',
+    )
+    solve_captchas: bool | None = Field(
+        True,
+        alias='solveCaptchas',
+        description='Whether the browser detects and solves CAPTCHAs on its own. Set to false to handle CAPTCHAs yourself. Defaults to true.',
+        title='Solve Captchas',
     )
     custom_proxy: CustomProxy | None = Field(
         None,

--- a/browser-use-python/src/browser_use_sdk/v2/resources/browsers.py
+++ b/browser-use-python/src/browser_use_sdk/v2/resources/browsers.py
@@ -23,6 +23,8 @@ def _build_create_body(
     browser_screen_width: int | None = None,
     browser_screen_height: int | None = None,
     allow_resizing: bool | None = None,
+    pdf_renderer_enabled: bool | None = None,
+    solve_captchas: bool | None = None,
     custom_proxy: CustomProxy | None = None,
     enable_recording: bool | None = None,
     **extra: Any,
@@ -45,6 +47,10 @@ def _build_create_body(
         body["browserScreenHeight"] = browser_screen_height
     if allow_resizing is not None:
         body["allowResizing"] = allow_resizing
+    if pdf_renderer_enabled is not None:
+        body["pdfRendererEnabled"] = pdf_renderer_enabled
+    if solve_captchas is not None:
+        body["solveCaptchas"] = solve_captchas
     if custom_proxy is not None:
         body["customProxy"] = custom_proxy.model_dump(by_alias=True, exclude_none=True)
     if enable_recording is not None:
@@ -67,6 +73,8 @@ class Browsers:
         browser_screen_width: int | None = None,
         browser_screen_height: int | None = None,
         allow_resizing: bool | None = None,
+        pdf_renderer_enabled: bool | None = None,
+        solve_captchas: bool | None = None,
         custom_proxy: CustomProxy | None = None,
         enable_recording: bool | None = None,
         **extra: Any,
@@ -80,6 +88,8 @@ class Browsers:
             browser_screen_width=browser_screen_width,
             browser_screen_height=browser_screen_height,
             allow_resizing=allow_resizing,
+            pdf_renderer_enabled=pdf_renderer_enabled,
+            solve_captchas=solve_captchas,
             custom_proxy=custom_proxy,
             enable_recording=enable_recording,
             **extra,
@@ -165,6 +175,8 @@ class AsyncBrowsers:
         browser_screen_width: int | None = None,
         browser_screen_height: int | None = None,
         allow_resizing: bool | None = None,
+        pdf_renderer_enabled: bool | None = None,
+        solve_captchas: bool | None = None,
         custom_proxy: CustomProxy | None = None,
         enable_recording: bool | None = None,
         **extra: Any,
@@ -178,6 +190,8 @@ class AsyncBrowsers:
             browser_screen_width=browser_screen_width,
             browser_screen_height=browser_screen_height,
             allow_resizing=allow_resizing,
+            pdf_renderer_enabled=pdf_renderer_enabled,
+            solve_captchas=solve_captchas,
             custom_proxy=custom_proxy,
             enable_recording=enable_recording,
             **extra,

--- a/browser-use-python/src/browser_use_sdk/v3/resources/browsers.py
+++ b/browser-use-python/src/browser_use_sdk/v3/resources/browsers.py
@@ -35,6 +35,8 @@ class Browsers:
         browser_screen_width: int | None = None,
         browser_screen_height: int | None = None,
         allow_resizing: bool | None = None,
+        pdf_renderer_enabled: bool | None = None,
+        solve_captchas: bool | None = None,
         custom_proxy: CustomProxy | None = None,
         enable_recording: bool | None = None,
         **extra: Any,
@@ -56,6 +58,10 @@ class Browsers:
             body["browserScreenHeight"] = browser_screen_height
         if allow_resizing is not None:
             body["allowResizing"] = allow_resizing
+        if pdf_renderer_enabled is not None:
+            body["pdfRendererEnabled"] = pdf_renderer_enabled
+        if solve_captchas is not None:
+            body["solveCaptchas"] = solve_captchas
         if custom_proxy is not None:
             body["customProxy"] = custom_proxy.model_dump(
                 by_alias=True, exclude_none=True
@@ -145,6 +151,8 @@ class AsyncBrowsers:
         browser_screen_width: int | None = None,
         browser_screen_height: int | None = None,
         allow_resizing: bool | None = None,
+        pdf_renderer_enabled: bool | None = None,
+        solve_captchas: bool | None = None,
         custom_proxy: CustomProxy | None = None,
         enable_recording: bool | None = None,
         **extra: Any,
@@ -166,6 +174,10 @@ class AsyncBrowsers:
             body["browserScreenHeight"] = browser_screen_height
         if allow_resizing is not None:
             body["allowResizing"] = allow_resizing
+        if pdf_renderer_enabled is not None:
+            body["pdfRendererEnabled"] = pdf_renderer_enabled
+        if solve_captchas is not None:
+            body["solveCaptchas"] = solve_captchas
         if custom_proxy is not None:
             body["customProxy"] = custom_proxy.model_dump(
                 by_alias=True, exclude_none=True

--- a/browser-use-python/src/browser_use_sdk/v4/__init__.py
+++ b/browser-use-python/src/browser_use_sdk/v4/__init__.py
@@ -8,6 +8,7 @@ from ..generated.v4.models import (
     CustomProxy,
     InlineSecretSource,
     Model as RunModel,
+    OnePasswordSecretSource,
     ProxyCountryCode,
     QueuedMessage,
     QueueListResponse,
@@ -60,6 +61,7 @@ __all__ = [
     "RunBrowserSettings",
     "RunJudgeSettings",
     "InlineSecretSource",
+    "OnePasswordSecretSource",
     "SecretBinding",
     "SecretBindings",
     # Session models

--- a/browser-use-python/src/browser_use_sdk/v4/resources/browsers.py
+++ b/browser-use-python/src/browser_use_sdk/v4/resources/browsers.py
@@ -23,6 +23,8 @@ def _build_create_body(
     browser_screen_width: int | None = None,
     browser_screen_height: int | None = None,
     allow_resizing: bool | None = None,
+    pdf_renderer_enabled: bool | None = None,
+    solve_captchas: bool | None = None,
     custom_proxy: CustomProxy | None = None,
     enable_recording: bool | None = None,
     **extra: Any,
@@ -49,6 +51,10 @@ def _build_create_body(
         body["browserScreenHeight"] = browser_screen_height
     if allow_resizing is not None:
         body["allowResizing"] = allow_resizing
+    if pdf_renderer_enabled is not None:
+        body["pdfRendererEnabled"] = pdf_renderer_enabled
+    if solve_captchas is not None:
+        body["solveCaptchas"] = solve_captchas
     if custom_proxy is not None:
         body["customProxy"] = custom_proxy.model_dump(by_alias=True, exclude_none=True)
     if enable_recording is not None:
@@ -71,6 +77,8 @@ class Browsers:
         browser_screen_width: int | None = None,
         browser_screen_height: int | None = None,
         allow_resizing: bool | None = None,
+        pdf_renderer_enabled: bool | None = None,
+        solve_captchas: bool | None = None,
         custom_proxy: CustomProxy | None = None,
         enable_recording: bool | None = None,
         **extra: Any,
@@ -84,6 +92,8 @@ class Browsers:
             browser_screen_width=browser_screen_width,
             browser_screen_height=browser_screen_height,
             allow_resizing=allow_resizing,
+            pdf_renderer_enabled=pdf_renderer_enabled,
+            solve_captchas=solve_captchas,
             custom_proxy=custom_proxy,
             enable_recording=enable_recording,
             **extra,
@@ -115,6 +125,8 @@ class AsyncBrowsers:
         browser_screen_width: int | None = None,
         browser_screen_height: int | None = None,
         allow_resizing: bool | None = None,
+        pdf_renderer_enabled: bool | None = None,
+        solve_captchas: bool | None = None,
         custom_proxy: CustomProxy | None = None,
         enable_recording: bool | None = None,
         **extra: Any,
@@ -128,6 +140,8 @@ class AsyncBrowsers:
             browser_screen_width=browser_screen_width,
             browser_screen_height=browser_screen_height,
             allow_resizing=allow_resizing,
+            pdf_renderer_enabled=pdf_renderer_enabled,
+            solve_captchas=solve_captchas,
             custom_proxy=custom_proxy,
             enable_recording=enable_recording,
             **extra,

--- a/browser-use-python/src/browser_use_sdk/v4/resources/runs.py
+++ b/browser-use-python/src/browser_use_sdk/v4/resources/runs.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from ..._core.http import AsyncHttpClient, SyncHttpClient
 from ...generated.v4.models import (
+    InlineSecretSource,
     RunAttachmentsResponse,
     RunBrowserSettings,
     RunCreateResponse,
@@ -69,10 +70,16 @@ def _build_create_body(
         body["secretBindings"] = [
             {
                 "alias": binding.alias,
-                "source": {
-                    "type": binding.source.type,
-                    "value": binding.source.value.get_secret_value(),
-                },
+                "source": (
+                    {
+                        "type": binding.source.type,
+                        "value": binding.source.value.get_secret_value(),
+                    }
+                    if isinstance(binding.source, InlineSecretSource)
+                    else binding.source.model_dump(
+                        by_alias=True, exclude_none=True, mode="json"
+                    )
+                ),
                 "allowedDomains": binding.allowed_domains,
             }
             if isinstance(binding, SecretBinding)

--- a/browser-use-python/src/browser_use_sdk/v4/resources/sessions.py
+++ b/browser-use-python/src/browser_use_sdk/v4/resources/sessions.py
@@ -68,19 +68,22 @@ class Sessions:
         *,
         interrupt: bool | None = None,
         attached_file_ids: list[str | UUID] | None = None,
+        deduplicate: str | None = None,
         **extra: Any,
     ) -> QueuedMessage:
         """Send a message to the session.
 
         Runs as the next turn when the session is busy; pass ``interrupt=True``
-        to cancel the active run so the message runs immediately.
+        to cancel the active run so the message runs immediately. Pass
+        ``deduplicate="exact-text-v1"`` to reuse an equivalent queued message.
         """
+        request_kwargs: dict[str, Any] = {
+            "json": _build_message_body(text, interrupt, attached_file_ids, extra)
+        }
+        if deduplicate is not None:
+            request_kwargs["headers"] = {"X-V4-Queue-Deduplicate": deduplicate}
         return QueuedMessage.model_validate(
-            self._http.request(
-                "POST",
-                f"/sessions/{session_id}/queue",
-                json=_build_message_body(text, interrupt, attached_file_ids, extra),
-            )
+            self._http.request("POST", f"/sessions/{session_id}/queue", **request_kwargs)
         )
 
     def queue(self, session_id: str | UUID) -> QueueListResponse:
@@ -141,18 +144,23 @@ class AsyncSessions:
         *,
         interrupt: bool | None = None,
         attached_file_ids: list[str | UUID] | None = None,
+        deduplicate: str | None = None,
         **extra: Any,
     ) -> QueuedMessage:
         """Send a message to the session.
 
         Runs as the next turn when the session is busy; pass ``interrupt=True``
-        to cancel the active run so the message runs immediately.
+        to cancel the active run so the message runs immediately. Pass
+        ``deduplicate="exact-text-v1"`` to reuse an equivalent queued message.
         """
+        request_kwargs: dict[str, Any] = {
+            "json": _build_message_body(text, interrupt, attached_file_ids, extra)
+        }
+        if deduplicate is not None:
+            request_kwargs["headers"] = {"X-V4-Queue-Deduplicate": deduplicate}
         return QueuedMessage.model_validate(
             await self._http.request(
-                "POST",
-                f"/sessions/{session_id}/queue",
-                json=_build_message_body(text, interrupt, attached_file_ids, extra),
+                "POST", f"/sessions/{session_id}/queue", **request_kwargs
             )
         )
 

--- a/browser-use-python/tests/test_browsers.py
+++ b/browser-use-python/tests/test_browsers.py
@@ -39,11 +39,19 @@ def test_browser_metadata_create_and_list(browser_cls: type[Any]) -> None:
     http = FakeHttp()
     browsers = browser_cls(http)
 
-    created = browsers.create(metadata={"team": "sdk", "env": "test"})
+    created = browsers.create(
+        metadata={"team": "sdk", "env": "test"},
+        pdf_renderer_enabled=False,
+        solve_captchas=False,
+    )
     browsers.list(metadata=["team", "env=test"])
 
     assert created.metadata == {"team": "sdk", "env": "test"}
-    assert http.calls[0][2] == {"metadata": {"team": "sdk", "env": "test"}}
+    assert http.calls[0][2] == {
+        "metadata": {"team": "sdk", "env": "test"},
+        "pdfRendererEnabled": False,
+        "solveCaptchas": False,
+    }
     assert http.calls[1][3] == {
         "pageSize": None,
         "pageNumber": None,

--- a/browser-use-python/tests/test_http.py
+++ b/browser-use-python/tests/test_http.py
@@ -1,6 +1,6 @@
 import httpx
 
-from browser_use_sdk._core.http import _clean_params
+from browser_use_sdk._core.http import SyncHttpClient, _clean_params
 
 
 def test_clean_params_repeats_sequence_values() -> None:
@@ -23,3 +23,32 @@ def test_clean_params_repeats_sequence_values() -> None:
         ("pageSize", "10"),
         ("includeUrls", "false"),
     ]
+
+
+def test_request_forwards_headers_alongside_authentication() -> None:
+    requested_headers = httpx.Headers()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal requested_headers
+        requested_headers = request.headers
+        return httpx.Response(200, json={})
+
+    client = SyncHttpClient("https://api.example.com", "test")
+    client._client.close()
+    client._client = httpx.Client(
+        base_url="https://api.example.com",
+        headers={"X-Browser-Use-API-Key": "test"},
+        transport=httpx.MockTransport(handler),
+    )
+    try:
+        client.request(
+            "POST",
+            "/sessions/id/queue",
+            json={"text": "hello"},
+            headers={"X-V4-Queue-Deduplicate": "exact-text-v1"},
+        )
+    finally:
+        client.close()
+
+    assert requested_headers["X-V4-Queue-Deduplicate"] == "exact-text-v1"
+    assert requested_headers["X-Browser-Use-API-Key"] == "test"

--- a/browser-use-python/tests/test_v4.py
+++ b/browser-use-python/tests/test_v4.py
@@ -82,6 +82,7 @@ class FakeSyncHttp:
     def __init__(self, responses: list[dict[str, Any]]) -> None:
         self.responses = list(responses)
         self.calls: list[tuple[str, str, dict[str, Any] | None, dict[str, Any] | None]] = []
+        self.headers: list[dict[str, str] | None] = []
 
     def request(
         self,
@@ -90,8 +91,10 @@ class FakeSyncHttp:
         *,
         json: dict[str, Any] | None = None,
         params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         self.calls.append((method, path, json, params))
+        self.headers.append(headers)
         return self.responses.pop(0)
 
 
@@ -99,6 +102,7 @@ class FakeAsyncHttp:
     def __init__(self, responses: list[dict[str, Any]]) -> None:
         self.responses = list(responses)
         self.calls: list[tuple[str, str, dict[str, Any] | None, dict[str, Any] | None]] = []
+        self.headers: list[dict[str, str] | None] = []
 
     async def request(
         self,
@@ -107,8 +111,10 @@ class FakeAsyncHttp:
         *,
         json: dict[str, Any] | None = None,
         params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         self.calls.append((method, path, json, params))
+        self.headers.append(headers)
         return self.responses.pop(0)
 
 
@@ -522,11 +528,17 @@ def test_sessions_send_message() -> None:
     http = FakeSyncHttp([_queued_message()])
     sessions = Sessions(http)  # type: ignore[arg-type]
 
-    msg = sessions.send_message(SESSION_ID, "also check the careers page", interrupt=True)
+    msg = sessions.send_message(
+        SESSION_ID,
+        "also check the careers page",
+        interrupt=True,
+        deduplicate="exact-text-v1",
+    )
 
     method, path, body, _ = http.calls[0]
     assert (method, path) == ("POST", f"/sessions/{SESSION_ID}/queue")
     assert body == {"text": "also check the careers page", "interrupt": True}
+    assert http.headers[0] == {"X-V4-Queue-Deduplicate": "exact-text-v1"}
     assert msg.status.value == "pending"
 
 

--- a/browser-use-python/tests/test_v4.py
+++ b/browser-use-python/tests/test_v4.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 from typing import Any
+from uuid import UUID
 
 import httpx
 import pytest
+from pydantic import SecretStr
 
-from browser_use_sdk.v4 import InlineSecretSource, SecretBinding
+from browser_use_sdk.v4 import InlineSecretSource, OnePasswordSecretSource, SecretBinding
 from browser_use_sdk.v4.resources.browsers import AsyncBrowsers, Browsers
 from browser_use_sdk.v4.resources.runs import AsyncRuns, Runs
 from browser_use_sdk.v4.resources.sessions import Sessions
@@ -128,12 +130,22 @@ def test_browsers_create() -> None:
     http = FakeSyncHttp([_active_browser()])
     browsers = Browsers(http)  # type: ignore[arg-type]
 
-    browser = browsers.create(proxy_country_code="DE", metadata={"flow": "quickstart"})
+    browser = browsers.create(
+        proxy_country_code="DE",
+        metadata={"flow": "quickstart"},
+        pdf_renderer_enabled=False,
+        solve_captchas=False,
+    )
 
     assert http.calls[0][:3] == (
         "POST",
         "/browsers",
-        {"proxyCountryCode": "de", "metadata": {"flow": "quickstart"}},
+        {
+            "proxyCountryCode": "de",
+            "metadata": {"flow": "quickstart"},
+            "pdfRendererEnabled": False,
+            "solveCaptchas": False,
+        },
     )
     assert browser.cdp_url == "wss://connect.browser-use.com/devtools/browser/test"
 
@@ -367,7 +379,9 @@ def test_runs_create_sends_camel_case_body() -> None:
         secret_bindings=[
             SecretBinding(
                 alias="github_password",
-                source=InlineSecretSource(type="inline", value="not-masked"),
+                source=InlineSecretSource(
+                    type="inline", value=SecretStr("not-masked")
+                ),
                 allowedDomains=["github.com"],
             )
         ],
@@ -394,6 +408,57 @@ def test_runs_create_sends_camel_case_body() -> None:
         "maxCostUsd": "1.50",
     }
     assert str(created.id) == RUN_ID
+
+
+def test_runs_create_serializes_onepassword_binding() -> None:
+    http = FakeSyncHttp(
+        [
+            {
+                "id": RUN_ID,
+                "status": "queued",
+                "model": "gpt-5.6-luna",
+                "sessionId": SESSION_ID,
+                "workspaceId": WORKSPACE_ID,
+                "eventsUrl": f"https://api.browser-use.com/api/v4/runs/{RUN_ID}/events",
+            }
+        ]
+    )
+    runs = Runs(http)  # type: ignore[arg-type]
+    integration_id = "00000000-0000-0000-0000-000000000004"
+
+    runs.create(
+        "Sign in",
+        secret_bindings=[
+            SecretBinding(
+                alias="github_password",
+                source=OnePasswordSecretSource(
+                    type="onepassword",
+                    integrationId=UUID(integration_id),
+                    vaultId="vault-id",
+                    itemId="item-id",
+                    fieldId="password",
+                ),
+                allowedDomains=["github.com"],
+            )
+        ],
+    )
+
+    assert http.calls[0][2] == {
+        "task": "Sign in",
+        "secretBindings": [
+            {
+                "alias": "github_password",
+                "source": {
+                    "type": "onepassword",
+                    "integrationId": integration_id,
+                    "vaultId": "vault-id",
+                    "itemId": "item-id",
+                    "fieldId": "password",
+                },
+                "allowedDomains": ["github.com"],
+            }
+        ],
+    }
 
 
 def test_runs_list_cursor_pagination() -> None:

--- a/browser-use-python/uv.lock
+++ b/browser-use-python/uv.lock
@@ -342,7 +342,7 @@ wheels = [
 
 [[package]]
 name = "browser-use-sdk"
-version = "3.11.2"
+version = "3.11.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/docs/cloud/openapi/v2.json
+++ b/docs/cloud/openapi/v2.json
@@ -3849,7 +3849,6 @@
                                 "additionalProperties": {
                                     "type": "string"
                                 },
-                                "maxProperties": 10,
                                 "type": "object"
                             },
                             {
@@ -3900,6 +3899,18 @@
                         "title": "Allow Resizing",
                         "description": "Whether to allow the browser to be resized during the session (not recommended since it reduces stealthiness).",
                         "default": false
+                    },
+                    "pdfRendererEnabled": {
+                        "type": "boolean",
+                        "title": "PDF Renderer Enabled",
+                        "description": "Whether Chrome renders PDFs in a tab. Set to false to stop the in-tab render; the file is saved to the session's download directory either way.",
+                        "default": true
+                    },
+                    "solveCaptchas": {
+                        "type": "boolean",
+                        "title": "Solve Captchas",
+                        "description": "Whether the browser detects and solves CAPTCHAs on its own. Set to false to handle CAPTCHAs yourself. Defaults to true.",
+                        "default": true
                     },
                     "customProxy": {
                         "anyOf": [
@@ -4249,7 +4260,7 @@
                             }
                         ],
                         "title": "Thinking Level",
-                        "description": "Optional model reasoning depth. Omit this field to preserve the provider default. API V2 accepts disabled/low/medium/high for browser-use-llm, browser-use-2.0, gemini-2.5-flash, gemini-3-flash-preview, gemini-3.5-flash, gemini-flash-latest, gemini-flash-lite-latest, gpt-5.5, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, claude-sonnet-5, claude-opus-4-7, claude-opus-4-8, and claude-opus-5; low/medium/high for gemini-2.5-pro, o3, and o4-mini; low/high for gemini-3-pro-preview and gemini-3.1-pro-preview; and disabled only for claude-sonnet-4-20250514, claude-sonnet-4-5-20250929, and claude-opus-4-5-20251101. For browser-use-llm, browser-use-2.0, Gemini 3 Flash, and Gemini 3.5 Flash, disabled maps to Google's minimal thinking level. For Gemini 2.5 Flash and the gemini-flash-latest variants, disabled maps to a zero thinking budget. bu-2-0-mini-preview does not support configurable thinking, so omit thinkingLevel for that model. Other V2 models reject an explicit level. API V2 cannot configure GLM thinking or enable fixed-budget Claude thinking; use API V3 or V4 for those combinations."
+                        "description": "Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected. API V2 cannot configure GLM or fixed-budget Claude thinking; use API V3 or V4 for those combinations."
                     },
                     "vision": {
                         "anyOf": [
@@ -6298,6 +6309,9 @@
                     "claude-opus-5",
                     "glm-5.2",
                     "minimax-m3",
+                    "grok-4.6",
+                    "glm-5.3-flash",
+                    "deepseek-v4-flash-vision",
                     "llama-4-maverick-17b-128e-instruct",
                     "claude-3-7-sonnet-20250219"
                 ],

--- a/docs/cloud/openapi/v2.json
+++ b/docs/cloud/openapi/v2.json
@@ -4260,7 +4260,7 @@
                             }
                         ],
                         "title": "Thinking Level",
-                        "description": "Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected. API V2 cannot configure GLM or fixed-budget Claude thinking; use API V3 or V4 for those combinations."
+                        "description": "Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level for Gemini 3 Flash and 3.5 Flash, and to a zero thinking budget for Gemini 2.5 Flash and the gemini-flash-latest variants); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected. API V2 cannot configure GLM or fixed-budget Claude thinking; use API V3 or V4 for those combinations."
                     },
                     "vision": {
                         "anyOf": [

--- a/docs/cloud/openapi/v3.json
+++ b/docs/cloud/openapi/v3.json
@@ -2212,6 +2212,9 @@
                     "gpt-5.4-mini",
                     "glm-5.2",
                     "minimax-m3",
+                    "grok-4.6",
+                    "glm-5.3-flash",
+                    "deepseek-v4-flash-vision",
                     "claude-haiku-4.5",
                     "gpt-5.2",
                     "gpt-5-mini",
@@ -2224,7 +2227,7 @@
                     "gemini-3.5-flash"
                 ],
                 "title": "BuModel",
-                "description": "The model to use for the agent. Each model has different capabilities and pricing.\n\n- `bu-mini` / `gemini-3-flash`: Gemini 3 Flash \u2014 fast and cost-effective. Best for simple, well-defined tasks like form filling or data extraction.\n- `bu-max` / `claude-sonnet-4.6` (legacy aliases) / `claude-sonnet-5`: Claude Sonnet 5 \u2014 balanced performance. Best for multi-step workflows that require reasoning and decision-making.\n- `bu-ultra` / `claude-opus-4.6`: Claude Opus 4.6 \u2014 capable general-purpose Opus tier.\n- `claude-opus-4.7`: Claude Opus 4.7 \u2014 most capable. Best for complex tasks that require advanced reasoning, long-horizon planning, or handling ambiguous instructions.\n- `claude-opus-4.8`: Claude Opus 4.8 \u2014 most capable Opus-tier model, state-of-the-art on long-horizon agentic work.\n- `gpt-5.4-mini`: GPT-5.4 mini \u2014 OpenAI's fast and efficient model. Best for tasks that benefit from OpenAI's capabilities.\n- `glm-5.2`: Z.ai GLM 5.2 \u2014 capable, low-cost open model. Best for cost-sensitive agentic tasks.\n- `minimax-m3`: MiniMax M3 \u2014 fast, very low-cost model. Best for simple, high-volume tasks.\n\nAdditional provider models (e.g. `gemini-3.5-flash`, `gpt-5.2`, and `gpt-5-mini`)\nare selectable only with `use_own_key=true`, where your own provider key serves\nthem. The GPT-5.6 family is native when either Browser Use's direct OpenAI key\nor Amazon Bedrock route is configured. GPT-5.5 becomes native only through the\nBedrock rollout."
+                "description": "The model to use for the agent. Each model has different capabilities and pricing.\n\n- `bu-mini` / `gemini-3-flash`: Gemini 3 Flash \u2014 fast and cost-effective. Best for simple, well-defined tasks like form filling or data extraction.\n- `bu-max` / `claude-sonnet-4.6` (legacy aliases) / `claude-sonnet-5`: Claude Sonnet 5 \u2014 balanced performance. Best for multi-step workflows that require reasoning and decision-making.\n- `bu-ultra` / `claude-opus-4.6`: Claude Opus 4.6 \u2014 capable general-purpose Opus tier.\n- `claude-opus-4.7`: Claude Opus 4.7 \u2014 most capable. Best for complex tasks that require advanced reasoning, long-horizon planning, or handling ambiguous instructions.\n- `claude-opus-4.8`: Claude Opus 4.8 \u2014 most capable Opus-tier model, state-of-the-art on long-horizon agentic work.\n- `gpt-5.4-mini`: GPT-5.4 mini \u2014 OpenAI's fast and efficient model. Best for tasks that benefit from OpenAI's capabilities.\n- `glm-5.2`: Z.ai GLM 5.2 \u2014 capable, low-cost open model. Best for cost-sensitive agentic tasks.\n- `minimax-m3`: MiniMax M3 \u2014 fast, very low-cost model. Best for simple, high-volume tasks.\n- `grok-4.6`: xAI Grok 4.6. Fast frontier model with a large context window.\n- `glm-5.3-flash`: Z.ai GLM 5.3 Flash. Multimodal, very low cost, served by Fireworks.\n- `deepseek-v4-flash-vision`: DeepSeek V4 Flash Vision. Experimental, very low cost.\n\nAdditional provider models (e.g. `gemini-3.5-flash`, `gpt-5.2`, and `gpt-5-mini`)\nare selectable only with `use_own_key=true`, where your own provider key serves\nthem. The GPT-5.6 family is native when either Browser Use's direct OpenAI key\nor Amazon Bedrock route is configured. GPT-5.5 becomes native only through the\nBedrock rollout."
             },
             "CreateBrowserSessionRequest": {
                 "properties": {
@@ -2260,7 +2263,6 @@
                                 "additionalProperties": {
                                     "type": "string"
                                 },
-                                "maxProperties": 10,
                                 "type": "object"
                             },
                             {
@@ -2311,6 +2313,18 @@
                         "title": "Allow Resizing",
                         "description": "Whether to allow the browser to be resized during the session (not recommended since it reduces stealthiness).",
                         "default": false
+                    },
+                    "pdfRendererEnabled": {
+                        "type": "boolean",
+                        "title": "PDF Renderer Enabled",
+                        "description": "Whether Chrome renders PDFs in a tab. Set to false to stop the in-tab render; the file is saved to the session's download directory either way.",
+                        "default": true
+                    },
+                    "solveCaptchas": {
+                        "type": "boolean",
+                        "title": "Solve Captchas",
+                        "description": "Whether the browser detects and solves CAPTCHAs on its own. Set to false to handle CAPTCHAs yourself. Defaults to true.",
+                        "default": true
                     },
                     "customProxy": {
                         "anyOf": [

--- a/docs/cloud/openapi/v3.json
+++ b/docs/cloud/openapi/v3.json
@@ -3256,7 +3256,7 @@
                                 "type": "null"
                             }
                         ],
-                        "description": "Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected."
+                        "description": "Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level for Gemini 3 Flash and 3.5 Flash, and to a zero thinking budget for Gemini 2.5 Flash and the gemini-flash-latest variants); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected."
                     },
                     "sessionId": {
                         "anyOf": [

--- a/docs/cloud/openapi/v4.json
+++ b/docs/cloud/openapi/v4.json
@@ -670,6 +670,22 @@
                             "format": "uuid",
                             "title": "Session Id"
                         }
+                    },
+                    {
+                        "name": "X-V4-Queue-Deduplicate",
+                        "in": "header",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "X-V4-Queue-Deduplicate"
+                        }
                     }
                 ],
                 "requestBody": {
@@ -2567,6 +2583,18 @@
                         "description": "Whether to allow the browser to be resized during the session (not recommended since it reduces stealthiness).",
                         "default": false
                     },
+                    "pdfRendererEnabled": {
+                        "type": "boolean",
+                        "title": "PDF Renderer Enabled",
+                        "description": "Whether Chrome renders PDFs in a tab. Set to false to stop the in-tab render; the file is saved to the session's download directory either way.",
+                        "default": true
+                    },
+                    "solveCaptchas": {
+                        "type": "boolean",
+                        "title": "Solve Captchas",
+                        "description": "Whether the browser detects and solves CAPTCHAs on its own. Set to false to handle CAPTCHAs yourself. Defaults to true.",
+                        "default": true
+                    },
                     "customProxy": {
                         "anyOf": [
                             {
@@ -2591,7 +2619,6 @@
                                 "additionalProperties": {
                                     "type": "string"
                                 },
-                                "maxProperties": 10,
                                 "type": "object"
                             },
                             {
@@ -2746,6 +2773,51 @@
                 "type": "object",
                 "title": "InsufficientCreditsError",
                 "description": "Error response when there are insufficient credits"
+            },
+            "OnePasswordSecretSource": {
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "const": "onepassword",
+                        "title": "Type"
+                    },
+                    "integrationId": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Integrationid",
+                        "description": "1Password integration to resolve through. Must belong to this project."
+                    },
+                    "vaultId": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "minLength": 1,
+                        "title": "Vaultid"
+                    },
+                    "itemId": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "minLength": 1,
+                        "title": "Itemid"
+                    },
+                    "fieldId": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "minLength": 1,
+                        "title": "Fieldid",
+                        "description": "Field id from the item-fields endpoint, e.g. \"password\"."
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "type",
+                    "integrationId",
+                    "vaultId",
+                    "itemId",
+                    "fieldId"
+                ],
+                "title": "OnePasswordSecretSource",
+                "description": "One field of a 1Password item, resolved only when the agent asks for it.\n\nNothing here is a secret: the quadruple NAMES a credential without carrying\nit. Creating the binding makes no call to 1Password \u2014 a provider outage must\nnot stop a run from being dispatched, and no vault is ever enumerated.\n\nA one-time-password field resolves to its current code; its seed is never\nread, so there is no flag to ask for one."
             },
             "ProfileCreateRequest": {
                 "properties": {
@@ -3490,6 +3562,9 @@
                         "enum": [
                             "glm-5.2",
                             "grok-4.5",
+                            "grok-4.6",
+                            "glm-5.3-flash",
+                            "deepseek-v4-flash-vision",
                             "kimi-k3",
                             "minimax-m3",
                             "claude-opus-4.7",
@@ -3987,7 +4062,22 @@
                         "description": "Name the agent refers to this secret by, e.g. \"github_password\"."
                     },
                     "source": {
-                        "$ref": "#/components/schemas/InlineSecretSource"
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/InlineSecretSource"
+                            },
+                            {
+                                "$ref": "#/components/schemas/OnePasswordSecretSource"
+                            }
+                        ],
+                        "title": "Source",
+                        "discriminator": {
+                            "propertyName": "type",
+                            "mapping": {
+                                "inline": "#/components/schemas/InlineSecretSource",
+                                "onepassword": "#/components/schemas/OnePasswordSecretSource"
+                            }
+                        }
                     },
                     "allowedDomains": {
                         "items": {

--- a/docs/openapi/v2.json
+++ b/docs/openapi/v2.json
@@ -4260,7 +4260,7 @@
               }
             ],
             "title": "Thinking Level",
-            "description": "Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected. API V2 cannot configure GLM or fixed-budget Claude thinking; use API V3 or V4 for those combinations."
+            "description": "Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level for Gemini 3 Flash and 3.5 Flash, and to a zero thinking budget for Gemini 2.5 Flash and the gemini-flash-latest variants); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected. API V2 cannot configure GLM or fixed-budget Claude thinking; use API V3 or V4 for those combinations."
           },
           "vision": {
             "anyOf": [

--- a/docs/openapi/v2.json
+++ b/docs/openapi/v2.json
@@ -3849,7 +3849,6 @@
                 "additionalProperties": {
                   "type": "string"
                 },
-                "maxProperties": 10,
                 "type": "object"
               },
               {
@@ -3900,6 +3899,18 @@
             "title": "Allow Resizing",
             "description": "Whether to allow the browser to be resized during the session (not recommended since it reduces stealthiness).",
             "default": false
+          },
+          "pdfRendererEnabled": {
+            "type": "boolean",
+            "title": "PDF Renderer Enabled",
+            "description": "Whether Chrome renders PDFs in a tab. Set to false to stop the in-tab render; the file is saved to the session's download directory either way.",
+            "default": true
+          },
+          "solveCaptchas": {
+            "type": "boolean",
+            "title": "Solve Captchas",
+            "description": "Whether the browser detects and solves CAPTCHAs on its own. Set to false to handle CAPTCHAs yourself. Defaults to true.",
+            "default": true
           },
           "customProxy": {
             "anyOf": [
@@ -4249,7 +4260,7 @@
               }
             ],
             "title": "Thinking Level",
-            "description": "Optional model reasoning depth. Omit this field to preserve the provider default. API V2 accepts disabled/low/medium/high for browser-use-llm, browser-use-2.0, gemini-2.5-flash, gemini-3-flash-preview, gemini-3.5-flash, gemini-flash-latest, gemini-flash-lite-latest, gpt-5.5, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, claude-sonnet-5, claude-opus-4-7, claude-opus-4-8, and claude-opus-5; low/medium/high for gemini-2.5-pro, o3, and o4-mini; low/high for gemini-3-pro-preview and gemini-3.1-pro-preview; and disabled only for claude-sonnet-4-20250514, claude-sonnet-4-5-20250929, and claude-opus-4-5-20251101. For browser-use-llm, browser-use-2.0, Gemini 3 Flash, and Gemini 3.5 Flash, disabled maps to Google's minimal thinking level. For Gemini 2.5 Flash and the gemini-flash-latest variants, disabled maps to a zero thinking budget. bu-2-0-mini-preview does not support configurable thinking, so omit thinkingLevel for that model. Other V2 models reject an explicit level. API V2 cannot configure GLM thinking or enable fixed-budget Claude thinking; use API V3 or V4 for those combinations."
+            "description": "Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected. API V2 cannot configure GLM or fixed-budget Claude thinking; use API V3 or V4 for those combinations."
           },
           "vision": {
             "anyOf": [
@@ -6298,6 +6309,9 @@
           "claude-opus-5",
           "glm-5.2",
           "minimax-m3",
+          "grok-4.6",
+          "glm-5.3-flash",
+          "deepseek-v4-flash-vision",
           "llama-4-maverick-17b-128e-instruct",
           "claude-3-7-sonnet-20250219"
         ],

--- a/docs/openapi/v3.json
+++ b/docs/openapi/v3.json
@@ -2212,6 +2212,9 @@
           "gpt-5.4-mini",
           "glm-5.2",
           "minimax-m3",
+          "grok-4.6",
+          "glm-5.3-flash",
+          "deepseek-v4-flash-vision",
           "claude-haiku-4.5",
           "gpt-5.2",
           "gpt-5-mini",
@@ -2224,7 +2227,7 @@
           "gemini-3.5-flash"
         ],
         "title": "BuModel",
-        "description": "The model to use for the agent. Each model has different capabilities and pricing.\n\n- `bu-mini` / `gemini-3-flash`: Gemini 3 Flash \u2014 fast and cost-effective. Best for simple, well-defined tasks like form filling or data extraction.\n- `bu-max` / `claude-sonnet-4.6` (legacy aliases) / `claude-sonnet-5`: Claude Sonnet 5 \u2014 balanced performance. Best for multi-step workflows that require reasoning and decision-making.\n- `bu-ultra` / `claude-opus-4.6`: Claude Opus 4.6 \u2014 capable general-purpose Opus tier.\n- `claude-opus-4.7`: Claude Opus 4.7 \u2014 most capable. Best for complex tasks that require advanced reasoning, long-horizon planning, or handling ambiguous instructions.\n- `claude-opus-4.8`: Claude Opus 4.8 \u2014 most capable Opus-tier model, state-of-the-art on long-horizon agentic work.\n- `gpt-5.4-mini`: GPT-5.4 mini \u2014 OpenAI's fast and efficient model. Best for tasks that benefit from OpenAI's capabilities.\n- `glm-5.2`: Z.ai GLM 5.2 \u2014 capable, low-cost open model. Best for cost-sensitive agentic tasks.\n- `minimax-m3`: MiniMax M3 \u2014 fast, very low-cost model. Best for simple, high-volume tasks.\n\nAdditional provider models (e.g. `gemini-3.5-flash`, `gpt-5.2`, and `gpt-5-mini`)\nare selectable only with `use_own_key=true`, where your own provider key serves\nthem. The GPT-5.6 family is native when either Browser Use's direct OpenAI key\nor Amazon Bedrock route is configured. GPT-5.5 becomes native only through the\nBedrock rollout."
+        "description": "The model to use for the agent. Each model has different capabilities and pricing.\n\n- `bu-mini` / `gemini-3-flash`: Gemini 3 Flash \u2014 fast and cost-effective. Best for simple, well-defined tasks like form filling or data extraction.\n- `bu-max` / `claude-sonnet-4.6` (legacy aliases) / `claude-sonnet-5`: Claude Sonnet 5 \u2014 balanced performance. Best for multi-step workflows that require reasoning and decision-making.\n- `bu-ultra` / `claude-opus-4.6`: Claude Opus 4.6 \u2014 capable general-purpose Opus tier.\n- `claude-opus-4.7`: Claude Opus 4.7 \u2014 most capable. Best for complex tasks that require advanced reasoning, long-horizon planning, or handling ambiguous instructions.\n- `claude-opus-4.8`: Claude Opus 4.8 \u2014 most capable Opus-tier model, state-of-the-art on long-horizon agentic work.\n- `gpt-5.4-mini`: GPT-5.4 mini \u2014 OpenAI's fast and efficient model. Best for tasks that benefit from OpenAI's capabilities.\n- `glm-5.2`: Z.ai GLM 5.2 \u2014 capable, low-cost open model. Best for cost-sensitive agentic tasks.\n- `minimax-m3`: MiniMax M3 \u2014 fast, very low-cost model. Best for simple, high-volume tasks.\n- `grok-4.6`: xAI Grok 4.6. Fast frontier model with a large context window.\n- `glm-5.3-flash`: Z.ai GLM 5.3 Flash. Multimodal, very low cost, served by Fireworks.\n- `deepseek-v4-flash-vision`: DeepSeek V4 Flash Vision. Experimental, very low cost.\n\nAdditional provider models (e.g. `gemini-3.5-flash`, `gpt-5.2`, and `gpt-5-mini`)\nare selectable only with `use_own_key=true`, where your own provider key serves\nthem. The GPT-5.6 family is native when either Browser Use's direct OpenAI key\nor Amazon Bedrock route is configured. GPT-5.5 becomes native only through the\nBedrock rollout."
       },
       "CreateBrowserSessionRequest": {
         "properties": {
@@ -2260,7 +2263,6 @@
                 "additionalProperties": {
                   "type": "string"
                 },
-                "maxProperties": 10,
                 "type": "object"
               },
               {
@@ -2311,6 +2313,18 @@
             "title": "Allow Resizing",
             "description": "Whether to allow the browser to be resized during the session (not recommended since it reduces stealthiness).",
             "default": false
+          },
+          "pdfRendererEnabled": {
+            "type": "boolean",
+            "title": "PDF Renderer Enabled",
+            "description": "Whether Chrome renders PDFs in a tab. Set to false to stop the in-tab render; the file is saved to the session's download directory either way.",
+            "default": true
+          },
+          "solveCaptchas": {
+            "type": "boolean",
+            "title": "Solve Captchas",
+            "description": "Whether the browser detects and solves CAPTCHAs on its own. Set to false to handle CAPTCHAs yourself. Defaults to true.",
+            "default": true
           },
           "customProxy": {
             "anyOf": [

--- a/docs/openapi/v3.json
+++ b/docs/openapi/v3.json
@@ -3256,7 +3256,7 @@
                 "type": "null"
               }
             ],
-            "description": "Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected."
+            "description": "Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level for Gemini 3 Flash and 3.5 Flash, and to a zero thinking budget for Gemini 2.5 Flash and the gemini-flash-latest variants); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected."
           },
           "sessionId": {
             "anyOf": [

--- a/docs/openapi/v4.json
+++ b/docs/openapi/v4.json
@@ -670,6 +670,22 @@
               "format": "uuid",
               "title": "Session Id"
             }
+          },
+          {
+            "name": "X-V4-Queue-Deduplicate",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-V4-Queue-Deduplicate"
+            }
           }
         ],
         "requestBody": {
@@ -2567,6 +2583,18 @@
             "description": "Whether to allow the browser to be resized during the session (not recommended since it reduces stealthiness).",
             "default": false
           },
+          "pdfRendererEnabled": {
+            "type": "boolean",
+            "title": "PDF Renderer Enabled",
+            "description": "Whether Chrome renders PDFs in a tab. Set to false to stop the in-tab render; the file is saved to the session's download directory either way.",
+            "default": true
+          },
+          "solveCaptchas": {
+            "type": "boolean",
+            "title": "Solve Captchas",
+            "description": "Whether the browser detects and solves CAPTCHAs on its own. Set to false to handle CAPTCHAs yourself. Defaults to true.",
+            "default": true
+          },
           "customProxy": {
             "anyOf": [
               {
@@ -2591,7 +2619,6 @@
                 "additionalProperties": {
                   "type": "string"
                 },
-                "maxProperties": 10,
                 "type": "object"
               },
               {
@@ -2746,6 +2773,51 @@
         "type": "object",
         "title": "InsufficientCreditsError",
         "description": "Error response when there are insufficient credits"
+      },
+      "OnePasswordSecretSource": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "onepassword",
+            "title": "Type"
+          },
+          "integrationId": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Integrationid",
+            "description": "1Password integration to resolve through. Must belong to this project."
+          },
+          "vaultId": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Vaultid"
+          },
+          "itemId": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Itemid"
+          },
+          "fieldId": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Fieldid",
+            "description": "Field id from the item-fields endpoint, e.g. \"password\"."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "type",
+          "integrationId",
+          "vaultId",
+          "itemId",
+          "fieldId"
+        ],
+        "title": "OnePasswordSecretSource",
+        "description": "One field of a 1Password item, resolved only when the agent asks for it.\n\nNothing here is a secret: the quadruple NAMES a credential without carrying\nit. Creating the binding makes no call to 1Password \u2014 a provider outage must\nnot stop a run from being dispatched, and no vault is ever enumerated.\n\nA one-time-password field resolves to its current code; its seed is never\nread, so there is no flag to ask for one."
       },
       "ProfileCreateRequest": {
         "properties": {
@@ -3490,6 +3562,9 @@
             "enum": [
               "glm-5.2",
               "grok-4.5",
+              "grok-4.6",
+              "glm-5.3-flash",
+              "deepseek-v4-flash-vision",
               "kimi-k3",
               "minimax-m3",
               "claude-opus-4.7",
@@ -3987,7 +4062,22 @@
             "description": "Name the agent refers to this secret by, e.g. \"github_password\"."
           },
           "source": {
-            "$ref": "#/components/schemas/InlineSecretSource"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/InlineSecretSource"
+              },
+              {
+                "$ref": "#/components/schemas/OnePasswordSecretSource"
+              }
+            ],
+            "title": "Source",
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "inline": "#/components/schemas/InlineSecretSource",
+                "onepassword": "#/components/schemas/OnePasswordSecretSource"
+              }
+            }
           },
           "allowedDomains": {
             "items": {

--- a/snapshots/v2.json
+++ b/snapshots/v2.json
@@ -4260,7 +4260,7 @@
               }
             ],
             "title": "Thinking Level",
-            "description": "Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected. API V2 cannot configure GLM or fixed-budget Claude thinking; use API V3 or V4 for those combinations."
+            "description": "Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level for Gemini 3 Flash and 3.5 Flash, and to a zero thinking budget for Gemini 2.5 Flash and the gemini-flash-latest variants); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected. API V2 cannot configure GLM or fixed-budget Claude thinking; use API V3 or V4 for those combinations."
           },
           "vision": {
             "anyOf": [

--- a/snapshots/v2.json
+++ b/snapshots/v2.json
@@ -3849,7 +3849,6 @@
                 "additionalProperties": {
                   "type": "string"
                 },
-                "maxProperties": 10,
                 "type": "object"
               },
               {
@@ -3900,6 +3899,18 @@
             "title": "Allow Resizing",
             "description": "Whether to allow the browser to be resized during the session (not recommended since it reduces stealthiness).",
             "default": false
+          },
+          "pdfRendererEnabled": {
+            "type": "boolean",
+            "title": "PDF Renderer Enabled",
+            "description": "Whether Chrome renders PDFs in a tab. Set to false to stop the in-tab render; the file is saved to the session's download directory either way.",
+            "default": true
+          },
+          "solveCaptchas": {
+            "type": "boolean",
+            "title": "Solve Captchas",
+            "description": "Whether the browser detects and solves CAPTCHAs on its own. Set to false to handle CAPTCHAs yourself. Defaults to true.",
+            "default": true
           },
           "customProxy": {
             "anyOf": [
@@ -4249,7 +4260,7 @@
               }
             ],
             "title": "Thinking Level",
-            "description": "Optional model reasoning depth. Omit this field to preserve the provider default. API V2 accepts disabled/low/medium/high for browser-use-llm, browser-use-2.0, gemini-2.5-flash, gemini-3-flash-preview, gemini-3.5-flash, gemini-flash-latest, gemini-flash-lite-latest, gpt-5.5, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, claude-sonnet-5, claude-opus-4-7, claude-opus-4-8, and claude-opus-5; low/medium/high for gemini-2.5-pro, o3, and o4-mini; low/high for gemini-3-pro-preview and gemini-3.1-pro-preview; and disabled only for claude-sonnet-4-20250514, claude-sonnet-4-5-20250929, and claude-opus-4-5-20251101. For browser-use-llm, browser-use-2.0, Gemini 3 Flash, and Gemini 3.5 Flash, disabled maps to Google's minimal thinking level. For Gemini 2.5 Flash and the gemini-flash-latest variants, disabled maps to a zero thinking budget. bu-2-0-mini-preview does not support configurable thinking, so omit thinkingLevel for that model. Other V2 models reject an explicit level. API V2 cannot configure GLM thinking or enable fixed-budget Claude thinking; use API V3 or V4 for those combinations."
+            "description": "Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected. API V2 cannot configure GLM or fixed-budget Claude thinking; use API V3 or V4 for those combinations."
           },
           "vision": {
             "anyOf": [
@@ -6298,6 +6309,9 @@
           "claude-opus-5",
           "glm-5.2",
           "minimax-m3",
+          "grok-4.6",
+          "glm-5.3-flash",
+          "deepseek-v4-flash-vision",
           "llama-4-maverick-17b-128e-instruct",
           "claude-3-7-sonnet-20250219"
         ],

--- a/snapshots/v3.json
+++ b/snapshots/v3.json
@@ -2212,6 +2212,9 @@
           "gpt-5.4-mini",
           "glm-5.2",
           "minimax-m3",
+          "grok-4.6",
+          "glm-5.3-flash",
+          "deepseek-v4-flash-vision",
           "claude-haiku-4.5",
           "gpt-5.2",
           "gpt-5-mini",
@@ -2224,7 +2227,7 @@
           "gemini-3.5-flash"
         ],
         "title": "BuModel",
-        "description": "The model to use for the agent. Each model has different capabilities and pricing.\n\n- `bu-mini` / `gemini-3-flash`: Gemini 3 Flash \u2014 fast and cost-effective. Best for simple, well-defined tasks like form filling or data extraction.\n- `bu-max` / `claude-sonnet-4.6` (legacy aliases) / `claude-sonnet-5`: Claude Sonnet 5 \u2014 balanced performance. Best for multi-step workflows that require reasoning and decision-making.\n- `bu-ultra` / `claude-opus-4.6`: Claude Opus 4.6 \u2014 capable general-purpose Opus tier.\n- `claude-opus-4.7`: Claude Opus 4.7 \u2014 most capable. Best for complex tasks that require advanced reasoning, long-horizon planning, or handling ambiguous instructions.\n- `claude-opus-4.8`: Claude Opus 4.8 \u2014 most capable Opus-tier model, state-of-the-art on long-horizon agentic work.\n- `gpt-5.4-mini`: GPT-5.4 mini \u2014 OpenAI's fast and efficient model. Best for tasks that benefit from OpenAI's capabilities.\n- `glm-5.2`: Z.ai GLM 5.2 \u2014 capable, low-cost open model. Best for cost-sensitive agentic tasks.\n- `minimax-m3`: MiniMax M3 \u2014 fast, very low-cost model. Best for simple, high-volume tasks.\n\nAdditional provider models (e.g. `gemini-3.5-flash`, `gpt-5.2`, and `gpt-5-mini`)\nare selectable only with `use_own_key=true`, where your own provider key serves\nthem. The GPT-5.6 family is native when either Browser Use's direct OpenAI key\nor Amazon Bedrock route is configured. GPT-5.5 becomes native only through the\nBedrock rollout."
+        "description": "The model to use for the agent. Each model has different capabilities and pricing.\n\n- `bu-mini` / `gemini-3-flash`: Gemini 3 Flash \u2014 fast and cost-effective. Best for simple, well-defined tasks like form filling or data extraction.\n- `bu-max` / `claude-sonnet-4.6` (legacy aliases) / `claude-sonnet-5`: Claude Sonnet 5 \u2014 balanced performance. Best for multi-step workflows that require reasoning and decision-making.\n- `bu-ultra` / `claude-opus-4.6`: Claude Opus 4.6 \u2014 capable general-purpose Opus tier.\n- `claude-opus-4.7`: Claude Opus 4.7 \u2014 most capable. Best for complex tasks that require advanced reasoning, long-horizon planning, or handling ambiguous instructions.\n- `claude-opus-4.8`: Claude Opus 4.8 \u2014 most capable Opus-tier model, state-of-the-art on long-horizon agentic work.\n- `gpt-5.4-mini`: GPT-5.4 mini \u2014 OpenAI's fast and efficient model. Best for tasks that benefit from OpenAI's capabilities.\n- `glm-5.2`: Z.ai GLM 5.2 \u2014 capable, low-cost open model. Best for cost-sensitive agentic tasks.\n- `minimax-m3`: MiniMax M3 \u2014 fast, very low-cost model. Best for simple, high-volume tasks.\n- `grok-4.6`: xAI Grok 4.6. Fast frontier model with a large context window.\n- `glm-5.3-flash`: Z.ai GLM 5.3 Flash. Multimodal, very low cost, served by Fireworks.\n- `deepseek-v4-flash-vision`: DeepSeek V4 Flash Vision. Experimental, very low cost.\n\nAdditional provider models (e.g. `gemini-3.5-flash`, `gpt-5.2`, and `gpt-5-mini`)\nare selectable only with `use_own_key=true`, where your own provider key serves\nthem. The GPT-5.6 family is native when either Browser Use's direct OpenAI key\nor Amazon Bedrock route is configured. GPT-5.5 becomes native only through the\nBedrock rollout."
       },
       "CreateBrowserSessionRequest": {
         "properties": {
@@ -2260,7 +2263,6 @@
                 "additionalProperties": {
                   "type": "string"
                 },
-                "maxProperties": 10,
                 "type": "object"
               },
               {
@@ -2311,6 +2313,18 @@
             "title": "Allow Resizing",
             "description": "Whether to allow the browser to be resized during the session (not recommended since it reduces stealthiness).",
             "default": false
+          },
+          "pdfRendererEnabled": {
+            "type": "boolean",
+            "title": "PDF Renderer Enabled",
+            "description": "Whether Chrome renders PDFs in a tab. Set to false to stop the in-tab render; the file is saved to the session's download directory either way.",
+            "default": true
+          },
+          "solveCaptchas": {
+            "type": "boolean",
+            "title": "Solve Captchas",
+            "description": "Whether the browser detects and solves CAPTCHAs on its own. Set to false to handle CAPTCHAs yourself. Defaults to true.",
+            "default": true
           },
           "customProxy": {
             "anyOf": [

--- a/snapshots/v3.json
+++ b/snapshots/v3.json
@@ -3256,7 +3256,7 @@
                 "type": "null"
               }
             ],
-            "description": "Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected."
+            "description": "Optional model reasoning depth. Omit this field to preserve the model provider default. Supported values depend on the selected model: most supported Claude models and GPT-5.1+ models support disabled/low/medium/high; Gemini Flash models support all four (disabled maps to Gemini's minimal level for Gemini 3 Flash and 3.5 Flash, and to a zero thinking budget for Gemini 2.5 Flash and the gemini-flash-latest variants); Claude Fable 5, earlier GPT-5 models, Gemini 2.5 Pro, o3/o4, and Grok support low/medium/high; Gemini 3.1 Pro supports low/high; GLM supports disabled/high. Unsupported model/level combinations are rejected."
           },
           "sessionId": {
             "anyOf": [

--- a/snapshots/v4.json
+++ b/snapshots/v4.json
@@ -670,6 +670,22 @@
               "format": "uuid",
               "title": "Session Id"
             }
+          },
+          {
+            "name": "X-V4-Queue-Deduplicate",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-V4-Queue-Deduplicate"
+            }
           }
         ],
         "requestBody": {
@@ -2567,6 +2583,18 @@
             "description": "Whether to allow the browser to be resized during the session (not recommended since it reduces stealthiness).",
             "default": false
           },
+          "pdfRendererEnabled": {
+            "type": "boolean",
+            "title": "PDF Renderer Enabled",
+            "description": "Whether Chrome renders PDFs in a tab. Set to false to stop the in-tab render; the file is saved to the session's download directory either way.",
+            "default": true
+          },
+          "solveCaptchas": {
+            "type": "boolean",
+            "title": "Solve Captchas",
+            "description": "Whether the browser detects and solves CAPTCHAs on its own. Set to false to handle CAPTCHAs yourself. Defaults to true.",
+            "default": true
+          },
           "customProxy": {
             "anyOf": [
               {
@@ -2591,7 +2619,6 @@
                 "additionalProperties": {
                   "type": "string"
                 },
-                "maxProperties": 10,
                 "type": "object"
               },
               {
@@ -2746,6 +2773,51 @@
         "type": "object",
         "title": "InsufficientCreditsError",
         "description": "Error response when there are insufficient credits"
+      },
+      "OnePasswordSecretSource": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "onepassword",
+            "title": "Type"
+          },
+          "integrationId": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Integrationid",
+            "description": "1Password integration to resolve through. Must belong to this project."
+          },
+          "vaultId": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Vaultid"
+          },
+          "itemId": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Itemid"
+          },
+          "fieldId": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Fieldid",
+            "description": "Field id from the item-fields endpoint, e.g. \"password\"."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "type",
+          "integrationId",
+          "vaultId",
+          "itemId",
+          "fieldId"
+        ],
+        "title": "OnePasswordSecretSource",
+        "description": "One field of a 1Password item, resolved only when the agent asks for it.\n\nNothing here is a secret: the quadruple NAMES a credential without carrying\nit. Creating the binding makes no call to 1Password \u2014 a provider outage must\nnot stop a run from being dispatched, and no vault is ever enumerated.\n\nA one-time-password field resolves to its current code; its seed is never\nread, so there is no flag to ask for one."
       },
       "ProfileCreateRequest": {
         "properties": {
@@ -3490,6 +3562,9 @@
             "enum": [
               "glm-5.2",
               "grok-4.5",
+              "grok-4.6",
+              "glm-5.3-flash",
+              "deepseek-v4-flash-vision",
               "kimi-k3",
               "minimax-m3",
               "claude-opus-4.7",
@@ -3987,7 +4062,22 @@
             "description": "Name the agent refers to this secret by, e.g. \"github_password\"."
           },
           "source": {
-            "$ref": "#/components/schemas/InlineSecretSource"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/InlineSecretSource"
+              },
+              {
+                "$ref": "#/components/schemas/OnePasswordSecretSource"
+              }
+            ],
+            "title": "Source",
+            "discriminator": {
+              "propertyName": "type",
+              "mapping": {
+                "inline": "#/components/schemas/InlineSecretSource",
+                "onepassword": "#/components/schemas/OnePasswordSecretSource"
+              }
+            }
           },
           "allowedDomains": {
             "items": {


### PR DESCRIPTION
## Summary

- add typed V4 `onepassword` secret bindings to the TypeScript and Python SDKs
- serialize typed 1Password references correctly in Python without treating them as inline secrets
- sync the latest additive OpenAPI changes, including browser PDF/CAPTCHA controls and model enums
- bump npm and PyPI packages to 3.11.3

## Verification

- `task test`
- `task check`
- `task build`

Merging this PR triggers the gated release workflow for npm and PyPI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds typed V4 `onepassword` secret bindings to the TypeScript and Python SDKs and fixes Python serialization so 1Password references serialize correctly instead of being treated as inline secrets. Adds an optional queue deduplication header to session `sendMessage`, syncs the latest additive OpenAPI changes (browser PDF/CAPTCHA controls and new model enums), and bumps both packages to 3.11.3.

**Rollout**
- Merging this PR triggers the gated release workflow for npm and PyPI.

<sup>Written for commit 098476a1bc2ffc742897c0266c198d401ef72050. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

