### PR TITLE
docs: use generic CAPTCHA wording

### DIFF
--- a/docs/cloud/browser/captcha-handling.mdx
+++ b/docs/cloud/browser/captcha-handling.mdx
@@ -8,7 +8,7 @@ Every Browser Use Cloud browser enables automatic CAPTCHA solving. This applies
 to API V4 Agent runs and standalone Cloud Browser sessions. There is no request
 field to turn on.
 
-The automatic solver handles **reCAPTCHA** challenges. Cloudflare and other bot walls are handled by the browser's stealth layer and residential proxies, not by the CAPTCHA solver.
+The automatic solver handles **CAPTCHAs**. Cloudflare and other bot walls are handled by the browser's stealth layer and residential proxies, not by the CAPTCHA solver.
 
 Other anti-bot pages may still be passed by the browser's stealth protections
 or residential proxy. That is separate from automatic CAPTCHA solver coverage.

--- a/docs/cloud/browser/stealth.mdx
+++ b/docs/cloud/browser/stealth.mdx
@@ -14,7 +14,7 @@ Every cloud browser session runs in a hardened Chromium fork with stealth enable
 - **Ad and cookie banner blocking** — Banners are dismissed automatically so the agent sees clean pages and executes faster.
 - **Cloudflare / anti-bot bypass** — Works on sites protected by Cloudflare, PerimeterX, and other bot detection services.
 
-Cloud browsers also solve reCAPTCHA challenges automatically.
+Cloud browsers also solve CAPTCHAs automatically.
 See [CAPTCHA handling](/cloud/browser/captcha-handling) for what to do when a
 solver is still working or a site has a specific anti-bot issue.
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1182,7 +1182,7 @@ Every cloud browser session runs in a hardened Chromium fork with stealth enable
 - **Ad and cookie banner blocking** — Banners are dismissed automatically so the agent sees clean pages and executes faster.
 - **Cloudflare / anti-bot bypass** — Works on sites protected by Cloudflare, PerimeterX, and other bot detection services.
 
-Cloud browsers also solve reCAPTCHA challenges automatically.
+Cloud browsers also solve CAPTCHAs automatically.
 See [CAPTCHA handling](https://docs.browser-use.com/cloud/browser/captcha-handling) for what to do when a
 solver is still working or a site has a specific anti-bot issue.
 
@@ -1198,7 +1198,7 @@ Every Browser Use Cloud browser enables automatic CAPTCHA solving. This applies
 to API V4 Agent runs and standalone Cloud Browser sessions. There is no request
 field to turn on.
 
-The automatic solver handles **reCAPTCHA** challenges. Cloudflare and other bot walls are handled by the browser's stealth layer and residential proxies, not by the CAPTCHA solver.
+The automatic solver handles **CAPTCHAs**. Cloudflare and other bot walls are handled by the browser's stealth layer and residential proxies, not by the CAPTCHA solver.
 
 Other anti-bot pages may still be passed by the browser's stealth protections
 or residential proxy. That is separate from automatic CAPTCHA solver coverage.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1182,7 +1182,7 @@ Every cloud browser session runs in a hardened Chromium fork with stealth enable
 - **Ad and cookie banner blocking** — Banners are dismissed automatically so the agent sees clean pages and executes faster.
 - **Cloudflare / anti-bot bypass** — Works on sites protected by Cloudflare, PerimeterX, and other bot detection services.
 
-Cloud browsers also solve reCAPTCHA challenges automatically.
+Cloud browsers also solve CAPTCHAs automatically.
 See [CAPTCHA handling](https://docs.browser-use.com/cloud/browser/captcha-handling) for what to do when a
 solver is still working or a site has a specific anti-bot issue.
 
@@ -1198,7 +1198,7 @@ Every Browser Use Cloud browser enables automatic CAPTCHA solving. This applies
 to API V4 Agent runs and standalone Cloud Browser sessions. There is no request
 field to turn on.
 
-The automatic solver handles **reCAPTCHA** challenges. Cloudflare and other bot walls are handled by the browser's stealth layer and residential proxies, not by the CAPTCHA solver.
+The automatic solver handles **CAPTCHAs**. Cloudflare and other bot walls are handled by the browser's stealth layer and residential proxies, not by the CAPTCHA solver.
 
 Other anti-bot pages may still be passed by the browser's stealth protections
 or residential proxy. That is separate from automatic CAPTCHA solver coverage.


### PR DESCRIPTION
## Change

Use “CAPTCHAs” instead of a named challenge type in the CAPTCHA handling and stealth pages. Keep both LLM-readable full-text mirrors in sync.

The existing no-guarantee warning, wait guidance, human-control fallback and separation from stealth remain unchanged. The short llms.txt indexes already use generic wording.

## Validation

- Verified the complete diff contains only the six wording replacements across four documentation files.
- Checked the source paragraphs match both mirrors and that the changed passages contain no named CAPTCHA type.
- Confirmed docs.json parses and existing local page links resolve.

Documentation only. No SDK, API, solver configuration, dependency or package version changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the specific “reCAPTCHA” terminology with generic “CAPTCHAs” across the CAPTCHA handling and stealth pages and their `llms-full.txt` mirrors, so the docs no longer imply support for a single challenge type. This is documentation-only; no code, API, or configuration changes.

<sup>Written for commit f74ba4328619e351d939d94ce0dbc1feb0872d55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

