### PR TITLE
docs: remove stale SDK model caveats

### DIFF
--- a/docs/cloud/agent/models.mdx
+++ b/docs/cloud/agent/models.mdx
@@ -48,14 +48,6 @@ rollout and configured provider key.
 See [Thinking levels](/cloud/agent/thinking-levels) for the reasoning controls
 accepted by each model. Not every model accepts `modelParams`.
 
-<Note>
-  The current generated SDK request types predate this contract. The
-  TypeScript model union does not yet include GPT-5.6 Luna or every model on
-  this page, and neither generated V4 request model exposes `modelParams`.
-  Use `POST /api/v4/runs` directly for those fields until the follow-up SDK
-  regeneration is released.
-</Note>
-
 <CodeGroup>
 ```python Python
 from browser_use_sdk.v4 import BrowserUse
@@ -72,8 +64,7 @@ import { BrowserUse } from "browser-use-sdk/v4";
 const client = new BrowserUse();
 const run = await client.runs.create({
   task: "Compare three project-management tools",
-  // Use REST for GPT-5.6 Luna until the generated union is updated.
-  model: "grok-4.5",
+  model: "gpt-5.6-luna",
 });
 ```
 ```bash curl

--- a/docs/cloud/agent/thinking-levels.mdx
+++ b/docs/cloud/agent/thinking-levels.mdx
@@ -197,10 +197,9 @@ Model "gemini-3.1-pro" does not support modelParams.thinkingConfig.thinkingLevel
 
 The normalized V2/V3 field is optional and nullable. New sessions use provider
 defaults until a level is supplied. Existing V3 sessions retain their current
-setting when the field is omitted; send `null` to clear it. The checked-in
-generated SDK clients do not expose this field yet, so use the REST examples
-above until the follow-up SDK regeneration is released. V4 SDK clients can
-send `modelParams` once their generated V4 type includes the current contract.
+setting when the field is omitted; send `null` to clear it. The current Python
+and TypeScript SDKs expose the V2/V3 and V4 reasoning fields in their request
+types and client methods.
 
 <CardGroup cols={3}>
   <Card title="V4 create run" icon="code" href="/cloud/api-v4/runs/create-run">

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -317,12 +317,6 @@ rollout and configured provider key.
 See [Thinking levels](https://docs.browser-use.com/cloud/agent/thinking-levels) for the reasoning controls
 accepted by each model. Not every model accepts `modelParams`.
 
-  The current generated SDK request types predate this contract. The
-  TypeScript model union does not yet include GPT-5.6 Luna or every model on
-  this page, and neither generated V4 request model exposes `modelParams`.
-  Use `POST /api/v4/runs` directly for those fields until the follow-up SDK
-  regeneration is released.
-
 ```python Python
 from browser_use_sdk.v4 import BrowserUse
 
@@ -338,8 +332,7 @@ import { BrowserUse } from "browser-use-sdk/v4";
 const client = new BrowserUse();
 const run = await client.runs.create({
   task: "Compare three project-management tools",
-  // Use REST for GPT-5.6 Luna until the generated union is updated.
-  model: "grok-4.5",
+  model: "gpt-5.6-luna",
 });
 ```
 ```bash curl
@@ -548,10 +541,9 @@ Model "gemini-3.1-pro" does not support modelParams.thinkingConfig.thinkingLevel
 
 The normalized V2/V3 field is optional and nullable. New sessions use provider
 defaults until a level is supplied. Existing V3 sessions retain their current
-setting when the field is omitted; send `null` to clear it. The checked-in
-generated SDK clients do not expose this field yet, so use the REST examples
-above until the follow-up SDK regeneration is released. V4 SDK clients can
-send `modelParams` once their generated V4 type includes the current contract.
+setting when the field is omitted; send `null` to clear it. The current Python
+and TypeScript SDKs expose the V2/V3 and V4 reasoning fields in their request
+types and client methods.
 
   [V4 create run](https://docs.browser-use.com/cloud/api-v4/runs/create-run)
 Generated V4 `modelParams` schema.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -317,12 +317,6 @@ rollout and configured provider key.
 See [Thinking levels](https://docs.browser-use.com/cloud/agent/thinking-levels) for the reasoning controls
 accepted by each model. Not every model accepts `modelParams`.
 
-  The current generated SDK request types predate this contract. The
-  TypeScript model union does not yet include GPT-5.6 Luna or every model on
-  this page, and neither generated V4 request model exposes `modelParams`.
-  Use `POST /api/v4/runs` directly for those fields until the follow-up SDK
-  regeneration is released.
-
 ```python Python
 from browser_use_sdk.v4 import BrowserUse
 
@@ -338,8 +332,7 @@ import { BrowserUse } from "browser-use-sdk/v4";
 const client = new BrowserUse();
 const run = await client.runs.create({
   task: "Compare three project-management tools",
-  // Use REST for GPT-5.6 Luna until the generated union is updated.
-  model: "grok-4.5",
+  model: "gpt-5.6-luna",
 });
 ```
 ```bash curl
@@ -548,10 +541,9 @@ Model "gemini-3.1-pro" does not support modelParams.thinkingConfig.thinkingLevel
 
 The normalized V2/V3 field is optional and nullable. New sessions use provider
 defaults until a level is supplied. Existing V3 sessions retain their current
-setting when the field is omitted; send `null` to clear it. The checked-in
-generated SDK clients do not expose this field yet, so use the REST examples
-above until the follow-up SDK regeneration is released. V4 SDK clients can
-send `modelParams` once their generated V4 type includes the current contract.
+setting when the field is omitted; send `null` to clear it. The current Python
+and TypeScript SDKs expose the V2/V3 and V4 reasoning fields in their request
+types and client methods.
 
   [V4 create run](https://docs.browser-use.com/cloud/api-v4/runs/create-run)
 Generated V4 `modelParams` schema.


### PR DESCRIPTION
## Summary
- remove the obsolete warning that V4 SDKs cannot use GPT-5.6 Luna or `modelParams`
- make the TypeScript model example match the recommended Luna model
- update the reasoning compatibility note for the current Python and TypeScript SDKs
- regenerate both `llms-full.txt` mirrors

## Proof
- npm and PyPI `browser-use-sdk` latest: `3.11.3`
- released TypeScript package compiles V4 Luna + `modelParams`, V3 `thinkingLevel`, and V2 `thinkingLevel`
- released Python package exposes V4 `model_params` and V2/V3 `thinking_level` and serializes Luna reasoning to `modelParams`

## Validation
- `npx --yes mintlify@latest broken-links`
- `./docs/generate-llms-txt.sh` (idempotent on a second run)
- TypeScript SDK: build, typecheck, 147 tests
- Python SDK: wheel + sdist build, 61 tests
- `git diff --check`

## Known baseline checks
- the checked-in pnpm lock currently fails frozen install because the package override config is out of sync; validation used pnpm 10.23.0 with a temporary regenerated lock, then restored the committed lock exactly
- Python `pyright src/` currently reports the two pre-existing optional `eth_account` imports in `_core/x402.py`; this docs-only change does not touch Python source

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes stale caveats from the model and thinking-levels docs now that the Python and TypeScript SDKs support GPT-5.6 Luna, `modelParams`, and the V2/V3 reasoning fields. Updates the TypeScript example to use `gpt-5.6-luna` and regenerates both `llms-full.txt` mirrors.

<sup>Written for commit dc6deed168bcc8a31b13689bf05517d6d196b6a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

