### PR TITLE
docs: drop GPT-5.6 Sol from the recommended V4 model list

### DIFF
--- a/docs/cloud/agent/models.mdx
+++ b/docs/cloud/agent/models.mdx
@@ -13,7 +13,6 @@ pricing:
 | GPT-5.6 Luna (recommended) | `gpt-5.6-luna` | \$0.24 | \$0.024 | \$1.44 | OpenAI |
 | Claude Opus 5 | `claude-opus-5` | \$6.00 | \$0.60 | \$30.00 | Anthropic |
 | Grok 4.5 | `grok-4.5` | \$2.40 | \$0.36 | \$7.20 | — |
-| GPT-5.6 Sol | `gpt-5.6-sol` | \$6.00 | \$0.60 | \$36.00 | OpenAI |
 | MiniMax M3 | `minimax-m3` | \$0.36 | \$0.072 | \$1.44 | — |
 
 Token prices are USD per 1 million tokens. Browser sessions

--- a/docs/cloud/faq.mdx
+++ b/docs/cloud/faq.mdx
@@ -9,7 +9,6 @@ icon: circle-question
 - **GPT-5.6 Luna** (`gpt-5.6-luna`, recommended) — the best balance of accuracy, speed, and price for most tasks.
 - **Claude Opus 5** (`claude-opus-5`) — maximum intelligence for difficult, long-horizon work.
 - **Grok 4.5** (`grok-4.5`) — a strong general-purpose alternative.
-- **GPT-5.6 Sol** (`gpt-5.6-sol`) — a higher-cost OpenAI option for complex tasks.
 - **MiniMax M3** (`minimax-m3`) — inexpensive for simple and high-volume tasks.
 
 See [Models](/cloud/agent/models) for the complete V4 picker and pricing.


### PR DESCRIPTION
Sol is being removed from every new-task picker in Cloud (browser-use/cloud#5868), so the FAQ and the recommended-models table should stop listing it. It remains a valid API model ID, so the supported-IDs and thinking-levels tables keep it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes GPT-5.6 Sol from the recommended V4 model list in the docs because it's no longer offered in the Cloud pickers. It remains a valid API model ID, so the supported-IDs and thinking-levels tables keep it.

<sup>Written for commit 5e672c80d43a98e9352da8cc4a2958437f29e357. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

