### PR TITLE
docs: fix browser lifecycle in the entry quickstart

### DIFF
--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -26,7 +26,7 @@ export BROWSER_USE_API_KEY=your_key
 
 ## Install the SDK
 
-Skip this step if you use curl.
+Use Python 3.10 or newer for the Python SDK. Skip installation if you use curl.
 
 <CodeGroup>
 ```bash Python
@@ -68,67 +68,59 @@ curl https://api.browser-use.com/api/v4/runs \
 
 ## Use Browser Infrastructure
 
-Launch a browser, connect to its CDP URL, then stop it:
+These examples connect to the managed browser's existing context and stop it
+in `finally`, including when connecting or navigating fails.
 
 <CodeGroup>
 ```python Python
 from browser_use_sdk.v4 import BrowserUse
 from playwright.sync_api import sync_playwright
 
-client = BrowserUse()
-browser = client.browsers.create(proxy_country_code="us")
-print(browser.cdp_url)
-
-with sync_playwright() as p:
-    chrome = p.chromium.connect_over_cdp(browser.cdp_url)
-    page = chrome.new_page()
-    page.goto("https://example.com")
-    print(page.title())
-
-# When finished:
-client.browsers.stop(browser.id)
+with BrowserUse() as client:
+    session = client.browsers.create(proxy_country_code="us")
+    try:
+        if not session.cdp_url:
+            raise RuntimeError("The browser did not return a CDP URL")
+        with sync_playwright() as p:
+            browser = p.chromium.connect_over_cdp(session.cdp_url)
+            context = browser.contexts[0]
+            page = context.pages[0] if context.pages else context.new_page()
+            page.goto("https://example.com")
+            print(page.title())
+    finally:
+        client.browsers.stop(session.id)
 ```
 ```typescript TypeScript
 import { BrowserUse } from "browser-use-sdk/v4";
 import puppeteer from "puppeteer-core";
 
 const client = new BrowserUse();
-const browser = await client.browsers.create({ proxyCountryCode: "us" });
-console.log(browser.cdpUrl);
-
-const chrome = await puppeteer.connect({
-  browserWSEndpoint: browser.cdpUrl,
-});
-const page = await chrome.newPage();
-await page.goto("https://example.com");
-console.log(await page.title());
-
-// When finished:
-await client.browsers.stop(browser.id);
-```
-```bash curl
-browser=$(curl -sS https://api.browser-use.com/api/v4/browsers \
-  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"proxyCountryCode":"us"}')
-
-export BROWSER_SESSION_ID=$(echo "$browser" | jq -r .id)
-export BROWSER_USE_CDP_URL=$(echo "$browser" | jq -r .cdpUrl)
-
-# Connect Playwright or Puppeteer to $BROWSER_USE_CDP_URL, then stop:
-curl -X PATCH \
-  "https://api.browser-use.com/api/v4/browsers/$BROWSER_SESSION_ID" \
-  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"action":"stop"}'
+const session = await client.browsers.create({ proxyCountryCode: "us" });
+try {
+  if (!session.cdpUrl) throw new Error("The browser did not return a CDP URL");
+  const browser = await puppeteer.connect({ browserWSEndpoint: session.cdpUrl });
+  try {
+    const context = browser.defaultBrowserContext();
+    const page = (await context.pages())[0] ?? await context.newPage();
+    await page.goto("https://example.com");
+    console.log(await page.title());
+  } finally {
+    await browser.disconnect();
+  }
+} finally {
+  await client.browsers.stop(session.id);
+}
 ```
 </CodeGroup>
 
 <Warning>
-  Closing Playwright, Puppeteer, or CDP does not stop the browser. Use
-  `client.browsers.stop(browser.id)` or call `PATCH /api/v4/browsers/{id}` with
-  `{"action":"stop"}`.
+  Disconnecting CDP does not stop the managed browser. Use
+  `client.browsers.stop(session.id)` as above, or call
+  `PATCH /api/v4/browsers/{id}` with `{"action":"stop"}`.
 </Warning>
+
+For curl and additional connection options, follow the
+[Browser Infrastructure quickstart](/cloud/browser/quickstart#launch-and-connect).
 
 <Card title="Copy for an LLM" icon="sparkles" href="https://docs.browser-use.com/llms.txt">
   Give your coding agent the compact API V4 context.


### PR DESCRIPTION
The top-level Cloud quickstart still used a fresh Playwright context and skipped browser cleanup when CDP or navigation failed. Reuse the tested V4 examples from the Browser Infrastructure guide: connect to the existing context, handle an empty page list, and stop the managed browser in finally. Link to the canonical curl workflow instead of repeating its premature stop step, and state Python 3.10+ explicitly. Both browser snippets are byte-identical to the examples already tested against published SDK 3.11.3 with success and failure scenarios; Mintlify build and browser preview are checked before merge.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Cloud quickstart browser lifecycle examples to reuse the tested V4 pattern: connect to the existing context, handle an empty page list, and stop the managed browser in `finally` so cleanup runs even on failure. Replaces the inline curl snippet with a link to the canonical workflow and states Python 3.10+ explicitly.

<sup>Written for commit 698bb4c62a9069c27a62c5864f9b8a9ce90fae7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

