### PR TITLE
docs: add Vercel Marketplace integration guide

### DIFF
--- a/docs/cloud/tutorials/integrations/vercel.mdx
+++ b/docs/cloud/tutorials/integrations/vercel.mdx
@@ -1,0 +1,102 @@
+---
+title: Vercel
+description: Install Browser Use from the Vercel Marketplace and call it from Next.js or a Vercel eve agent.
+---
+
+The [Browser Use integration](https://vercel.com/marketplace/browseruse) on the Vercel Marketplace gives a Vercel project a Browser Use account, billing through Vercel, and a `BROWSER_USE_API_KEY` environment variable. From there you run hosted browser agents or connect your own code to a cloud browser.
+
+## Install from the Marketplace
+
+**1. Install the integration**
+
+In the Vercel dashboard open **Integrations → Browse Marketplace**, choose **Browser Use**, and select **Install**. Pick a plan (start with **Free**) and connect the resource to the project that will call Browser Use.
+
+**2. Check the environment variable**
+
+Vercel adds `BROWSER_USE_API_KEY` to the connected project for production, preview, and development. Pull it into your local environment:
+
+```bash
+vercel env pull .env.local
+```
+
+**3. Open Browser Use**
+
+Select **Open in Browser Use** on the resource page. Vercel signs you in to [cloud.browser-use.com](https://cloud.browser-use.com) without a separate account, where you can watch runs, replay sessions, and manage the project.
+
+## Next.js
+
+**1. Install the SDK**
+
+```bash
+npm install browser-use-sdk@latest
+```
+
+**2. Add a route handler**
+
+The client reads `BROWSER_USE_API_KEY` from the environment. Keep it server-side: call Browser Use from a route handler or server action, never from the browser.
+
+```typescript app/api/research/route.ts
+import { BrowserUse } from "browser-use-sdk/v4";
+
+export const maxDuration = 300;
+
+export async function POST(request: Request) {
+  const { task } = await request.json();
+
+  const client = new BrowserUse();
+  const run = await client.runs.create({ task });
+  const result = await client.runs.waitForCompletion(run.id, {
+    timeout: 240_000,
+  });
+
+  return Response.json({ runId: run.id, result: result.result });
+}
+```
+
+**3. Call it**
+
+```bash
+curl -X POST http://localhost:3000/api/research \
+  -H "Content-Type: application/json" \
+  -d '{"task":"Find the top Hacker News story and summarize it"}'
+```
+
+Runs can outlast a single Vercel function invocation. For anything longer than your function's `maxDuration`, return `run.id` right away and read progress from a second route with `client.runs.status(runId)` and `client.runs.events(runId)`. See [Observability](/cloud/agent/observability) for the event stream and [Structured output](/cloud/agent/structured-output) for returning JSON your app can validate.
+
+## Vercel eve agents
+
+Give an [eve](https://eve.dev) agent a cloud browser with the official package. It adds the `open_cloud_browser` and `stop_cloud_browser` tools plus a browsing skill, and your API key never leaves the app runtime.
+
+```bash
+npm install @browser_use/eve
+npx browser-use-eve add
+```
+
+With `BROWSER_USE_API_KEY` set, ask the agent to "open example.com and tell me the title". To start from a working app, deploy the [Browser Agent Template](https://github.com/browser-use/browser-agent-template): a Next.js chat UI, an eve agent, and a live browser panel in one codebase.
+
+## Bring your own automation
+
+If you already drive browsers with Puppeteer or Playwright, use the cloud browser without the hosted agent:
+
+```typescript
+import { BrowserUse } from "browser-use-sdk/v4";
+import puppeteer from "puppeteer-core";
+
+const client = new BrowserUse();
+const session = await client.browsers.create({ proxyCountryCode: "us" });
+try {
+  const browser = await puppeteer.connect({ browserWSEndpoint: session.cdpUrl });
+  const page = (await browser.defaultBrowserContext().pages())[0];
+  await page.goto("https://example.com");
+  console.log(await page.title());
+  await browser.disconnect();
+} finally {
+  await client.browsers.stop(session.id);
+}
+```
+
+See the [Browser Infrastructure quickstart](/cloud/browser/quickstart) for Playwright, Selenium, and curl.
+
+## Billing and limits
+
+Usage is billed through your Vercel account on the plan you picked at install time. Keys in one project share concurrency and credits; read [Concurrency and limits](/cloud/guides/concurrency) before running many tasks in parallel. Changing the plan in Vercel updates the Browser Use project automatically.

--- a/docs/cloud/tutorials/integrations/vercel.mdx
+++ b/docs/cloud/tutorials/integrations/vercel.mdx
@@ -85,11 +85,16 @@ import puppeteer from "puppeteer-core";
 const client = new BrowserUse();
 const session = await client.browsers.create({ proxyCountryCode: "us" });
 try {
+  if (!session.cdpUrl) throw new Error("The browser did not return a CDP URL");
   const browser = await puppeteer.connect({ browserWSEndpoint: session.cdpUrl });
-  const page = (await browser.defaultBrowserContext().pages())[0];
-  await page.goto("https://example.com");
-  console.log(await page.title());
-  await browser.disconnect();
+  try {
+    const context = browser.defaultBrowserContext();
+    const page = (await context.pages())[0] ?? await context.newPage();
+    await page.goto("https://example.com");
+    console.log(await page.title());
+  } finally {
+    await browser.disconnect();
+  }
 } finally {
   await client.browsers.stop(session.id);
 }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -131,6 +131,7 @@
                       },
                       "cloud/tutorials/integrations/openclaw",
                       "cloud/tutorials/integrations/hermes-agent",
+                      "cloud/tutorials/integrations/vercel",
                       "cloud/guides/mcp-server",
                       "cloud/guides/webhooks",
                       "cloud/guides/x402",


### PR DESCRIPTION
## Why

Vercel's Marketplace review (2026-09-10) asked for the product's **Getting Started** guides to be filled in. This page is the long-form target those per-framework console entries link to, and the value for the listing's Documentation URL.

## What

New page `cloud/tutorials/integrations/vercel` under Integrations:

- Install from the Marketplace, where `BROWSER_USE_API_KEY` lands (`VERCEL_API_KEY_SECRET_NAME` in cloud `backend/app/endpoints/autumn/services.py`), `vercel env pull`, SSO via "Open in Browser Use".
- Next.js route handler on `browser-use-sdk/v4` (`runs.create` + `runs.waitForCompletion`), with the function-duration caveat pointing at `runs.status` / `runs.events`.
- Vercel eve agents via `@browser_use/eve` and the Browser Agent Template.
- Bring-your-own Puppeteer path, copied from the tested browser quickstart.
- Billing/limits pointer.

Nav entry added after Hermes Agent.

## Verification

`npx mint validate` and `npx mint broken-links` both pass from `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Vercel Marketplace integration guide that Vercel's Marketplace review required for the listing's Getting Started docs.

- Covers installing from the Marketplace, the `BROWSER_USE_API_KEY` environment variable, SSO via Open in Browser Use, a Next.js route handler on `browser-use-sdk/v4`, Vercel eve agents via `@browser_use/eve`, and the bring-your-own Puppeteer path.
- The Puppeteer example keeps the tested quickstart guards: the `cdpUrl` check and the `pages()` fallback.
- Adds the page to the docs nav after Hermes Agent.

<sup>Written for commit 0ddb7c7d3c595b88753ccad85104bce30b533fed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

