### PR TITLE
docs: remove obsolete custom proxy subscription requirements

### DIFF
--- a/browser-use-node/src/generated/v2/types.ts
+++ b/browser-use-node/src/generated/v2/types.ts
@@ -1131,7 +1131,7 @@ export interface components {
             solveCaptchas: boolean;
             /**
              * Custom Proxy
-             * @description Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription.
+             * @description Custom proxy settings to use for the session. If not provided, our proxies will be used.
              */
             customProxy?: components["schemas"]["CustomProxy"] | null;
             /**
@@ -1186,7 +1186,7 @@ export interface components {
             keepAlive: boolean;
             /**
              * Custom Proxy
-             * @description Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription.
+             * @description Custom proxy settings to use for the session. If not provided, our proxies will be used.
              */
             customProxy?: components["schemas"]["CustomProxy"] | null;
             /**

--- a/browser-use-node/src/generated/v3/types.ts
+++ b/browser-use-node/src/generated/v3/types.ts
@@ -852,7 +852,7 @@ export interface components {
             solveCaptchas: boolean;
             /**
              * Custom Proxy
-             * @description Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription.
+             * @description Custom proxy settings to use for the session. If not provided, our proxies will be used.
              */
             customProxy?: components["schemas"]["CustomProxy"] | null;
             /**

--- a/browser-use-node/src/generated/v4/types.ts
+++ b/browser-use-node/src/generated/v4/types.ts
@@ -857,7 +857,7 @@ export interface components {
             solveCaptchas: boolean;
             /**
              * Custom Proxy
-             * @description Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription.
+             * @description Custom proxy settings to use for the session. If not provided, our proxies will be used.
              */
             customProxy?: components["schemas"]["CustomProxy"] | null;
             /**
@@ -1218,7 +1218,7 @@ export interface components {
              * @default us
              */
             proxyCountryCode: components["schemas"]["ProxyCountryCode"] | null;
-            /** @description Custom proxy for the browser. Overrides proxyCountryCode. Requires an active subscription. Never stored or inherited by follow-up runs; pass it on each run that should use it. */
+            /** @description Custom proxy for the browser. Overrides proxyCountryCode. Never stored or inherited by follow-up runs; pass it on each run that should use it. */
             customProxy?: components["schemas"]["CustomProxy"] | null;
             /**
              * Screenwidth

--- a/browser-use-python/src/browser_use_sdk/generated/v2/models.py
+++ b/browser-use-python/src/browser_use_sdk/generated/v2/models.py
@@ -1553,7 +1553,7 @@ class CreateBrowserSessionRequest(BaseModel):
     custom_proxy: CustomProxy | None = Field(
         None,
         alias='customProxy',
-        description='Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription.',
+        description='Custom proxy settings to use for the session. If not provided, our proxies will be used.',
         title='Custom Proxy',
     )
     enable_recording: bool | None = Field(
@@ -1610,7 +1610,7 @@ class CreateSessionRequest(BaseModel):
     custom_proxy: CustomProxy | None = Field(
         None,
         alias='customProxy',
-        description='Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription.',
+        description='Custom proxy settings to use for the session. If not provided, our proxies will be used.',
         title='Custom Proxy',
     )
     enable_recording: bool | None = Field(

--- a/browser-use-python/src/browser_use_sdk/generated/v3/models.py
+++ b/browser-use-python/src/browser_use_sdk/generated/v3/models.py
@@ -1121,7 +1121,7 @@ class CreateBrowserSessionRequest(BaseModel):
     custom_proxy: CustomProxy | None = Field(
         None,
         alias='customProxy',
-        description='Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription.',
+        description='Custom proxy settings to use for the session. If not provided, our proxies will be used.',
         title='Custom Proxy',
     )
     enable_recording: bool | None = Field(

--- a/browser-use-python/src/browser_use_sdk/generated/v4/models.py
+++ b/browser-use-python/src/browser_use_sdk/generated/v4/models.py
@@ -696,7 +696,7 @@ class RunBrowserSettings(BaseModel):
     custom_proxy: CustomProxy | None = Field(
         None,
         alias='customProxy',
-        description='Custom proxy for the browser. Overrides proxyCountryCode. Requires an active subscription. Never stored or inherited by follow-up runs; pass it on each run that should use it.',
+        description='Custom proxy for the browser. Overrides proxyCountryCode. Never stored or inherited by follow-up runs; pass it on each run that should use it.',
     )
     screen_width: ScreenWidth | None = Field(
         None,
@@ -1185,7 +1185,7 @@ class CreateBrowserSessionRequest(BaseModel):
     custom_proxy: CustomProxy | None = Field(
         None,
         alias='customProxy',
-        description='Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription.',
+        description='Custom proxy settings to use for the session. If not provided, our proxies will be used.',
         title='Custom Proxy',
     )
     enable_recording: bool | None = Field(

--- a/docs/cloud/openapi/v2.json
+++ b/docs/cloud/openapi/v2.json
@@ -3922,7 +3922,7 @@
                             }
                         ],
                         "title": "Custom Proxy",
-                        "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription."
+                        "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used."
                     },
                     "enableRecording": {
                         "type": "boolean",
@@ -4025,7 +4025,7 @@
                             }
                         ],
                         "title": "Custom Proxy",
-                        "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription."
+                        "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used."
                     },
                     "enableRecording": {
                         "type": "boolean",

--- a/docs/cloud/openapi/v3.json
+++ b/docs/cloud/openapi/v3.json
@@ -2336,7 +2336,7 @@
                             }
                         ],
                         "title": "Custom Proxy",
-                        "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription."
+                        "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used."
                     },
                     "enableRecording": {
                         "type": "boolean",

--- a/docs/cloud/openapi/v4.json
+++ b/docs/cloud/openapi/v4.json
@@ -2605,7 +2605,7 @@
                             }
                         ],
                         "title": "Custom Proxy",
-                        "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription."
+                        "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used."
                     },
                     "enableRecording": {
                         "type": "boolean",
@@ -3502,7 +3502,7 @@
                                 "type": "null"
                             }
                         ],
-                        "description": "Custom proxy for the browser. Overrides proxyCountryCode. Requires an active subscription. Never stored or inherited by follow-up runs; pass it on each run that should use it."
+                        "description": "Custom proxy for the browser. Overrides proxyCountryCode. Never stored or inherited by follow-up runs; pass it on each run that should use it."
                     },
                     "screenWidth": {
                         "anyOf": [

--- a/docs/openapi/v2.json
+++ b/docs/openapi/v2.json
@@ -3922,7 +3922,7 @@
               }
             ],
             "title": "Custom Proxy",
-            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription."
+            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used."
           },
           "enableRecording": {
             "type": "boolean",
@@ -4025,7 +4025,7 @@
               }
             ],
             "title": "Custom Proxy",
-            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription."
+            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used."
           },
           "enableRecording": {
             "type": "boolean",

--- a/docs/openapi/v3.json
+++ b/docs/openapi/v3.json
@@ -2336,7 +2336,7 @@
               }
             ],
             "title": "Custom Proxy",
-            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription."
+            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used."
           },
           "enableRecording": {
             "type": "boolean",

--- a/docs/openapi/v4.json
+++ b/docs/openapi/v4.json
@@ -2605,7 +2605,7 @@
               }
             ],
             "title": "Custom Proxy",
-            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription."
+            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used."
           },
           "enableRecording": {
             "type": "boolean",
@@ -3502,7 +3502,7 @@
                 "type": "null"
               }
             ],
-            "description": "Custom proxy for the browser. Overrides proxyCountryCode. Requires an active subscription. Never stored or inherited by follow-up runs; pass it on each run that should use it."
+            "description": "Custom proxy for the browser. Overrides proxyCountryCode. Never stored or inherited by follow-up runs; pass it on each run that should use it."
           },
           "screenWidth": {
             "anyOf": [

--- a/snapshots/v2.json
+++ b/snapshots/v2.json
@@ -3922,7 +3922,7 @@
               }
             ],
             "title": "Custom Proxy",
-            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription."
+            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used."
           },
           "enableRecording": {
             "type": "boolean",
@@ -4025,7 +4025,7 @@
               }
             ],
             "title": "Custom Proxy",
-            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription."
+            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used."
           },
           "enableRecording": {
             "type": "boolean",

--- a/snapshots/v3.json
+++ b/snapshots/v3.json
@@ -2336,7 +2336,7 @@
               }
             ],
             "title": "Custom Proxy",
-            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription."
+            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used."
           },
           "enableRecording": {
             "type": "boolean",

--- a/snapshots/v4.json
+++ b/snapshots/v4.json
@@ -2605,7 +2605,7 @@
               }
             ],
             "title": "Custom Proxy",
-            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used. Custom proxies are available on any active subscription."
+            "description": "Custom proxy settings to use for the session. If not provided, our proxies will be used."
           },
           "enableRecording": {
             "type": "boolean",
@@ -3502,7 +3502,7 @@
                 "type": "null"
               }
             ],
-            "description": "Custom proxy for the browser. Overrides proxyCountryCode. Requires an active subscription. Never stored or inherited by follow-up runs; pass it on each run that should use it."
+            "description": "Custom proxy for the browser. Overrides proxyCountryCode. Never stored or inherited by follow-up runs; pass it on each run that should use it."
           },
           "screenWidth": {
             "anyOf": [


### PR DESCRIPTION
The published API reference still required a subscription for custom proxies after Cloud #5850 enabled access for every account. Remove that obsolete requirement from the V2/V3/V4 snapshots, both docs schema copies, and generated Python/TypeScript descriptions so a docs sync cannot restore it. All five descriptions match the live production APIs; validation confirms the 15-file diff changes only those descriptions, all JSON copies agree, and Python syntax is valid.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the obsolete "active subscription required" wording from custom proxy descriptions in the V2/V3/V4 OpenAPI docs, snapshots, and generated Python/TypeScript SDKs. Custom proxies are now available to every account, so the docs no longer claim otherwise.

- Updates both docs schema copies and all generated client descriptions to match the live production APIs.

<sup>Written for commit f28c52fe675e024ed3c1925c9250a4d287770a44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

