### PR TITLE
Reduce V4 event-wait polling to five seconds

### DIFF
--- a/browser-use-node/src/v4/resources/runs.ts
+++ b/browser-use-node/src/v4/resources/runs.ts
@@ -34,9 +34,9 @@ export interface RunEventsParams {
 }
 
 export interface WaitOptions {
-  /** Maximum time to wait in milliseconds. Default: 14_400_000 (4 hours). */
+  /** Maximum wait in milliseconds: completion defaults to 14_400_000, events to 300_000. */
   timeout?: number;
-  /** Polling interval in milliseconds. Default: 2_000. */
+  /** Polling interval in milliseconds: completion defaults to 2_000, events to 5_000. */
   interval?: number;
 }
 
@@ -71,14 +71,17 @@ export class Runs {
     );
   }
 
-  /** Poll events until the requested type appears (5-minute timeout, 1-second interval). */
+  /**
+   * Poll immediately, then every 5 seconds until the requested event appears (5-minute timeout).
+   * Event reads share the project's general request budget; tune interval across concurrent waits.
+   */
   async waitForEvent(
     runId: string,
     type: string,
     options?: WaitOptions & RunEventsParams,
   ): Promise<RunEvent> {
     const timeout = options?.timeout ?? 300_000;
-    const interval = options?.interval ?? 1_000;
+    const interval = options?.interval ?? 5_000;
     const deadline = Date.now() + timeout;
     let after = options?.after ?? null;
 

--- a/browser-use-node/tests/v4.test.ts
+++ b/browser-use-node/tests/v4.test.ts
@@ -138,6 +138,31 @@ describe("v4 runs.waitForCompletion", () => {
 });
 
 describe("v4 runs.waitForEvent", () => {
+  it.each([
+    [undefined, 300_000, 5_000],
+    [500, 300_000, 500],
+    [undefined, 2_000, 2_000],
+  ])("paces event reads and bounds sleep by the remaining timeout (%s, %s)", async (interval, timeout, expected) => {
+    vi.useFakeTimers();
+    try {
+      const http = { get: vi.fn()
+        .mockResolvedValueOnce({ events: [], nextAfter: 7, hasMore: false })
+        .mockResolvedValueOnce({
+          events: [{ runId: RUN_ID, id: 8, ts: "2026-01-01T00:00:00Z", type: "browser.ready", data: {} }],
+          nextAfter: 8, hasMore: false,
+        }) };
+      const pending = new Runs(http as any).waitForEvent(RUN_ID, "browser.ready", { interval, timeout });
+      expect(http.get).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(expected - 1);
+      expect(http.get).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect((await pending).id).toBe(8);
+      expect(http.get).toHaveBeenLastCalledWith(`/runs/${RUN_ID}/events`, { after: 7, limit: 100 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("returns browser.ready before any terminal-status wait", async () => {
     const http = { get: vi.fn(async (_path: string, query?: Record<string, unknown>) =>
       query?.after === 1

--- a/browser-use-python/src/browser_use_sdk/v4/resources/runs.py
+++ b/browser-use-python/src/browser_use_sdk/v4/resources/runs.py
@@ -193,11 +193,15 @@ class Runs:
         event_type: str,
         *,
         timeout: float = 300,
-        interval: float = 1,
+        interval: float = 5,
         after: int | None = None,
         limit: int = 100,
     ) -> RunEvent:
-        """Poll run events until ``event_type`` appears."""
+        """Poll immediately, then every five seconds until ``event_type`` appears.
+
+        Event reads share the project's general request budget. Set ``interval``
+        in seconds to tune latency and traffic across concurrent waits.
+        """
         deadline = time.monotonic() + timeout
         while True:
             page = self.events(run_id, after=after, limit=limit)
@@ -363,11 +367,15 @@ class AsyncRuns:
         event_type: str,
         *,
         timeout: float = 300,
-        interval: float = 1,
+        interval: float = 5,
         after: int | None = None,
         limit: int = 100,
     ) -> RunEvent:
-        """Poll run events until ``event_type`` appears."""
+        """Poll immediately, then every five seconds until ``event_type`` appears.
+
+        Event reads share the project's general request budget. Set ``interval``
+        in seconds to tune latency and traffic across concurrent waits.
+        """
         deadline = time.monotonic() + timeout
         while True:
             page = await self.events(run_id, after=after, limit=limit)

--- a/browser-use-python/tests/test_v4.py
+++ b/browser-use-python/tests/test_v4.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
 from uuid import UUID
 
 import httpx
@@ -352,6 +353,40 @@ def test_wait_for_event_stops_when_run_ends_first() -> None:
         assert len(async_http.calls) == 1
 
     asyncio.run(run())
+
+
+@pytest.mark.parametrize("interval,timeout,expected", [(None, 300, 5), (0.5, 300, 0.5), (None, 2, 2)])
+@pytest.mark.parametrize("is_async", [False, True])
+def test_event_wait_cadence_and_timeout_bound(interval, timeout, expected, is_async) -> None:
+    pages = [
+        {"events": [], "nextAfter": 7, "hasMore": False},
+        {
+            "events": [{"runId": RUN_ID, "id": 8, "ts": "2026-01-01T00:00:00Z",
+                        "type": "browser.ready", "data": {}}],
+            "nextAfter": 8, "hasMore": False,
+        },
+    ]
+    options = {"timeout": timeout}
+    if interval is not None:
+        options["interval"] = interval
+    module = "browser_use_sdk.v4.resources.runs"
+    with patch(f"{module}.time.monotonic", return_value=0):
+        if is_async:
+            http = FakeAsyncHttp(pages)
+            sleep = AsyncMock()
+            with patch(f"{module}.asyncio.sleep", sleep):
+                event = asyncio.run(AsyncRuns(http).wait_for_event(  # type: ignore[arg-type]
+                    RUN_ID, "browser.ready", **options
+                ))
+            sleep.assert_awaited_once_with(expected)
+        else:
+            http = FakeSyncHttp(pages)
+            sleep = Mock()
+            with patch(f"{module}.time.sleep", sleep):
+                event = Runs(http).wait_for_event(RUN_ID, "browser.ready", **options)  # type: ignore[arg-type]
+            sleep.assert_called_once_with(expected)
+    assert event.id == 8
+    assert http.calls[-1][3] == {"after": 7, "limit": 100}
 
 
 # ---------------------------------------------------------------------------

--- a/docs/cloud/browser/live-preview.mdx
+++ b/docs/cloud/browser/live-preview.mdx
@@ -13,7 +13,7 @@ from browser_use_sdk.v4 import BrowserUse
 
 client = BrowserUse()
 run = client.runs.create("Find the top Hacker News story")
-ready = client.runs.wait_for_event(run.id, "browser.ready")
+ready = client.runs.wait_for_event(run.id, "browser.ready", interval=5)
 print(ready.data["live_view_url"])
 ```
 ```typescript TypeScript
@@ -24,10 +24,16 @@ const run = await client.runs.create({
   task: "Find the top Hacker News story",
   model: "grok-4.5",
 });
-const ready = await client.runs.waitForEvent(run.id, "browser.ready");
+const ready = await client.runs.waitForEvent(run.id, "browser.ready", { interval: 5_000 });
 console.log(ready.data.live_view_url);
 ```
 </CodeGroup>
+
+These examples poll immediately, then every five seconds (Python uses seconds;
+TypeScript uses milliseconds). Setting the interval explicitly also reduces
+traffic on older SDK releases whose event default is one second. Event reads
+share the project's general request budget; [stagger concurrent
+waits](/cloud/guides/concurrency#when-you-need-events) and leave room for other calls.
 
 The helper advances the event cursor and times out after five minutes. See [run
 events](/cloud/agent/observability) for the full event stream and custom polling.

--- a/docs/cloud/guides/concurrency.mdx
+++ b/docs/cloud/guides/concurrency.mdx
@@ -160,6 +160,17 @@ Set a request budget across all event streams in the project. For example, polli
 
 Spread poll times so that every worker does not send its request on the same clock tick. A per-project limiter in your application is more predictable than each worker independently retrying.
 
+For SDK event waits, set `wait_for_event(..., interval=5)` in Python or
+`waitForEvent(..., { interval: 5_000 })` in TypeScript. This also works on SDK
+3.11.3, whose event-wait default is one second. One hundred waits at a
+five-second interval average 20 event requests per second; creates, pagination,
+and other general requests still share the standard 25 RPS budget. Higher
+parallelism needs a larger interval or a shared request scheduler.
+
+The event-wait helper pauses between pages too. For an old run with a large
+event history, start from a known cursor or implement paginated reads within
+your shared request budget; a longer interval also makes backlog traversal slower.
+
 ## Diagnose errors before retrying
 
 | Response | Likely meaning | What to do |


### PR DESCRIPTION
V4 event waits currently poll every second and can exhaust the shared general request budget when many runs wait concurrently. Change Python sync/async and TypeScript defaults to five seconds, preserving the immediate first read, explicit interval overrides, cursor handling, and timeout. Update live-preview and concurrency guidance with explicit intervals that also work on released SDKs; lower request volume trades off slower event discovery and paginated catch-up. All 36 Python and 29 Node V4 tests pass, as do the changed Python files' type checks, Node type checking, and the Node package build; independent review found no blocking defects.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces V4 event-wait polling from one second to five seconds in Python sync/async and TypeScript so many concurrent waits no longer exhaust the shared general request budget. The first read still happens immediately; explicit interval overrides, cursor handling, and timeouts are unchanged. The trade-off is slower event discovery and paginated catch-up.

- Updates live-preview and concurrency docs with explicit intervals that also work on older SDK releases.
- Adds timing tests for sync and async event waits.

<sup>Written for commit 2aaf9d37872ba631e2c1eded837ef47ed2101cf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

