### PR TITLE
docs: include every local MCP browser tool

### DIFF
--- a/docs/open-source/customize/integrations/mcp-server.mdx
+++ b/docs/open-source/customize/integrations/mcp-server.mdx
@@ -136,6 +136,8 @@ The local MCP server exposes these low-level browser automation tools for direct
 
 #### Content Extraction
 - **`browser_extract_content`** - Extract structured content from the current page
+- **`browser_get_html`** - Return the full page HTML or one CSS-selected element
+- **`browser_screenshot`** - Capture the viewport or the full scrollable page
 
 #### Session Management
 - **`browser_list_sessions`** - List all active browser sessions with details

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -2963,6 +2963,8 @@ The local MCP server exposes these low-level browser automation tools for direct
 
 #### Content Extraction
 - **`browser_extract_content`** - Extract structured content from the current page
+- **`browser_get_html`** - Return the full page HTML or one CSS-selected element
+- **`browser_screenshot`** - Capture the viewport or the full scrollable page
 
 #### Session Management
 - **`browser_list_sessions`** - List all active browser sessions with details


### PR DESCRIPTION
Lists `browser_get_html` and `browser_screenshot` in the local MCP guide and regenerates its LLM-readable mirror. Both tools already ship; this changes only the same two documentation bullets in both files.

Verified the 16 registered tool names match the updated list. In an isolated headless Chrome fixture, HTML extraction returned the full page and a selected element, and screenshots captured an 800x600 viewport and an 800x1506 full page without an LLM key. A missing selector retained its existing error message. The MCP transport and provider APIs were not exercised.

Mint reported no broken links on this page. `docs.json` parsed, two generation runs produced identical output, and `git diff --check` passed.
