### PR TITLE
docs: make free Cloud onboarding explicit and current

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,12 @@ Official SDKs for [Browser Use Cloud](https://browser-use.com).
 
 - **Browser Use Agents:** use the explicit V4 interface to give an agent a task
   and receive its completed result.
-- **Browser Infrastructure:** use the explicit V3 SDK browser resource, or the
+- **Browser Infrastructure:** use the V4 SDK `browsers` resource, or the
   V4 REST API, to create and control a managed browser.
+
+Eligible new Google, GitHub, or Microsoft signups receive a one-time $15 Cloud credit. No credit card is required. Email/password signups are not eligible; the credit does not renew. Start with the default V4 model (`gpt-5.6-luna`); paid-only models require a top-up. See [pricing](https://browser-use.com/pricing.md) for current eligibility and rates.
+
+The Cloud SDK is `browser-use-sdk`, distinct from the open-source `browser-use` library.
 
 | Package | Language | Registry |
 |---------|----------|----------|

--- a/browser-use-node/README.md
+++ b/browser-use-node/README.md
@@ -10,6 +10,8 @@ npm install browser-use-sdk
 
 ## Quick Start
 
+Eligible new Google, GitHub, or Microsoft signups receive a one-time $15 Cloud credit. No credit card is required. Email/password signups are not eligible; the credit does not renew. Start with the default V4 model (`gpt-5.6-luna`); paid-only models require a top-up. See [pricing](https://browser-use.com/pricing.md) for current eligibility and rates.
+
 Get your API key at [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1).
 
 ```bash
@@ -24,12 +26,17 @@ const run = await client.runs.create({
   task: "Find the top 3 trending repos on GitHub today",
 });
 const result = await client.runs.waitForCompletion(run.id);
+if (result.status !== "completed") {
+  throw new Error(`Run ${result.id}: ${result.status}`);
+}
 console.log(result.result);
 ```
 
-This is the current **Browser Use Agents** interface. Browser Infrastructure's
-browser-management resource currently lives in the explicit `browser-use-sdk/v3`
-entry point; see the [browser quickstart](https://docs.browser-use.com/cloud/browser/quickstart).
+This is the current **Browser Use Agents** interface. SDK 3.11.3 or newer also
+exposes `client.browsers.create` and `client.browsers.stop` in `browser-use-sdk/v4`.
+Always stop standalone browsers explicitly; closing a client or disconnecting
+CDP does not stop billing. See the [browser quickstart](https://docs.browser-use.com/cloud/browser/quickstart).
+Existing V2/V3 integrations can keep their versioned imports.
 
 ## v3 Bring Your Own LLM Key
 

--- a/browser-use-python/README.md
+++ b/browser-use-python/README.md
@@ -24,7 +24,7 @@ from browser_use_sdk.v4 import BrowserUse
 with BrowserUse() as client:
     run = client.runs.create("Find the top 3 trending repos on GitHub today")
     result = client.runs.wait_for_completion(run.id)
-    if result.status != "completed":
+    if result.status.value != "completed":
         raise RuntimeError(f"Run {result.id}: {result.status}")
     print(result.result)
 ```

--- a/browser-use-python/README.md
+++ b/browser-use-python/README.md
@@ -10,6 +10,8 @@ uv add browser-use-sdk
 
 ## Quick Start
 
+Eligible new Google, GitHub, or Microsoft signups receive a one-time $15 Cloud credit. No credit card is required. Email/password signups are not eligible; the credit does not renew. Start with the default V4 model (`gpt-5.6-luna`); paid-only models require a top-up. See [pricing](https://browser-use.com/pricing.md) for current eligibility and rates.
+
 Get your API key at [cloud.browser-use.com/settings](https://cloud.browser-use.com/settings?tab=api-keys&new=1).
 
 ```bash
@@ -22,12 +24,16 @@ from browser_use_sdk.v4 import BrowserUse
 with BrowserUse() as client:
     run = client.runs.create("Find the top 3 trending repos on GitHub today")
     result = client.runs.wait_for_completion(run.id)
+    if result.status != "completed":
+        raise RuntimeError(f"Run {result.id}: {result.status}")
     print(result.result)
 ```
 
-This is the current **Browser Use Agents** interface. Browser Infrastructure's
-browser-management resource currently lives in the explicit `browser_use_sdk.v3`
-namespace; see the [browser quickstart](https://docs.browser-use.com/cloud/browser/quickstart).
+This is the current **Browser Use Agents** interface. SDK 3.11.3 or newer also
+exposes `client.browsers.create` and `client.browsers.stop` in `browser_use_sdk.v4`.
+Always stop standalone browsers explicitly; closing a client or disconnecting
+CDP does not stop billing. See the [browser quickstart](https://docs.browser-use.com/cloud/browser/quickstart).
+Existing V2/V3 integrations can keep their versioned imports.
 
 ## v3 Bring Your Own LLM Key
 

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -59,7 +59,8 @@ to disable the managed proxy.
 **Finish the integration:** Create one bounded run with `maxCostUsd`, retain
 its returned ID, and use `runs.waitForCompletion` (TypeScript) or
 `runs.wait_for_completion` (Python). The helpers also return `failed` and
-`cancelled` runs: check `status == "completed"` before consuming `result`.
+`cancelled` runs: check `status === "completed"` (TypeScript) or `status.value == "completed"`
+(Python) before consuming `result`.
 V4 returns a result string; parse and validate structured output in your code.
 A polling timeout does not cancel remote work. Cancel the run explicitly if
 you are abandoning it, and do not blindly retry an ambiguous create request.

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -7,6 +7,8 @@
 > proxies, profiles, and live observability. Auth uses
 > `X-Browser-Use-API-Key` (keys start with `bu_`).
 
+**Start with free credits:** Eligible new Google, GitHub, or Microsoft signups receive a one-time $15 Cloud credit. No credit card is required. Email/password signups are not eligible; the credit does not renew. Start with the default V4 model (`gpt-5.6-luna`); paid-only models require a top-up. See [pricing](https://browser-use.com/pricing.md) for current eligibility and rates.
+
 - Dashboard: https://cloud.browser-use.com
 - Create API key: https://cloud.browser-use.com/settings?tab=api-keys&new=1
 - Docs: https://docs.browser-use.com
@@ -46,14 +48,23 @@ Log in once in that browser, stop it, then use the same profile ID to start the
 next browser already logged in. Full guide:
 https://docs.browser-use.com/cloud/guides/authentication
 
-**Current TypeScript SDK typing:** Pass `model` explicitly. Prefer
-`gpt-5.6-luna`, the recommended V4 model; if the generated union does not yet
-include it, use `grok-4.5` or call `POST /api/v4/runs` directly. Whenever
-`browserSettings` is present, also pass `proxyCountryCode`: use `"us"` to keep
-the default or `null` to disable the managed proxy. New model strings can reach
-REST before the generated TypeScript union. The generated SDK request types do
-not yet expose V4 `modelParams`; use REST for that field until the follow-up SDK
-release.
+**Current SDK (3.11.3 or newer):** V4 exposes `runs`, `sessions`,
+`workspaces`, and `browsers` in both Python and TypeScript. `runs.create`
+accepts an omitted `model` (the default is `gpt-5.6-luna`), and TypeScript
+supports `modelParams`. Upgrade older SDKs instead of switching a free starter
+to a paid-only model. Whenever `browserSettings` is present, current TypeScript
+types still require `proxyCountryCode`: use `"us"` for the default or `null`
+to disable the managed proxy.
+
+**Finish the integration:** Create one bounded run with `maxCostUsd`, retain
+its returned ID, and use `runs.waitForCompletion` (TypeScript) or
+`runs.wait_for_completion` (Python). The helpers also return `failed` and
+`cancelled` runs: check `status == "completed"` before consuming `result`.
+V4 returns a result string; parse and validate structured output in your code.
+A polling timeout does not cancel remote work. Cancel the run explicitly if
+you are abandoning it, and do not blindly retry an ambiguous create request.
+Keep API keys in server-side environment variables, never client bundles or
+prompts. Existing V2/V3 integrations can keep their versioned imports.
 
 Before writing code, check if `browser-use-sdk` is already installed. If so, upgrade to the latest version. If not, install it:
 - Python: `pip install --upgrade browser-use-sdk`

--- a/docs/generate-llms-txt.sh
+++ b/docs/generate-llms-txt.sh
@@ -266,6 +266,8 @@ cat > "$CLOUD_INDEX" << 'HEADER'
 > proxies, profiles, and live observability. Auth uses
 > `X-Browser-Use-API-Key` (keys start with `bu_`).
 
+**Start with free credits:** Eligible new Google, GitHub, or Microsoft signups receive a one-time $15 Cloud credit. No credit card is required. Email/password signups are not eligible; the credit does not renew. Start with the default V4 model (`gpt-5.6-luna`); paid-only models require a top-up. See [pricing](https://browser-use.com/pricing.md) for current eligibility and rates.
+
 - Dashboard: https://cloud.browser-use.com
 - Create API key: https://cloud.browser-use.com/settings?tab=api-keys&new=1
 - Docs: https://docs.browser-use.com
@@ -305,14 +307,23 @@ Log in once in that browser, stop it, then use the same profile ID to start the
 next browser already logged in. Full guide:
 https://docs.browser-use.com/cloud/guides/authentication
 
-**Current TypeScript SDK typing:** Pass `model` explicitly. Prefer
-`gpt-5.6-luna`, the recommended V4 model; if the generated union does not yet
-include it, use `grok-4.5` or call `POST /api/v4/runs` directly. Whenever
-`browserSettings` is present, also pass `proxyCountryCode`: use `"us"` to keep
-the default or `null` to disable the managed proxy. New model strings can reach
-REST before the generated TypeScript union. The generated SDK request types do
-not yet expose V4 `modelParams`; use REST for that field until the follow-up SDK
-release.
+**Current SDK (3.11.3 or newer):** V4 exposes `runs`, `sessions`,
+`workspaces`, and `browsers` in both Python and TypeScript. `runs.create`
+accepts an omitted `model` (the default is `gpt-5.6-luna`), and TypeScript
+supports `modelParams`. Upgrade older SDKs instead of switching a free starter
+to a paid-only model. Whenever `browserSettings` is present, current TypeScript
+types still require `proxyCountryCode`: use `"us"` for the default or `null`
+to disable the managed proxy.
+
+**Finish the integration:** Create one bounded run with `maxCostUsd`, retain
+its returned ID, and use `runs.waitForCompletion` (TypeScript) or
+`runs.wait_for_completion` (Python). The helpers also return `failed` and
+`cancelled` runs: check `status == "completed"` before consuming `result`.
+V4 returns a result string; parse and validate structured output in your code.
+A polling timeout does not cancel remote work. Cancel the run explicitly if
+you are abandoning it, and do not blindly retry an ambiguous create request.
+Keep API keys in server-side environment variables, never client bundles or
+prompts. Existing V2/V3 integrations can keep their versioned imports.
 
 Before writing code, check if `browser-use-sdk` is already installed. If so, upgrade to the latest version. If not, install it:
 - Python: `pip install --upgrade browser-use-sdk`

--- a/docs/generate-llms-txt.sh
+++ b/docs/generate-llms-txt.sh
@@ -318,7 +318,8 @@ to disable the managed proxy.
 **Finish the integration:** Create one bounded run with `maxCostUsd`, retain
 its returned ID, and use `runs.waitForCompletion` (TypeScript) or
 `runs.wait_for_completion` (Python). The helpers also return `failed` and
-`cancelled` runs: check `status == "completed"` before consuming `result`.
+`cancelled` runs: check `status === "completed"` (TypeScript) or `status.value == "completed"`
+(Python) before consuming `result`.
 V4 returns a result string; parse and validate structured output in your code.
 A polling timeout does not cancel remote work. Cancel the run explicitly if
 you are abandoning it, and do not blindly retry an ambiguous create request.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -59,7 +59,8 @@ to disable the managed proxy.
 **Finish the integration:** Create one bounded run with `maxCostUsd`, retain
 its returned ID, and use `runs.waitForCompletion` (TypeScript) or
 `runs.wait_for_completion` (Python). The helpers also return `failed` and
-`cancelled` runs: check `status == "completed"` before consuming `result`.
+`cancelled` runs: check `status === "completed"` (TypeScript) or `status.value == "completed"`
+(Python) before consuming `result`.
 V4 returns a result string; parse and validate structured output in your code.
 A polling timeout does not cancel remote work. Cancel the run explicitly if
 you are abandoning it, and do not blindly retry an ambiguous create request.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -7,6 +7,8 @@
 > proxies, profiles, and live observability. Auth uses
 > `X-Browser-Use-API-Key` (keys start with `bu_`).
 
+**Start with free credits:** Eligible new Google, GitHub, or Microsoft signups receive a one-time $15 Cloud credit. No credit card is required. Email/password signups are not eligible; the credit does not renew. Start with the default V4 model (`gpt-5.6-luna`); paid-only models require a top-up. See [pricing](https://browser-use.com/pricing.md) for current eligibility and rates.
+
 - Dashboard: https://cloud.browser-use.com
 - Create API key: https://cloud.browser-use.com/settings?tab=api-keys&new=1
 - Docs: https://docs.browser-use.com
@@ -46,14 +48,23 @@ Log in once in that browser, stop it, then use the same profile ID to start the
 next browser already logged in. Full guide:
 https://docs.browser-use.com/cloud/guides/authentication
 
-**Current TypeScript SDK typing:** Pass `model` explicitly. Prefer
-`gpt-5.6-luna`, the recommended V4 model; if the generated union does not yet
-include it, use `grok-4.5` or call `POST /api/v4/runs` directly. Whenever
-`browserSettings` is present, also pass `proxyCountryCode`: use `"us"` to keep
-the default or `null` to disable the managed proxy. New model strings can reach
-REST before the generated TypeScript union. The generated SDK request types do
-not yet expose V4 `modelParams`; use REST for that field until the follow-up SDK
-release.
+**Current SDK (3.11.3 or newer):** V4 exposes `runs`, `sessions`,
+`workspaces`, and `browsers` in both Python and TypeScript. `runs.create`
+accepts an omitted `model` (the default is `gpt-5.6-luna`), and TypeScript
+supports `modelParams`. Upgrade older SDKs instead of switching a free starter
+to a paid-only model. Whenever `browserSettings` is present, current TypeScript
+types still require `proxyCountryCode`: use `"us"` for the default or `null`
+to disable the managed proxy.
+
+**Finish the integration:** Create one bounded run with `maxCostUsd`, retain
+its returned ID, and use `runs.waitForCompletion` (TypeScript) or
+`runs.wait_for_completion` (Python). The helpers also return `failed` and
+`cancelled` runs: check `status == "completed"` before consuming `result`.
+V4 returns a result string; parse and validate structured output in your code.
+A polling timeout does not cancel remote work. Cancel the run explicitly if
+you are abandoning it, and do not blindly retry an ambiguous create request.
+Keep API keys in server-side environment variables, never client bundles or
+prompts. Existing V2/V3 integrations can keep their versioned imports.
 
 Before writing code, check if `browser-use-sdk` is already installed. If so, upgrade to the latest version. If not, install it:
 - Python: `pip install --upgrade browser-use-sdk`


### PR DESCRIPTION
Agents reading the Cloud indexes and SDK READMEs miss the eligible $15 signup credit and receive outdated V4 typing and browser-resource guidance. This documents eligibility, the current default model, V4 resources, terminal-status handling, and explicit browser cleanup while preserving legacy imports. Regenerated both indexes, checked the claims against SDK 3.11.3 and signup/model-gating source, and completed an independent review; no paid API calls were made. Runtime code and billing policy are unchanged, and rollback is a docs revert; the browser quickstart remains in #246.

<!-- agent-readiness-images:start -->

Local Markdown renders of exact base/head excerpts; the source file and commit are labeled in each image.

**SDK README**

| BEFORE | AFTER |
| --- | --- |
| ![BEFORE: SDK documentation; SDK README](https://github.com/user-attachments/assets/9054dc50-78a9-4b70-bc76-de2b37c4f4f5) | ![AFTER: SDK documentation; SDK README](https://github.com/user-attachments/assets/913d6b76-1574-4ffd-9ad3-47130659b1bc) |

**Python quickstart**

| BEFORE | AFTER |
| --- | --- |
| ![BEFORE: SDK documentation; Python quickstart](https://github.com/user-attachments/assets/4e392fb9-6b4f-4338-8d1f-bb2916be8b8b) | ![AFTER: SDK documentation; Python quickstart](https://github.com/user-attachments/assets/cdfb6980-6654-4ec7-a1e8-d6cf39be2c6f) |

<!-- agent-readiness-images:end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Cloud SDK docs and LLM indexes so agents and users get current V4 onboarding guidance instead of outdated V3 typing and browser-resource advice.

- Documents the one-time $15 credit for eligible Google, GitHub, or Microsoft signups and the default V4 model `gpt-5.6-luna`.
- Switches browser-infrastructure instructions from the V3 resource to V4 `browsers` create/stop, with explicit cleanup guidance.
- Adds terminal-status checks for run results, including the correct Python status enum comparison, and preserves existing V2/V3 imports.
- Regenerates the `llms.txt` indexes from the updated generation script; runtime code and billing policy are unchanged.

<sup>Written for commit 5157d47ece8673ff53c9d71adec6760f94928d22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->