### PR TITLE
docs: make the Pydantic tools example self-contained

### DIFF
--- a/docs/open-source/customize/tools/add.mdx
+++ b/docs/open-source/customize/tools/add.mdx
@@ -102,7 +102,11 @@ Available methods on `Element`:
 You can use Pydantic for the tool parameters:
 
 ```python
-from pydantic import BaseModel
+import json
+from pydantic import BaseModel, Field
+from browser_use import Tools
+
+tools = Tools()
 
 class Cars(BaseModel):
     name: str = Field(description='The name of the car, e.g. "Toyota Camry"')

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -2717,7 +2717,11 @@ Available methods on `Element`:
 You can use Pydantic for the tool parameters:
 
 ```python
-from pydantic import BaseModel
+import json
+from pydantic import BaseModel, Field
+from browser_use import Tools
+
+tools = Tools()
 
 class Cars(BaseModel):
     name: str = Field(description='The name of the car, e.g. "Toyota Camry"')


### PR DESCRIPTION
Adds the missing json, Field and Tools imports and a Tools instance to the Pydantic Input example. Synchronizes the same block in the LLM-readable mirror.

The published block fails standalone with NameError for Field. The corrected literal snippet registers and saves one car, multiple Unicode-named cars and an empty list through actual Tools.act. Invalid prices are rejected before writing. Built-in actions remain registered.

The registry already normalizes Pydantic values to dictionaries before calling save_cars, so json.dump is unchanged. No runtime, serialization, browser or model changes; no browser or model request was made.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Pydantic tools example so it runs standalone without a NameError for `Field`.

- Adds the missing `json`, `Field`, and `Tools` imports plus a `tools = Tools()` instance.
- Mirrors the same change in `docs/open-source/llms-full.txt`.

<sup>Written for commit 1a9d6dd39ebac3916614198293106fa8f4c9b1e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

