### PR TITLE
docs: quote alternate video install extras for zsh

### DIFF
--- a/docs/open-source/customize/browser/all-parameters.mdx
+++ b/docs/open-source/customize/browser/all-parameters.mdx
@@ -100,7 +100,7 @@ pip install "browser-use[video]"
 ```
 or:
 ```bash
-pip install imageio[ffmpeg] numpy
+pip install "imageio[ffmpeg]" numpy
 ```
 </Warning>
 

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -2453,7 +2453,7 @@ pip install "browser-use[video]"
 ```
 or:
 ```bash
-pip install imageio[ffmpeg] numpy
+pip install "imageio[ffmpeg]" numpy
 ```
 
 - `record_video_dir`: Directory to save video recordings as `.mp4` files


### PR DESCRIPTION
The alternate video dependency command uses an unquoted imageio[ffmpeg] extra. Default zsh treats the brackets as a filename pattern and fails with no matches found before pip starts.

Quote the requirement and regenerate the open-source full-text copy. The preferred browser-use[video] install command is already quoted and stays unchanged.

Verification uses the literal documented command under zsh -f and bash -f with a local pip function that records arguments. Before: zsh fails before calling pip. After: zsh receives install, imageio[ffmpeg], numpy. Bash receives the same arguments before and after. This is a shell-parsing check; package installation and MP4 recording were not tested.

The generated mirror is deterministic and the docs link check is clean. No dependency or runtime behavior changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quotes the alternate `imageio[ffmpeg]` pip install argument in the video docs so the command works in zsh, which previously failed with "no matches found" before pip ran.

- Updates both the `all-parameters.mdx` page and the regenerated `llms-full.txt` mirror.
- Shell-parsing verified with `zsh -f` and `bash -f`; package installation and MP4 recording were not tested.

<sup>Written for commit de165b6c4e4c44c4e299784b9329d9e72a58fb64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

