### PR TITLE
docs: state local MCP key requirements exactly

### DIFF
--- a/docs/open-source/customize/integrations/mcp-server.mdx
+++ b/docs/open-source/customize/integrations/mcp-server.mdx
@@ -3,7 +3,7 @@ title: "MCP Server"
 description: "Run browser-use as a local Model Context Protocol server. Connect AI models to browser automation through the MCP standard."
 ---
 
-Browser Use can run as a local **Model Context Protocol (MCP)** server on your machine via stdio. This is the **free, open-source option** for direct browser control. Navigation, clicks, typing, page state, HTML, and screenshots do not need an LLM API key. Content extraction requires an OpenAI-compatible key. `retry_with_browser_use_agent` uses an OpenAI-compatible key by default or configured AWS Bedrock credentials when `MODEL_PROVIDER=bedrock`.
+Connect your MCP client to Browser Use running locally on your machine. The free, open-source server lets your AI navigate, click, type and inspect pages. Direct browser control needs no LLM API key in the server.
 
 <Note>
 Looking for a hosted solution? Use the [Cloud MCP Server](/cloud/guides/mcp-server) instead — no setup required, just an API key.
@@ -107,11 +107,41 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 </Tab>
 </Tabs>
 
+## Model keys
+
+Your MCP client supplies the AI for direct browser control. Two optional tools ask the server to call a model itself:
+
+| What you call | What the server needs |
+| --- | --- |
+| Direct browser tools: navigate, click, type, state, HTML, screenshot | No LLM key |
+| `browser_extract_content`: turn page content into structured data | An OpenAI-compatible key |
+| `retry_with_browser_use_agent`: hand a complete task to a separate browser agent | An OpenAI-compatible key, or the Bedrock setup below |
+
+The last row is an existing tool name, not an automatic retry of every browser action.
+
 ## Environment Variables
 
-- `OPENAI_API_KEY` - Optional for direct browser control; required for `browser_extract_content` and the default OpenAI-compatible route of `retry_with_browser_use_agent`
+- `OPENAI_API_KEY` - Required for extraction and the default autonomous agent. Omit it from the client configurations above if you only use direct browser tools
 - `BROWSER_USE_HEADLESS` - Set to `false` to show browser window
 - `BROWSER_USE_DISABLE_SECURITY` - Set to `true` to disable browser security features
+
+### AWS Bedrock agent setup
+
+For the optional autonomous agent tool, use `browser-use[cli,aws]` instead of `browser-use[cli]` in your MCP client's command arguments. This installs the required AWS dependency:
+
+```bash
+uvx --from 'browser-use[cli,aws]' browser-use --mcp
+```
+
+Set these in the MCP server's environment:
+
+- `MODEL_PROVIDER=bedrock` - Select Bedrock for the autonomous agent
+- `BROWSER_USE_LLM_MODEL` - A Bedrock model or inference-profile ID available to your AWS account and region. This overrides the saved model; `MODEL` alone does not override it
+- `REGION` - Your Bedrock region, for example `us-east-1`. The MCP agent defaults to `us-east-1`; `AWS_DEFAULT_REGION` does not override this choice
+- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` - Your AWS credentials with access to the chosen Bedrock model
+- `AWS_SESSION_TOKEN` - Also set this when using temporary AWS credentials
+
+This setup does not need `OPENAI_API_KEY` for the autonomous agent. It does not configure `browser_extract_content` for Bedrock; extraction still uses the separate OpenAI-compatible LLM path.
 
 ## Available Tools
 

--- a/docs/open-source/customize/integrations/mcp-server.mdx
+++ b/docs/open-source/customize/integrations/mcp-server.mdx
@@ -3,7 +3,7 @@ title: "MCP Server"
 description: "Run browser-use as a local Model Context Protocol server. Connect AI models to browser automation through the MCP standard."
 ---
 
-Browser Use can run as a local **Model Context Protocol (MCP)** server on your machine via stdio. This is the **free, open-source option** that gives you direct, low-level control over browser automation but requires your own LLM API keys.
+Browser Use can run as a local **Model Context Protocol (MCP)** server on your machine via stdio. This is the **free, open-source option** for direct browser control. Navigation, clicks, typing, page state, HTML, and screenshots do not need an LLM API key. Content extraction requires an OpenAI-compatible key. `retry_with_browser_use_agent` uses an OpenAI-compatible key by default or configured AWS Bedrock credentials when `MODEL_PROVIDER=bedrock`.
 
 <Note>
 Looking for a hosted solution? Use the [Cloud MCP Server](/cloud/guides/mcp-server) instead — no setup required, just an API key.
@@ -109,8 +109,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 
 ## Environment Variables
 
-- `OPENAI_API_KEY` - Your OpenAI API key (required)
-- `ANTHROPIC_API_KEY` - Your Anthropic API key (alternative to OpenAI)
+- `OPENAI_API_KEY` - Optional for direct browser control; required for `browser_extract_content` and the default OpenAI-compatible route of `retry_with_browser_use_agent`
 - `BROWSER_USE_HEADLESS` - Set to `false` to show browser window
 - `BROWSER_USE_DISABLE_SECURITY` - Set to `true` to disable browser security features
 
@@ -212,9 +211,8 @@ Claude Desktop cannot find `uvx` in its PATH. Use the full path in your config:
 - Ensure no other browser instances are using the same profile
 
 **API Key Issues**
-- Verify your `OPENAI_API_KEY` is set correctly
-- Check API key permissions and billing status
-- Try using `ANTHROPIC_API_KEY` as an alternative
+- Direct browser tools such as navigate, click, type, page state, HTML, and screenshot do not require a key
+- For `browser_extract_content` or the default OpenAI-compatible agent route, verify that `OPENAI_API_KEY` is set and has billing enabled
 
 **Connection Issues in Claude Desktop**
 - Restart Claude Desktop after config changes

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -2883,7 +2883,7 @@ def finish_task() -> ActionResult:
 Source: https://docs.browser-use.com/open-source/customize/integrations/mcp-server
 
 
-Browser Use can run as a local **Model Context Protocol (MCP)** server on your machine via stdio. This is the **free, open-source option** for direct browser control. Navigation, clicks, typing, page state, HTML, and screenshots do not need an LLM API key. Content extraction requires an OpenAI-compatible key. `retry_with_browser_use_agent` uses an OpenAI-compatible key by default or configured AWS Bedrock credentials when `MODEL_PROVIDER=bedrock`.
+Connect your MCP client to Browser Use running locally on your machine. The free, open-source server lets your AI navigate, click, type and inspect pages. Direct browser control needs no LLM API key in the server.
 
 Looking for a hosted solution? Use the [Cloud MCP Server](https://docs.browser-use.com/cloud/guides/mcp-server) instead — no setup required, just an API key.
 
@@ -2973,11 +2973,41 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 }
 ```
 
+## Model keys
+
+Your MCP client supplies the AI for direct browser control. Two optional tools ask the server to call a model itself:
+
+| What you call | What the server needs |
+| --- | --- |
+| Direct browser tools: navigate, click, type, state, HTML, screenshot | No LLM key |
+| `browser_extract_content`: turn page content into structured data | An OpenAI-compatible key |
+| `retry_with_browser_use_agent`: hand a complete task to a separate browser agent | An OpenAI-compatible key, or the Bedrock setup below |
+
+The last row is an existing tool name, not an automatic retry of every browser action.
+
 ## Environment Variables
 
-- `OPENAI_API_KEY` - Optional for direct browser control; required for `browser_extract_content` and the default OpenAI-compatible route of `retry_with_browser_use_agent`
+- `OPENAI_API_KEY` - Required for extraction and the default autonomous agent. Omit it from the client configurations above if you only use direct browser tools
 - `BROWSER_USE_HEADLESS` - Set to `false` to show browser window
 - `BROWSER_USE_DISABLE_SECURITY` - Set to `true` to disable browser security features
+
+### AWS Bedrock agent setup
+
+For the optional autonomous agent tool, use `browser-use[cli,aws]` instead of `browser-use[cli]` in your MCP client's command arguments. This installs the required AWS dependency:
+
+```bash
+uvx --from 'browser-use[cli,aws]' browser-use --mcp
+```
+
+Set these in the MCP server's environment:
+
+- `MODEL_PROVIDER=bedrock` - Select Bedrock for the autonomous agent
+- `BROWSER_USE_LLM_MODEL` - A Bedrock model or inference-profile ID available to your AWS account and region. This overrides the saved model; `MODEL` alone does not override it
+- `REGION` - Your Bedrock region, for example `us-east-1`. The MCP agent defaults to `us-east-1`; `AWS_DEFAULT_REGION` does not override this choice
+- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` - Your AWS credentials with access to the chosen Bedrock model
+- `AWS_SESSION_TOKEN` - Also set this when using temporary AWS credentials
+
+This setup does not need `OPENAI_API_KEY` for the autonomous agent. It does not configure `browser_extract_content` for Bedrock; extraction still uses the separate OpenAI-compatible LLM path.
 
 ## Available Tools
 

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -2844,7 +2844,7 @@ def finish_task() -> ActionResult:
 Source: https://docs.browser-use.com/open-source/customize/integrations/mcp-server
 
 
-Browser Use can run as a local **Model Context Protocol (MCP)** server on your machine via stdio. This is the **free, open-source option** that gives you direct, low-level control over browser automation but requires your own LLM API keys.
+Browser Use can run as a local **Model Context Protocol (MCP)** server on your machine via stdio. This is the **free, open-source option** for direct browser control. Navigation, clicks, typing, page state, HTML, and screenshots do not need an LLM API key. Content extraction requires an OpenAI-compatible key. `retry_with_browser_use_agent` uses an OpenAI-compatible key by default or configured AWS Bedrock credentials when `MODEL_PROVIDER=bedrock`.
 
 Looking for a hosted solution? Use the [Cloud MCP Server](https://docs.browser-use.com/cloud/guides/mcp-server) instead — no setup required, just an API key.
 
@@ -2936,8 +2936,7 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 
 ## Environment Variables
 
-- `OPENAI_API_KEY` - Your OpenAI API key (required)
-- `ANTHROPIC_API_KEY` - Your Anthropic API key (alternative to OpenAI)
+- `OPENAI_API_KEY` - Optional for direct browser control; required for `browser_extract_content` and the default OpenAI-compatible route of `retry_with_browser_use_agent`
 - `BROWSER_USE_HEADLESS` - Set to `false` to show browser window
 - `BROWSER_USE_DISABLE_SECURITY` - Set to `true` to disable browser security features
 
@@ -3039,9 +3038,8 @@ Claude Desktop cannot find `uvx` in its PATH. Use the full path in your config:
 - Ensure no other browser instances are using the same profile
 
 **API Key Issues**
-- Verify your `OPENAI_API_KEY` is set correctly
-- Check API key permissions and billing status
-- Try using `ANTHROPIC_API_KEY` as an alternative
+- Direct browser tools such as navigate, click, type, page state, HTML, and screenshot do not require a key
+- For `browser_extract_content` or the default OpenAI-compatible agent route, verify that `OPENAI_API_KEY` is set and has billing enabled
 
 **Connection Issues in Claude Desktop**
 - Restart Claude Desktop after config changes


### PR DESCRIPTION
Clarifies that direct local MCP browser tools do not need an LLM key. Content extraction uses an OpenAI-compatible key. The autonomous agent tool uses that route by default and also supports configured AWS Bedrock credentials. Removes the unsupported Anthropic-key fallback claim.

Validated the absent-OpenAI/Anthropic-only error and the Bedrock routing branch without provider calls. The Bedrock constructor was replaced by a sentinel for routing only; AWS authentication and inference were not tested. Mint found no broken links, docs.json parsed, and git diff --check passed. The generated LLM-readable mirror was synchronized.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the local MCP server's LLM key requirements so users don't set up unused keys. Direct browser automation tools like navigate, click, type, page state, HTML, and screenshot work without an LLM key; content extraction requires an OpenAI-compatible key, and the default autonomous agent route also uses OpenAI-compatible by default or AWS Bedrock when configured. Removes the unsupported Anthropic-key fallback from environment variables and troubleshooting.

<sup>Written for commit 0dd66943583cd0b04d6080da797f0dcab1510581. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

