### PR TITLE
docs: fix browser storage settings anchor

### DIFF
--- a/docs/open-source/customize/browser/authentication.mdx
+++ b/docs/open-source/customize/browser/authentication.mdx
@@ -49,7 +49,7 @@ await agent.run()
 Export cookies and localStorage from an authenticated browser, then load them in headless mode. Useful for production/CI where you cannot use a real browser profile.
 
 <Info>
-See [Browser Parameters](/open-source/customize/browser/all-parameters#user-data--profiles) for all storage options.
+See [Browser Parameters](/open-source/customize/browser/all-parameters#user-data-&-profiles) for all storage options.
 </Info>
 
 ### Export from Real Browser


### PR DESCRIPTION
Fix the Browser Parameters link on the authentication page. It points to `#user-data--profiles`, but the existing destination heading renders as `#user-data-&-profiles`.

Extract only the one-line correction already present in draft #237. Leave that broader draft, the destination heading, generated text files and all other content unchanged.

Verified the broken source link and actual destination ID in the public HTML. Mintlify's anchor-aware link check passes for both pages after the fix. `git diff --check` passes. One file, one link, no runtime or workflow changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken Browser Parameters link on the authentication page so it now points to the correct heading ID (`#user-data-&-profiles` instead of `#user-data--profiles`).

<sup>Written for commit 624983f10af4f6264ae82d3bdf73abd1a1e5cb32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

