### PR TITLE
Set V4 event-wait polling to three seconds

### DIFF
--- a/browser-use-node/src/v4/resources/runs.ts
+++ b/browser-use-node/src/v4/resources/runs.ts
@@ -36,7 +36,7 @@ export interface RunEventsParams {
 export interface WaitOptions {
   /** Maximum wait in milliseconds: completion defaults to 14_400_000, events to 300_000. */
   timeout?: number;
-  /** Polling interval in milliseconds: completion defaults to 2_000, events to 5_000. */
+  /** Polling interval in milliseconds: completion defaults to 2_000, events to 3_000. */
   interval?: number;
 }
 
@@ -72,7 +72,7 @@ export class Runs {
   }
 
   /**
-   * Poll immediately, then every 5 seconds until the requested event appears (5-minute timeout).
+   * Poll immediately, then every 3 seconds until the requested event appears (5-minute timeout).
    * Event reads share the project's general request budget; tune interval across concurrent waits.
    */
   async waitForEvent(
@@ -81,7 +81,7 @@ export class Runs {
     options?: WaitOptions & RunEventsParams,
   ): Promise<RunEvent> {
     const timeout = options?.timeout ?? 300_000;
-    const interval = options?.interval ?? 5_000;
+    const interval = options?.interval ?? 3_000;
     const deadline = Date.now() + timeout;
     let after = options?.after ?? null;
 

--- a/browser-use-node/tests/v4.test.ts
+++ b/browser-use-node/tests/v4.test.ts
@@ -139,7 +139,7 @@ describe("v4 runs.waitForCompletion", () => {
 
 describe("v4 runs.waitForEvent", () => {
   it.each([
-    [undefined, 300_000, 5_000],
+    [undefined, 300_000, 3_000],
     [500, 300_000, 500],
     [undefined, 2_000, 2_000],
   ])("paces event reads and bounds sleep by the remaining timeout (%s, %s)", async (interval, timeout, expected) => {

--- a/browser-use-python/src/browser_use_sdk/v4/resources/runs.py
+++ b/browser-use-python/src/browser_use_sdk/v4/resources/runs.py
@@ -193,11 +193,11 @@ class Runs:
         event_type: str,
         *,
         timeout: float = 300,
-        interval: float = 5,
+        interval: float = 3,
         after: int | None = None,
         limit: int = 100,
     ) -> RunEvent:
-        """Poll immediately, then every five seconds until ``event_type`` appears.
+        """Poll immediately, then every three seconds until ``event_type`` appears.
 
         Event reads share the project's general request budget. Set ``interval``
         in seconds to tune latency and traffic across concurrent waits.
@@ -367,11 +367,11 @@ class AsyncRuns:
         event_type: str,
         *,
         timeout: float = 300,
-        interval: float = 5,
+        interval: float = 3,
         after: int | None = None,
         limit: int = 100,
     ) -> RunEvent:
-        """Poll immediately, then every five seconds until ``event_type`` appears.
+        """Poll immediately, then every three seconds until ``event_type`` appears.
 
         Event reads share the project's general request budget. Set ``interval``
         in seconds to tune latency and traffic across concurrent waits.

--- a/browser-use-python/tests/test_v4.py
+++ b/browser-use-python/tests/test_v4.py
@@ -355,7 +355,7 @@ def test_wait_for_event_stops_when_run_ends_first() -> None:
     asyncio.run(run())
 
 
-@pytest.mark.parametrize("interval,timeout,expected", [(None, 300, 5), (0.5, 300, 0.5), (None, 2, 2)])
+@pytest.mark.parametrize("interval,timeout,expected", [(None, 300, 3), (0.5, 300, 0.5), (None, 2, 2)])
 @pytest.mark.parametrize("is_async", [False, True])
 def test_event_wait_cadence_and_timeout_bound(interval, timeout, expected, is_async) -> None:
     pages = [

--- a/docs/cloud/browser/live-preview.mdx
+++ b/docs/cloud/browser/live-preview.mdx
@@ -13,7 +13,7 @@ from browser_use_sdk.v4 import BrowserUse
 
 client = BrowserUse()
 run = client.runs.create("Find the top Hacker News story")
-ready = client.runs.wait_for_event(run.id, "browser.ready", interval=5)
+ready = client.runs.wait_for_event(run.id, "browser.ready", interval=3)
 print(ready.data["live_view_url"])
 ```
 ```typescript TypeScript
@@ -24,12 +24,12 @@ const run = await client.runs.create({
   task: "Find the top Hacker News story",
   model: "grok-4.5",
 });
-const ready = await client.runs.waitForEvent(run.id, "browser.ready", { interval: 5_000 });
+const ready = await client.runs.waitForEvent(run.id, "browser.ready", { interval: 3_000 });
 console.log(ready.data.live_view_url);
 ```
 </CodeGroup>
 
-These examples poll immediately, then every five seconds (Python uses seconds;
+These examples poll immediately, then every three seconds (Python uses seconds;
 TypeScript uses milliseconds). Setting the interval explicitly also reduces
 traffic on older SDK releases whose event default is one second. Event reads
 share the project's general request budget; [stagger concurrent

--- a/docs/cloud/guides/concurrency.mdx
+++ b/docs/cloud/guides/concurrency.mdx
@@ -160,12 +160,13 @@ Set a request budget across all event streams in the project. For example, polli
 
 Spread poll times so that every worker does not send its request on the same clock tick. A per-project limiter in your application is more predictable than each worker independently retrying.
 
-For SDK event waits, set `wait_for_event(..., interval=5)` in Python or
-`waitForEvent(..., { interval: 5_000 })` in TypeScript. This also works on SDK
+For SDK event waits, set `wait_for_event(..., interval=3)` in Python or
+`waitForEvent(..., { interval: 3_000 })` in TypeScript. This also works on SDK
 3.11.3, whose event-wait default is one second. One hundred waits at a
-five-second interval average 20 event requests per second; creates, pagination,
-and other general requests still share the standard 25 RPS budget. Higher
-parallelism needs a larger interval or a shared request scheduler.
+three-second interval average about 33 event requests per second, exceeding
+the standard 25 RPS general budget. For that workload, explicitly use a
+five-second interval (20 event requests per second) or a shared request
+scheduler, leaving headroom for creates, pagination, and other general calls.
 
 The event-wait helper pauses between pages too. For an old run with a large
 event history, start from a known cursor or implement paginated reads within


### PR DESCRIPTION
Set V4 event-wait defaults to three seconds in Python sync/async and TypeScript to reduce event-discovery latency. Update cadence tests and live-preview examples, and explain that 100 concurrent waits at this interval still exceed the standard general request budget. Explicit intervals, the immediate first read, completion polling, and timeouts retain their current behavior. All 36 Python and 29 Node V4 tests, changed Python file type checks, Node type checking, and the Node package build pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets the V4 event-wait polling default to three seconds in the Python and TypeScript SDKs, down from five, so events surface sooner. Explicit intervals, the immediate first read, completion polling, and timeouts are unchanged.

**Migration**
- One hundred concurrent waits at the new three-second default exceed the standard 25 RPS general request budget; use a five-second interval or a shared request scheduler for that workload.

<sup>Written for commit 06b42bffbe007db0296ea6a499796a3998b8ea24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

