### PR TITLE
docs: clarify custom proxy access and browser request format

### DIFF
--- a/docs/cloud/browser/proxies.mdx
+++ b/docs/cloud/browser/proxies.mdx
@@ -1,6 +1,6 @@
 ---
 title: Proxies
-description: "Route API V4 agent runs through residential or custom proxies."
+description: "Configure residential or custom proxies for API V4 browsers and agent runs."
 icon: globe
 ---
 
@@ -81,7 +81,51 @@ const run = await client.runs.create({
 
 ## Custom proxy
 
-Custom HTTP and SOCKS5 proxies are available on paid plans:
+Custom proxies are available to all accounts, including free and pay-as-you-go
+accounts. No subscription is required. Normal credit, spend, and concurrency
+limits still apply.
+
+The request format depends on what you are creating:
+
+| REST endpoint | Custom proxy field |
+| --- | --- |
+| `POST /api/v4/browsers` | Top-level `customProxy` |
+| `POST /api/v4/runs` | `browserSettings.customProxy` |
+
+`browser_settings` is the Python SDK keyword for agent runs. In REST JSON,
+the agent-run field is `browserSettings`.
+
+### Standalone browsers
+
+For a browser you control with Playwright, Puppeteer, or another CDP client,
+put `customProxy` directly in the request body:
+
+```bash curl
+curl https://api.browser-use.com/api/v4/browsers \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "customProxy": {
+      "host": "proxy.example.com",
+      "port": 8080,
+      "username": "YOUR_PROXY_USERNAME",
+      "password": "YOUR_PROXY_PASSWORD"
+    }
+  }'
+```
+
+Replace the proxy details with yours. Omit both `username` and `password` if
+your proxy does not require authentication. Do not wrap these settings in
+`browserSettings` or `browser_settings` on `/api/v4/browsers`.
+
+Keep the returned browser ID and stop the browser with
+`PATCH /api/v4/browsers/{id}` and `{"action":"stop"}` when finished. See the
+[Create browser reference](/cloud/api-v4/browsers/create-browser-session) and
+[Browser quickstart](/cloud/browser/quickstart).
+
+### Agent runs
+
+For a hosted agent, pass the proxy in the run's browser settings:
 
 <CodeGroup>
 ```python Python

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1291,7 +1291,51 @@ const run = await client.runs.create({
 
 ## Custom proxy
 
-Custom HTTP and SOCKS5 proxies are available on paid plans:
+Custom proxies are available to all accounts, including free and pay-as-you-go
+accounts. No subscription is required. Normal credit, spend, and concurrency
+limits still apply.
+
+The request format depends on what you are creating:
+
+| REST endpoint | Custom proxy field |
+| --- | --- |
+| `POST /api/v4/browsers` | Top-level `customProxy` |
+| `POST /api/v4/runs` | `browserSettings.customProxy` |
+
+`browser_settings` is the Python SDK keyword for agent runs. In REST JSON,
+the agent-run field is `browserSettings`.
+
+### Standalone browsers
+
+For a browser you control with Playwright, Puppeteer, or another CDP client,
+put `customProxy` directly in the request body:
+
+```bash curl
+curl https://api.browser-use.com/api/v4/browsers \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "customProxy": {
+      "host": "proxy.example.com",
+      "port": 8080,
+      "username": "YOUR_PROXY_USERNAME",
+      "password": "YOUR_PROXY_PASSWORD"
+    }
+  }'
+```
+
+Replace the proxy details with yours. Omit both `username` and `password` if
+your proxy does not require authentication. Do not wrap these settings in
+`browserSettings` or `browser_settings` on `/api/v4/browsers`.
+
+Keep the returned browser ID and stop the browser with
+`PATCH /api/v4/browsers/{id}` and `{"action":"stop"}` when finished. See the
+[Create browser reference](https://docs.browser-use.com/cloud/api-v4/browsers/create-browser-session) and
+[Browser quickstart](https://docs.browser-use.com/cloud/browser/quickstart).
+
+### Agent runs
+
+For a hosted agent, pass the proxy in the run's browser settings:
 
 ```python Python
 run = client.runs.create(

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -86,7 +86,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 - [Browser Infrastructure quickstart](https://docs.browser-use.com/cloud/browser/quickstart): Launch a cloud browser and connect to it from your code.
 - [Stealth](https://docs.browser-use.com/cloud/browser/stealth): Best stealth on the planet. We fork Chromium to give agents access to all websites.
 - [CAPTCHA handling](https://docs.browser-use.com/cloud/browser/captcha-handling): Cloud browsers solve supported CAPTCHA challenges automatically.
-- [Proxies](https://docs.browser-use.com/cloud/browser/proxies): Route API V4 agent runs through residential or custom proxies.
+- [Proxies](https://docs.browser-use.com/cloud/browser/proxies): Configure residential or custom proxies for API V4 browsers and agent runs.
 - [Live preview & recording](https://docs.browser-use.com/cloud/browser/live-preview): Watch an API V4 run in real time or record its browser.
 - [Playwright, Puppeteer, Selenium](https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium): Control a Browser Use cloud browser directly over CDP.
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1291,7 +1291,51 @@ const run = await client.runs.create({
 
 ## Custom proxy
 
-Custom HTTP and SOCKS5 proxies are available on paid plans:
+Custom proxies are available to all accounts, including free and pay-as-you-go
+accounts. No subscription is required. Normal credit, spend, and concurrency
+limits still apply.
+
+The request format depends on what you are creating:
+
+| REST endpoint | Custom proxy field |
+| --- | --- |
+| `POST /api/v4/browsers` | Top-level `customProxy` |
+| `POST /api/v4/runs` | `browserSettings.customProxy` |
+
+`browser_settings` is the Python SDK keyword for agent runs. In REST JSON,
+the agent-run field is `browserSettings`.
+
+### Standalone browsers
+
+For a browser you control with Playwright, Puppeteer, or another CDP client,
+put `customProxy` directly in the request body:
+
+```bash curl
+curl https://api.browser-use.com/api/v4/browsers \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "customProxy": {
+      "host": "proxy.example.com",
+      "port": 8080,
+      "username": "YOUR_PROXY_USERNAME",
+      "password": "YOUR_PROXY_PASSWORD"
+    }
+  }'
+```
+
+Replace the proxy details with yours. Omit both `username` and `password` if
+your proxy does not require authentication. Do not wrap these settings in
+`browserSettings` or `browser_settings` on `/api/v4/browsers`.
+
+Keep the returned browser ID and stop the browser with
+`PATCH /api/v4/browsers/{id}` and `{"action":"stop"}` when finished. See the
+[Create browser reference](https://docs.browser-use.com/cloud/api-v4/browsers/create-browser-session) and
+[Browser quickstart](https://docs.browser-use.com/cloud/browser/quickstart).
+
+### Agent runs
+
+For a hosted agent, pass the proxy in the run's browser settings:
 
 ```python Python
 run = client.runs.create(

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -86,7 +86,7 @@ export BROWSER_USE_API_KEY=bu_your_key_here
 - [Browser Infrastructure quickstart](https://docs.browser-use.com/cloud/browser/quickstart): Launch a cloud browser and connect to it from your code.
 - [Stealth](https://docs.browser-use.com/cloud/browser/stealth): Best stealth on the planet. We fork Chromium to give agents access to all websites.
 - [CAPTCHA handling](https://docs.browser-use.com/cloud/browser/captcha-handling): Cloud browsers solve supported CAPTCHA challenges automatically.
-- [Proxies](https://docs.browser-use.com/cloud/browser/proxies): Route API V4 agent runs through residential or custom proxies.
+- [Proxies](https://docs.browser-use.com/cloud/browser/proxies): Configure residential or custom proxies for API V4 browsers and agent runs.
 - [Live preview & recording](https://docs.browser-use.com/cloud/browser/live-preview): Watch an API V4 run in real time or record its browser.
 - [Playwright, Puppeteer, Selenium](https://docs.browser-use.com/cloud/browser/playwright-puppeteer-selenium): Control a Browser Use cloud browser directly over CDP.
 


### PR DESCRIPTION
The Browser proxy guide still required a paid plan and only showed agent-run examples, which can lead standalone-browser users to nest customProxy incorrectly. State that all accounts can use custom proxies subject to normal credits and limits, distinguish the two REST request shapes, and add a standalone-browser curl example plus cleanup guidance. Regenerate the Cloud llms indexes and full-text mirrors. Mintlify build validation passes, Python and curl syntax checks pass, and the new browser payload matches the live production schema.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the proxies guide so custom proxy usage is accurate for standalone browsers and agent runs; the guide previously said custom proxies required a paid plan and only showed agent-run examples, and it now documents that all accounts, including free and pay-as-you-go, can use them. No API or runtime behavior changes.

- States normal credit, spend, and concurrency limits still apply.
- Documents top-level `customProxy` for `POST /api/v4/browsers` and `browserSettings.customProxy` for `POST /api/v4/runs`.
- Clarifies that the Python SDK `browser_settings` keyword maps to REST `browserSettings` for agent runs.
- Adds a curl example for standalone browsers and browser cleanup steps.
- Regenerates the Cloud and root `llms.txt` and `llms-full.txt` mirrors.

<sup>Written for commit 81082fd320c602887bf4b7eb1dfa97d12fb71a71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

