### PR TITLE
docs: use supported managed AI exports and retire stale asset links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,9 +6,13 @@ The public site is built from this directory on `main`.
 
 Mintlify generates `/llms.txt` and `/llms-full.txt` from the documentation and navigation. Do not check in static copies: they override the managed files and become stale. Site-wide AI guidance lives in `markdown.instructions` in `docs.json`. Put detailed guidance in navigable MDX pages so it appears in both human docs and AI exports.
 
-The former `/cloud/llms*.txt` and `/open-source/llms*.txt` URLs serve small compatibility indexes linking to the managed root exports, which cover both products. Mintlify serves `.txt` assets through a static handler that bypasses page redirects; keep these pointers, not duplicated documentation bundles. Use `/llms.txt` for new links. Bux is retired; its old documentation routes redirect to the current product guide.
+Use `/llms.txt` for the current index and `/.well-known/llms-full.txt` for the managed full bundle. Mintlify supports both root and `.well-known` managed exports on this site. Full bundles may be cached for up to 24 hours; use the index and individual `.md` pages when freshness matters.
 
-After publishing, check the normal public URLs (without relying only on a preview): `/llms.txt`, `/llms-full.txt`, the scoped compatibility indexes, and the changed `.md` pages. Mintlify or CDN caches can delay visibility.
+Do not restore `/cloud/llms*.txt` or `/open-source/llms*.txt` as static files. This site uses Mintlify Pro, while static `.txt` asset publishing requires Enterprise. Preview assets can work even though production retains a legacy asset. Page redirects also bypass these static routes. Old scoped URLs still serving historical files require Mintlify-side cleanup; neither a normal deploy nor the manual rebuild on September 9 refreshed them. The supported managed exports avoid this limitation without a plan change.
+
+Bux is retired; its old documentation routes redirect to the current product guide.
+
+After publishing, check the normal public URLs (without relying only on a preview): `/llms.txt`, `/.well-known/llms-full.txt`, the Bux redirects, and the changed `.md` pages. Mintlify or CDN caches can delay visibility.
 
 ## Validation
 

--- a/docs/cloud/llms-full.txt
+++ b/docs/cloud/llms-full.txt
@@ -1,8 +1,0 @@
-# Browser Use Cloud documentation has moved
-
-> This compatibility index points to the current, automatically maintained documentation. Fetch the linked export before answering API, concurrency, or billing questions. This file intentionally contains no copied documentation.
-
-- [Current documentation index](https://docs.browser-use.com/llms.txt): Discover Cloud and Open Source pages and their API versions.
-- [Current full documentation](https://docs.browser-use.com/llms-full.txt): Read the complete current documentation and shared agent guidance.
-
-Use the Cloud sections for this product. Cloud SDK and Open Source library APIs are different.

--- a/docs/cloud/llms.txt
+++ b/docs/cloud/llms.txt
@@ -1,8 +1,0 @@
-# Browser Use Cloud documentation has moved
-
-> This compatibility index points to the current, automatically maintained documentation. Fetch the linked export before answering API, concurrency, or billing questions. This file intentionally contains no copied documentation.
-
-- [Current documentation index](https://docs.browser-use.com/llms.txt): Discover Cloud and Open Source pages and their API versions.
-- [Current full documentation](https://docs.browser-use.com/llms-full.txt): Read the complete current documentation and shared agent guidance.
-
-Use the Cloud sections for this product. Cloud SDK and Open Source library APIs are different.

--- a/docs/cloud/vibecoding.mdx
+++ b/docs/cloud/vibecoding.mdx
@@ -12,4 +12,6 @@ https://docs.browser-use.com/llms.txt
 
 Ask it to use the **Cloud** pages and **API V4** for a new hosted agent integration. The open-source library has a separate API.
 
-The index links to Markdown pages and API specifications. For a single bundle of documentation, use [llms-full.txt](https://docs.browser-use.com/llms-full.txt). Both exports update with the documentation and include guidance on [concurrency](/cloud/guides/concurrency) and [billing](/cloud/guides/billing).
+The index links to Markdown pages and API specifications. For a single bundle of documentation, use [llms-full.txt](https://docs.browser-use.com/.well-known/llms-full.txt). These managed exports include guidance on [concurrency](/cloud/guides/concurrency) and [billing](/cloud/guides/billing).
+
+Full bundles can be cached for up to 24 hours. For the freshest guidance, have your agent follow the index to the linked `.md` pages. Use these managed exports instead of the older `/cloud/llms*.txt` or `/open-source/llms*.txt` URLs.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1175,6 +1175,7 @@
   "description": "Documentation for Browser Use Cloud Agent and Browser APIs, and the separate open-source Python library.",
   "markdown": {
     "instructions": [
+      "Use https://docs.browser-use.com/llms.txt and its linked .md pages for current documentation. The managed full bundle is https://docs.browser-use.com/.well-known/llms-full.txt and can be cached for up to 24 hours. Do not use the obsolete /cloud/llms*.txt or /open-source/llms*.txt static exports.",
       "Choose Cloud API V4 for new agent integrations; V2 is the lower-cost option for simple tasks. Keep V3 examples explicitly versioned. The open-source browser-use library and hosted browser-use-sdk have different APIs.",
       "Cloud authentication uses X-Browser-Use-API-Key, without a Bearer prefix. Install or upgrade browser-use-sdk and use its explicit v4 import for V4. Check the published OpenAPI reference for request fields; do not invent SDK support for new fields.",
       "Cloud concurrency and HTTP request rate are separate. Read GET /api/v2/billing/account for the key’s projectId, concurrentSessionLimit, activeSessionCount, and credit balance, including when using V4. Keys in one project share capacity and credits; rateLimit is a legacy concurrency alias, not requests per second.",

--- a/docs/open-source/llms-full.txt
+++ b/docs/open-source/llms-full.txt
@@ -1,8 +1,0 @@
-# Browser Use Open Source documentation has moved
-
-> This compatibility index points to the current, automatically maintained documentation. Fetch the linked export before answering API, concurrency, or billing questions. This file intentionally contains no copied documentation.
-
-- [Current documentation index](https://docs.browser-use.com/llms.txt): Discover Cloud and Open Source pages and their API versions.
-- [Current full documentation](https://docs.browser-use.com/llms-full.txt): Read the complete current documentation and shared agent guidance.
-
-Use the Open Source sections for this product. Cloud SDK and Open Source library APIs are different.

--- a/docs/open-source/llms.txt
+++ b/docs/open-source/llms.txt
@@ -1,8 +1,0 @@
-# Browser Use Open Source documentation has moved
-
-> This compatibility index points to the current, automatically maintained documentation. Fetch the linked export before answering API, concurrency, or billing questions. This file intentionally contains no copied documentation.
-
-- [Current documentation index](https://docs.browser-use.com/llms.txt): Discover Cloud and Open Source pages and their API versions.
-- [Current full documentation](https://docs.browser-use.com/llms-full.txt): Read the complete current documentation and shared agent guidance.
-
-Use the Open Source sections for this product. Cloud SDK and Open Source library APIs are different.


### PR DESCRIPTION
Production checks after #261 found that scoped static `.txt` assets still came from Mintlify's legacy store, even after a successful manual rebuild. Their compatibility indexes worked in previews but were not published on the live Pro site. Mintlify documents static `.txt` publishing as Enterprise-only; managed root and `.well-known` AI exports are supported.

Remove the ineffective scoped static files. Point readers and agent instructions to `/llms.txt`, its current `.md` pages, and the verified current `/.well-known/llms-full.txt` bundle. Document the bundle's 24-hour cache and the legacy URLs' remaining Mintlify-side cleanup requirement. No hosting plan or runtime billing changes.

Validation: the public index and `.well-known` bundle contain the new concurrency/billing guidance; all six public OpenAPI files match production; the three corrected examples and Bux redirect are live. The old scoped assets and cached root full bundle remain explicitly documented hosting limitations, not claimed successful redirects.

References: https://www.mintlify.com/docs/create/files and https://www.mintlify.com/docs/ai/llmstxt.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes stale scoped `.txt` compatibility assets that never published on the live Mintlify Pro site and points agent instructions to the supported managed exports.

- Static `.txt` asset publishing is Enterprise-only; the removed `/cloud/llms*.txt` and `/open-source/llms*.txt` files worked in previews but were served from a legacy store on production.
- Updates `docs/README.md`, `docs/docs.json`, and `docs/cloud/vibecoding.mdx` to reference `/llms.txt` and `/.well-known/llms-full.txt` and document the full bundle's 24-hour cache.
- Legacy scoped URLs still serving historical files require Mintlify-side cleanup; no plan change is needed.

<sup>Written for commit 7d70fd6ac91fc651a1116bff9d9f965cea48e8d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

