### PR TITLE
docs: document V4 1Password vault runs

### DIFF
--- a/docs/cloud/guides/1password.mdx
+++ b/docs/cloud/guides/1password.mdx
@@ -1,6 +1,6 @@
 ---
 title: 1Password & 2FA
-description: "Auto-fill passwords and TOTP codes from 1Password in API tasks: v4 runs with secret bindings, v2 and v3 tasks with a vault id."
+description: "Auto-fill passwords and TOTP codes from 1Password in API tasks."
 icon: lock
 ---
 
@@ -25,7 +25,31 @@ Create a new vault in 1Password for Browser Use. Add the credentials you want th
 
 ## Use a vault in a v4 run
 
-A v4 run does not take a vault id. It takes **secret bindings**: each binding names one field of one 1Password item, gives it an alias the agent can ask for, and lists the hosts it may be typed into. The value never reaches the model; the server types it into the focused field when the agent asks for the alias on an allowed domain. Bindings are run-scoped, so a follow-up run that needs the same login must send them again.
+Pass the vault id and the domains where its credentials may be typed. Browser Use finds the project's connected 1Password integration and makes the vault's username, password, and TOTP fields available to the run. You do not need the integration, item, or field ids.
+
+```bash
+curl -X POST https://api.browser-use.com/api/v4/runs \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "task": "Open amazon.com, log in, and check my recent orders",
+    "opVaultId": "<vault-id>",
+    "opVaultAllowedDomains": ["amazon.com"]
+  }'
+```
+
+- `opVaultAllowedDomains` is required with `opVaultId`. Use bare hostnames; a hostname also covers its subdomains.
+- Vault items become aliases based on their titles, with `_username`, `_password`, or `_bu_2fa_code` suffixes.
+- Vault fields and explicit `secretBindings` share a limit of 10 bindings per run. The API returns `422` if the combined total exceeds 10.
+- Vault access requires exactly one active 1Password integration on the project and is unavailable for zero-data-retention projects.
+
+<Note>
+  These fields are available in the v4 REST API. Typed Python and TypeScript SDK support will follow the v4 OpenAPI specification update. Until then, use the REST request above.
+</Note>
+
+## Bind individual fields in a v4 run
+
+For least-privilege access, use **secret bindings** instead of exposing every credential field in a vault. Each binding names one field of one 1Password item, gives it an alias the agent can ask for, and lists the hosts where it may be typed. The value never reaches the model; the server types it into the focused field when the agent asks for the alias on an allowed domain. Bindings are run-scoped, so a follow-up run that needs the same login must send them again.
 
 <CodeGroup>
 ```python Python
@@ -78,7 +102,7 @@ const run = await client.runs.create({
 - `fieldId` is the field's id, not its label: `username`, `password`, or `one-time-password` for a TOTP field, which resolves to the current code.
 - `allowedDomains` are bare hostnames; a host covers its subdomains.
 
-In the chat UI at cloud.browser-use.com the same picker lives under **Run settings → Credentials**: choose the vault, the item, and the field, give it an alias, and list the domains.
+In the chat UI at cloud.browser-use.com the field picker lives under **Run settings → Credentials**: choose the vault, the item, and the field, give it an alias, and list the domains.
 
 ## Use a vault in a v2 or v3 task
 

--- a/docs/cloud/guides/1password.mdx
+++ b/docs/cloud/guides/1password.mdx
@@ -27,6 +27,10 @@ Create a new vault in 1Password for Browser Use. Add the credentials you want th
 
 Pass the vault id and the domains where its credentials may be typed. Browser Use finds the project's connected 1Password integration and makes the vault's username, password, and TOTP fields available to the run. You do not need the integration, item, or field ids.
 
+<Warning>
+  Every supported credential field in the vault is made available to the run. Use a dedicated vault containing only the accounts the agent needs.
+</Warning>
+
 ```bash
 curl -X POST https://api.browser-use.com/api/v4/runs \
   -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
@@ -44,7 +48,7 @@ curl -X POST https://api.browser-use.com/api/v4/runs \
 - Vault access requires exactly one active 1Password integration on the project and is unavailable for zero-data-retention projects.
 
 <Note>
-  These fields are available in the v4 REST API. Typed Python and TypeScript SDK support will follow the v4 OpenAPI specification update. Until then, use the REST request above.
+  These fields work through the v4 REST API. The currently published Python and TypeScript SDK types do not expose them yet; use the REST request above until those clients are regenerated.
 </Note>
 
 ## Bind individual fields in a v4 run

--- a/docs/cloud/guides/1password.mdx
+++ b/docs/cloud/guides/1password.mdx
@@ -106,7 +106,7 @@ const run = await client.runs.create({
 - `fieldId` is the field's id, not its label: `username`, `password`, or `one-time-password` for a TOTP field, which resolves to the current code.
 - `allowedDomains` are bare hostnames; a host covers its subdomains.
 
-In the chat UI at cloud.browser-use.com the field picker lives under **Run settings → Credentials**: choose the vault, the item, and the field, give it an alias, and list the domains.
+In the chat UI at cloud.browser-use.com both options live under **Run settings → Credentials**. **Use a whole vault** asks for the vault and the allowed sites and sends `opVaultId` + `opVaultAllowedDomains`; **Add a credential** walks vault, item, and field, takes an alias and the domains, and sends one binding. The **Agents** page has a **1Password** section with the same vault + allowed-sites pair, and its REST snippet shows the resulting request.
 
 ## Use a vault in a v2 or v3 task
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1649,6 +1649,8 @@ Create a new vault in 1Password for Browser Use. Add the credentials you want th
 
 Pass the vault id and the domains where its credentials may be typed. Browser Use finds the project's connected 1Password integration and makes the vault's username, password, and TOTP fields available to the run. You do not need the integration, item, or field ids.
 
+  Every supported credential field in the vault is made available to the run. Use a dedicated vault containing only the accounts the agent needs.
+
 ```bash
 curl -X POST https://api.browser-use.com/api/v4/runs \
   -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
@@ -1665,7 +1667,7 @@ curl -X POST https://api.browser-use.com/api/v4/runs \
 - Vault fields and explicit `secretBindings` share a limit of 10 bindings per run. The API returns `422` if the combined total exceeds 10.
 - Vault access requires exactly one active 1Password integration on the project and is unavailable for zero-data-retention projects.
 
-  These fields are available in the v4 REST API. Typed Python and TypeScript SDK support will follow the v4 OpenAPI specification update. Until then, use the REST request above.
+  These fields work through the v4 REST API. The currently published Python and TypeScript SDK types do not expose them yet; use the REST request above until those clients are regenerated.
 
 ## Bind individual fields in a v4 run
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1647,7 +1647,29 @@ Create a new vault in 1Password for Browser Use. Add the credentials you want th
 
 ## Use a vault in a v4 run
 
-A v4 run does not take a vault id. It takes **secret bindings**: each binding names one field of one 1Password item, gives it an alias the agent can ask for, and lists the hosts it may be typed into. The value never reaches the model; the server types it into the focused field when the agent asks for the alias on an allowed domain. Bindings are run-scoped, so a follow-up run that needs the same login must send them again.
+Pass the vault id and the domains where its credentials may be typed. Browser Use finds the project's connected 1Password integration and makes the vault's username, password, and TOTP fields available to the run. You do not need the integration, item, or field ids.
+
+```bash
+curl -X POST https://api.browser-use.com/api/v4/runs \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "task": "Open amazon.com, log in, and check my recent orders",
+    "opVaultId": "<vault-id>",
+    "opVaultAllowedDomains": ["amazon.com"]
+  }'
+```
+
+- `opVaultAllowedDomains` is required with `opVaultId`. Use bare hostnames; a hostname also covers its subdomains.
+- Vault items become aliases based on their titles, with `_username`, `_password`, or `_bu_2fa_code` suffixes.
+- Vault fields and explicit `secretBindings` share a limit of 10 bindings per run. The API returns `422` if the combined total exceeds 10.
+- Vault access requires exactly one active 1Password integration on the project and is unavailable for zero-data-retention projects.
+
+  These fields are available in the v4 REST API. Typed Python and TypeScript SDK support will follow the v4 OpenAPI specification update. Until then, use the REST request above.
+
+## Bind individual fields in a v4 run
+
+For least-privilege access, use **secret bindings** instead of exposing every credential field in a vault. Each binding names one field of one 1Password item, gives it an alias the agent can ask for, and lists the hosts where it may be typed. The value never reaches the model; the server types it into the focused field when the agent asks for the alias on an allowed domain. Bindings are run-scoped, so a follow-up run that needs the same login must send them again.
 
 ```python Python
 from browser_use_sdk.v4 import BrowserUse
@@ -1698,7 +1720,7 @@ const run = await client.runs.create({
 - `fieldId` is the field's id, not its label: `username`, `password`, or `one-time-password` for a TOTP field, which resolves to the current code.
 - `allowedDomains` are bare hostnames; a host covers its subdomains.
 
-In the chat UI at cloud.browser-use.com the same picker lives under **Run settings → Credentials**: choose the vault, the item, and the field, give it an alias, and list the domains.
+In the chat UI at cloud.browser-use.com the field picker lives under **Run settings → Credentials**: choose the vault, the item, and the field, give it an alias, and list the domains.
 
 ## Use a vault in a v2 or v3 task
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1722,7 +1722,7 @@ const run = await client.runs.create({
 - `fieldId` is the field's id, not its label: `username`, `password`, or `one-time-password` for a TOTP field, which resolves to the current code.
 - `allowedDomains` are bare hostnames; a host covers its subdomains.
 
-In the chat UI at cloud.browser-use.com the field picker lives under **Run settings → Credentials**: choose the vault, the item, and the field, give it an alias, and list the domains.
+In the chat UI at cloud.browser-use.com both options live under **Run settings → Credentials**. **Use a whole vault** asks for the vault and the allowed sites and sends `opVaultId` + `opVaultAllowedDomains`; **Add a credential** walks vault, item, and field, takes an alias and the domains, and sends one binding. The **Agents** page has a **1Password** section with the same vault + allowed-sites pair, and its REST snippet shows the resulting request.
 
 ## Use a vault in a v2 or v3 task
 

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -93,7 +93,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 - [Profiles](https://docs.browser-use.com/cloud/guides/authentication): Reuse cookies and browser state in API V4 runs.
 - [Sync local and cloud cookies](https://docs.browser-use.com/cloud/guides/profile-sync): Sync a local login, then use it in an API V4 run.
 - [2FA](https://docs.browser-use.com/cloud/guides/2fa): Handle two-factor authentication in API V4 runs.
-- [1Password & 2FA](https://docs.browser-use.com/cloud/guides/1password): Auto-fill passwords and TOTP codes from 1Password in API tasks: v4 runs with secret bindings, v2 and v3 tasks with a vault id.
+- [1Password & 2FA](https://docs.browser-use.com/cloud/guides/1password): Auto-fill passwords and TOTP codes from 1Password in API tasks.
 - [Secrets](https://docs.browser-use.com/cloud/guides/secrets): Pass domain-scoped credentials to the agent securely.
 
 ## More

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1649,6 +1649,8 @@ Create a new vault in 1Password for Browser Use. Add the credentials you want th
 
 Pass the vault id and the domains where its credentials may be typed. Browser Use finds the project's connected 1Password integration and makes the vault's username, password, and TOTP fields available to the run. You do not need the integration, item, or field ids.
 
+  Every supported credential field in the vault is made available to the run. Use a dedicated vault containing only the accounts the agent needs.
+
 ```bash
 curl -X POST https://api.browser-use.com/api/v4/runs \
   -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
@@ -1665,7 +1667,7 @@ curl -X POST https://api.browser-use.com/api/v4/runs \
 - Vault fields and explicit `secretBindings` share a limit of 10 bindings per run. The API returns `422` if the combined total exceeds 10.
 - Vault access requires exactly one active 1Password integration on the project and is unavailable for zero-data-retention projects.
 
-  These fields are available in the v4 REST API. Typed Python and TypeScript SDK support will follow the v4 OpenAPI specification update. Until then, use the REST request above.
+  These fields work through the v4 REST API. The currently published Python and TypeScript SDK types do not expose them yet; use the REST request above until those clients are regenerated.
 
 ## Bind individual fields in a v4 run
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1647,7 +1647,29 @@ Create a new vault in 1Password for Browser Use. Add the credentials you want th
 
 ## Use a vault in a v4 run
 
-A v4 run does not take a vault id. It takes **secret bindings**: each binding names one field of one 1Password item, gives it an alias the agent can ask for, and lists the hosts it may be typed into. The value never reaches the model; the server types it into the focused field when the agent asks for the alias on an allowed domain. Bindings are run-scoped, so a follow-up run that needs the same login must send them again.
+Pass the vault id and the domains where its credentials may be typed. Browser Use finds the project's connected 1Password integration and makes the vault's username, password, and TOTP fields available to the run. You do not need the integration, item, or field ids.
+
+```bash
+curl -X POST https://api.browser-use.com/api/v4/runs \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "task": "Open amazon.com, log in, and check my recent orders",
+    "opVaultId": "<vault-id>",
+    "opVaultAllowedDomains": ["amazon.com"]
+  }'
+```
+
+- `opVaultAllowedDomains` is required with `opVaultId`. Use bare hostnames; a hostname also covers its subdomains.
+- Vault items become aliases based on their titles, with `_username`, `_password`, or `_bu_2fa_code` suffixes.
+- Vault fields and explicit `secretBindings` share a limit of 10 bindings per run. The API returns `422` if the combined total exceeds 10.
+- Vault access requires exactly one active 1Password integration on the project and is unavailable for zero-data-retention projects.
+
+  These fields are available in the v4 REST API. Typed Python and TypeScript SDK support will follow the v4 OpenAPI specification update. Until then, use the REST request above.
+
+## Bind individual fields in a v4 run
+
+For least-privilege access, use **secret bindings** instead of exposing every credential field in a vault. Each binding names one field of one 1Password item, gives it an alias the agent can ask for, and lists the hosts where it may be typed. The value never reaches the model; the server types it into the focused field when the agent asks for the alias on an allowed domain. Bindings are run-scoped, so a follow-up run that needs the same login must send them again.
 
 ```python Python
 from browser_use_sdk.v4 import BrowserUse
@@ -1698,7 +1720,7 @@ const run = await client.runs.create({
 - `fieldId` is the field's id, not its label: `username`, `password`, or `one-time-password` for a TOTP field, which resolves to the current code.
 - `allowedDomains` are bare hostnames; a host covers its subdomains.
 
-In the chat UI at cloud.browser-use.com the same picker lives under **Run settings → Credentials**: choose the vault, the item, and the field, give it an alias, and list the domains.
+In the chat UI at cloud.browser-use.com the field picker lives under **Run settings → Credentials**: choose the vault, the item, and the field, give it an alias, and list the domains.
 
 ## Use a vault in a v2 or v3 task
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1722,7 +1722,7 @@ const run = await client.runs.create({
 - `fieldId` is the field's id, not its label: `username`, `password`, or `one-time-password` for a TOTP field, which resolves to the current code.
 - `allowedDomains` are bare hostnames; a host covers its subdomains.
 
-In the chat UI at cloud.browser-use.com the field picker lives under **Run settings → Credentials**: choose the vault, the item, and the field, give it an alias, and list the domains.
+In the chat UI at cloud.browser-use.com both options live under **Run settings → Credentials**. **Use a whole vault** asks for the vault and the allowed sites and sends `opVaultId` + `opVaultAllowedDomains`; **Add a credential** walks vault, item, and field, takes an alias and the domains, and sends one binding. The **Agents** page has a **1Password** section with the same vault + allowed-sites pair, and its REST snippet shows the resulting request.
 
 ## Use a vault in a v2 or v3 task
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -93,7 +93,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 - [Profiles](https://docs.browser-use.com/cloud/guides/authentication): Reuse cookies and browser state in API V4 runs.
 - [Sync local and cloud cookies](https://docs.browser-use.com/cloud/guides/profile-sync): Sync a local login, then use it in an API V4 run.
 - [2FA](https://docs.browser-use.com/cloud/guides/2fa): Handle two-factor authentication in API V4 runs.
-- [1Password & 2FA](https://docs.browser-use.com/cloud/guides/1password): Auto-fill passwords and TOTP codes from 1Password in API tasks: v4 runs with secret bindings, v2 and v3 tasks with a vault id.
+- [1Password & 2FA](https://docs.browser-use.com/cloud/guides/1password): Auto-fill passwords and TOTP codes from 1Password in API tasks.
 - [Secrets](https://docs.browser-use.com/cloud/guides/secrets): Pass domain-scoped credentials to the agent securely.
 
 ## More


### PR DESCRIPTION
Documents the new V4 `opVaultId` and `opVaultAllowedDomains` convenience input introduced by browser-use/cloud#5832. The guide includes an exact REST example, domain and 10-binding limits, integration and ZDR requirements, generated aliases, and keeps explicit per-field bindings as the least-privilege option. It also states that typed SDK support waits for the V4 OpenAPI regeneration tracked in browser-use/cloud#5834. Regenerated both cloud and root `llms.txt`/`llms-full.txt` mirrors with the repository script.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the new `opVaultId` and `opVaultAllowedDomains` V4 run inputs so a run can use a whole 1Password vault without integration, item, or field IDs, and covers the matching "Use a whole vault" options in Run settings → Credentials and the Agents page.

- Vault access exposes every supported credential field, so the guide recommends a dedicated vault.
- Per-field `secretBindings` remain documented as the least-privilege option.
- Covers the required domain list, the shared 10-binding limit, the one-active-integration requirement, and the `422` error.
- Notes typed Python and TypeScript SDK support awaits V4 OpenAPI regeneration.
- Regenerated the cloud and root `llms.txt`/`llms-full.txt` mirrors to match.

<sup>Written for commit ffd62280a6639aee6bde5a1fd26923ed70855fed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

