### PR TITLE
Explain how to fetch a fresh full docs snapshot

### DIFF
--- a/docs/cloud/vibecoding.mdx
+++ b/docs/cloud/vibecoding.mdx
@@ -15,3 +15,15 @@ Ask it to use the **Cloud** pages and **API V4** for a new hosted agent integrat
 The index links to Markdown pages and API specifications. For a single bundle of documentation, use [llms-full.txt](https://docs.browser-use.com/.well-known/llms-full.txt). These managed exports include guidance on [concurrency](/cloud/guides/concurrency) and [billing](/cloud/guides/billing).
 
 Full bundles can be cached for up to 24 hours. For the freshest guidance, have your agent follow the index to the linked `.md` pages. Use these managed exports instead of the older `/cloud/llms*.txt` or `/open-source/llms*.txt` URLs.
+
+If you need a full snapshot immediately after a docs update, fetch the bundle
+with a fresh query value:
+
+```bash
+curl --fail --location \
+  "https://docs.browser-use.com/llms-full.txt?updated=$(date +%s)" \
+  --output browser-use-docs.txt
+```
+
+This requests a fresh cache entry; it does not update a copy your coding agent
+already downloaded. Replace that copy or ask the agent to fetch it again.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -425,6 +425,22 @@
   },
   "redirects": [
     {
+      "source": "/cloud/llms.txt",
+      "destination": "/llms.txt"
+    },
+    {
+      "source": "/cloud/llms-full.txt",
+      "destination": "/llms-full.txt"
+    },
+    {
+      "source": "/open-source/llms.txt",
+      "destination": "/llms.txt"
+    },
+    {
+      "source": "/open-source/llms-full.txt",
+      "destination": "/llms-full.txt"
+    },
+    {
       "source": "/",
       "destination": "/cloud/quickstart"
     },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -425,22 +425,6 @@
   },
   "redirects": [
     {
-      "source": "/cloud/llms.txt",
-      "destination": "/llms.txt"
-    },
-    {
-      "source": "/cloud/llms-full.txt",
-      "destination": "/llms-full.txt"
-    },
-    {
-      "source": "/open-source/llms.txt",
-      "destination": "/llms.txt"
-    },
-    {
-      "source": "/open-source/llms-full.txt",
-      "destination": "/llms-full.txt"
-    },
-    {
       "source": "/",
       "destination": "/cloud/quickstart"
     },


### PR DESCRIPTION
The generated full documentation bundle can remain cached after updated pages and the compact index are live. Show how to request a fresh full snapshot and remind readers to replace the copy already downloaded by their coding agent. Chrome and curl checks returned the latest content with a fresh query, and Mintlify validation and link checks pass.
