### PR TITLE
Document invoice access and iMessage setup

### DIFF
--- a/docs/cloud/guides/billing.mdx
+++ b/docs/cloud/guides/billing.mdx
@@ -20,6 +20,14 @@ This endpoint works with the same key you use for V4. Compare `projectId` with t
 
 If a payment succeeded but the expected credits are missing, first check the project and the payment's status. When contacting support, include the project ID, payment time, amount, and receipt or invoice reference. Never include API keys or card details.
 
+## Find invoices or cancel a legacy subscription
+
+Open [Settings → Billing](https://cloud.browser-use.com/settings?tab=billing) with the correct project selected. Under **Billing History**, click **Invoices** to view and download your invoices in Stripe.
+
+If your project has a cancellable legacy subscription, **Cancel subscription** appears below Billing History. Cancellation stops renewal; access continues until the current period ends. Pay-as-you-go projects do not have a recurring subscription to cancel. To stop automatic credit purchases, turn off **Auto recharge** in Billing; this is separate from cancelling a legacy subscription.
+
+If you cannot sign in, or a charge or credit amount looks wrong, contact support. Include the project ID if you know it, the payment time and amount, and an invoice reference. Do not send card details, passwords or API keys.
+
 ## Do credits expire or renew?
 
 | Credit type | Behavior |

--- a/docs/cloud/guides/imessage.mdx
+++ b/docs/cloud/guides/imessage.mdx
@@ -1,0 +1,24 @@
+---
+title: iMessage
+description: "Connect a Messages group to a Browser Use agent."
+---
+
+You can talk to a Browser Use agent from an iMessage group. The beta supports US phone numbers and depends on available capacity.
+
+## Connect a group
+
+1. Select your Cloud project and open [Settings → iMessage](https://cloud.browser-use.com/settings?tab=imessage).
+2. Choose **Get a number and code**.
+3. Add the provided number to a group in Messages.
+4. Send the code in that group. Each participant must send the same code from their own number.
+5. Wait for the chat to show **Active** in Settings.
+
+Keep the settings page open while linking: the code is shown when it is issued. If the group membership changes, linking pauses and the group needs to verify again. Follow the status shown in Settings.
+
+## Browser logins
+
+Each linked chat gets its own workspace and, when browser profiles are enabled for the project, a separate browser profile. Connecting Messages does not import the logins from your personal browser or another Cloud session.
+
+## Availability
+
+iMessage is unavailable for Zero Data Retention projects. If the number pool is full or at its daily limit, follow the availability message in Settings. You can unlink a chat there when you no longer want it connected.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -146,6 +146,7 @@
                   },
                   "cloud/guides/concurrency",
                   "cloud/guides/billing",
+                  "cloud/guides/imessage",
                   "cloud/guides/troubleshooting",
                   "cloud/faq",
                   {


### PR DESCRIPTION
Customers could not find clear instructions for invoice downloads, legacy cancellation, or iMessage setup. Adds the Billing History/Invoices route, separates subscription cancellation from auto recharge, and documents iMessage group verification, browser-profile separation, and availability. Verified against current Cloud UI/backend code; `npx mint validate` and `npx mint broken-links` pass. No CAPTCHA coverage details or customer data are added to public docs.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents invoice downloads, legacy subscription cancellation, and iMessage setup so customers no longer have to ask support for these steps.

**Docs changes**
- Billing guide now points to the Invoices page and clarifies that cancelling a legacy subscription is separate from turning off auto recharge.
- New iMessage guide covers group verification, per-chat browser profiles, and availability limits.
- Adds the iMessage guide to the docs navigation.

<sup>Written for commit e2ffd672743527caf17c562652ac81f70e11bbd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/sdk/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

